### PR TITLE
feat(ui): add Label, Checkbox, Switch, Radio form atoms

### DIFF
--- a/packages/web/src/__tests__/Checkbox.test.tsx
+++ b/packages/web/src/__tests__/Checkbox.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Checkbox } from "@/components/ui/checkbox";
+
+describe("Checkbox", () => {
+  it("renders a checkbox input", () => {
+    render(<Checkbox aria-label="Accept" />);
+    const checkbox = screen.getByRole("checkbox", { name: "Accept" });
+    expect(checkbox).toBeInTheDocument();
+    expect(checkbox).toHaveAttribute("type", "checkbox");
+  });
+
+  it("is unchecked by default", () => {
+    render(<Checkbox aria-label="Accept" />);
+    expect(screen.getByRole("checkbox", { name: "Accept" })).not.toBeChecked();
+  });
+
+  it("renders as checked when checked prop is true", () => {
+    render(<Checkbox aria-label="Accept" checked readOnly />);
+    expect(screen.getByRole("checkbox", { name: "Accept" })).toBeChecked();
+  });
+
+  it("renders as disabled", () => {
+    render(<Checkbox aria-label="Accept" disabled />);
+    expect(screen.getByRole("checkbox", { name: "Accept" })).toBeDisabled();
+  });
+
+  it("calls onChange handler", () => {
+    const handleChange = vi.fn();
+    render(<Checkbox aria-label="Accept" onChange={handleChange} />);
+    fireEvent.click(screen.getByRole("checkbox", { name: "Accept" }));
+    expect(handleChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("merges custom className", () => {
+    render(<Checkbox aria-label="Accept" className="extra" />);
+    expect(screen.getByRole("checkbox", { name: "Accept" })).toHaveClass("extra");
+    expect(screen.getByRole("checkbox", { name: "Accept" })).toHaveClass("h-4");
+  });
+});

--- a/packages/web/src/__tests__/Label.test.tsx
+++ b/packages/web/src/__tests__/Label.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Label } from "@/components/ui/label";
+
+describe("Label", () => {
+  it("renders children text", () => {
+    render(<Label>Username</Label>);
+    expect(screen.getByText("Username")).toBeInTheDocument();
+  });
+
+  it("renders a <label> element", () => {
+    render(<Label>Email</Label>);
+    expect(screen.getByText("Email").tagName).toBe("LABEL");
+  });
+
+  it("shows red asterisk when required", () => {
+    render(<Label required>Password</Label>);
+    expect(screen.getByText("*")).toBeInTheDocument();
+    expect(screen.getByText("*")).toHaveClass("text-destructive");
+  });
+
+  it("does not show asterisk when not required", () => {
+    render(<Label>Optional field</Label>);
+    expect(screen.queryByText("*")).not.toBeInTheDocument();
+  });
+
+  it("passes htmlFor prop to the label element", () => {
+    render(<Label htmlFor="email-input">Email</Label>);
+    expect(screen.getByText("Email")).toHaveAttribute("for", "email-input");
+  });
+
+  it("merges custom className", () => {
+    render(<Label className="custom-class">Name</Label>);
+    expect(screen.getByText("Name")).toHaveClass("custom-class");
+    expect(screen.getByText("Name")).toHaveClass("text-xs");
+  });
+});

--- a/packages/web/src/__tests__/Radio.test.tsx
+++ b/packages/web/src/__tests__/Radio.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Radio } from "@/components/ui/radio";
+
+describe("Radio", () => {
+  it("renders a radio input", () => {
+    render(<Radio aria-label="Option A" />);
+    const radio = screen.getByRole("radio", { name: "Option A" });
+    expect(radio).toBeInTheDocument();
+    expect(radio).toHaveAttribute("type", "radio");
+  });
+
+  it("is unchecked by default", () => {
+    render(<Radio aria-label="Option A" />);
+    expect(screen.getByRole("radio", { name: "Option A" })).not.toBeChecked();
+  });
+
+  it("renders as checked when checked prop is true", () => {
+    render(<Radio aria-label="Option A" checked readOnly />);
+    expect(screen.getByRole("radio", { name: "Option A" })).toBeChecked();
+  });
+
+  it("renders as disabled", () => {
+    render(<Radio aria-label="Option A" disabled />);
+    expect(screen.getByRole("radio", { name: "Option A" })).toBeDisabled();
+  });
+
+  it("calls onChange handler", () => {
+    const handleChange = vi.fn();
+    render(<Radio aria-label="Option A" onChange={handleChange} />);
+    fireEvent.click(screen.getByRole("radio", { name: "Option A" }));
+    expect(handleChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("merges custom className", () => {
+    render(<Radio aria-label="Option A" className="extra" />);
+    expect(screen.getByRole("radio", { name: "Option A" })).toHaveClass("extra");
+    expect(screen.getByRole("radio", { name: "Option A" })).toHaveClass("h-4");
+  });
+});

--- a/packages/web/src/__tests__/Switch.test.tsx
+++ b/packages/web/src/__tests__/Switch.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Switch } from "@/components/ui/switch";
+
+describe("Switch", () => {
+  it("renders with role switch", () => {
+    render(<Switch aria-label="Toggle" />);
+    expect(screen.getByRole("switch", { name: "Toggle" })).toBeInTheDocument();
+  });
+
+  it("has aria-checked false by default", () => {
+    render(<Switch aria-label="Toggle" />);
+    expect(screen.getByRole("switch", { name: "Toggle" })).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("has aria-checked true when checked", () => {
+    render(<Switch aria-label="Toggle" checked />);
+    expect(screen.getByRole("switch", { name: "Toggle" })).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("toggles on click", () => {
+    const handleChange = vi.fn();
+    render(<Switch aria-label="Toggle" checked={false} onCheckedChange={handleChange} />);
+    fireEvent.click(screen.getByRole("switch", { name: "Toggle" }));
+    expect(handleChange).toHaveBeenCalledWith(true);
+  });
+
+  it("toggles off on click when checked", () => {
+    const handleChange = vi.fn();
+    render(<Switch aria-label="Toggle" checked onCheckedChange={handleChange} />);
+    fireEvent.click(screen.getByRole("switch", { name: "Toggle" }));
+    expect(handleChange).toHaveBeenCalledWith(false);
+  });
+
+  it("does not toggle when disabled", () => {
+    const handleChange = vi.fn();
+    render(<Switch aria-label="Toggle" disabled onCheckedChange={handleChange} />);
+    fireEvent.click(screen.getByRole("switch", { name: "Toggle" }));
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it("renders sm size variant", () => {
+    render(<Switch aria-label="Toggle" size="sm" />);
+    const el = screen.getByRole("switch", { name: "Toggle" });
+    expect(el).toHaveClass("h-4");
+    expect(el).toHaveClass("w-7");
+  });
+
+  it("renders default size variant", () => {
+    render(<Switch aria-label="Toggle" />);
+    const el = screen.getByRole("switch", { name: "Toggle" });
+    expect(el).toHaveClass("h-5");
+    expect(el).toHaveClass("w-9");
+  });
+
+  it("applies checked styles", () => {
+    render(<Switch aria-label="Toggle" checked />);
+    expect(screen.getByRole("switch", { name: "Toggle" })).toHaveClass("bg-primary");
+  });
+
+  it("applies unchecked styles", () => {
+    render(<Switch aria-label="Toggle" />);
+    expect(screen.getByRole("switch", { name: "Toggle" })).toHaveClass("bg-input");
+  });
+});

--- a/packages/web/src/components/kanban/AddTaskForm.tsx
+++ b/packages/web/src/components/kanban/AddTaskForm.tsx
@@ -1,7 +1,9 @@
 import { useState, useEffect, useRef } from "react";
 import { Plus, X, Settings2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
+import { Radio } from "@/components/ui/radio";
 import { Textarea } from "@/components/ui/textarea";
 import { useCreateTask } from "@/hooks/useTasks";
 import { useProjects } from "@/hooks/useProjects";
@@ -196,13 +198,12 @@ export function AddTaskForm({ projectId }: Props) {
             Task type
           </p>
           <label className="flex items-start gap-2 text-xs text-muted-foreground">
-            <input
-              type="radio"
+            <Radio
               name="taskType"
               aria-label="Standard"
               checked={!isFix}
               onChange={() => setIsFix(false)}
-              className="mt-0.5 h-3.5 w-3.5 accent-[var(--color-primary)]"
+              className="mt-0.5 h-3.5 w-3.5"
             />
             <span>
               <span className="font-medium text-foreground">Standard</span>
@@ -210,13 +211,12 @@ export function AddTaskForm({ projectId }: Props) {
             </span>
           </label>
           <label className="flex items-start gap-2 text-xs text-muted-foreground">
-            <input
-              type="radio"
+            <Radio
               name="taskType"
               aria-label="Fix"
               checked={isFix}
               onChange={() => setIsFix(true)}
-              className="mt-0.5 h-3.5 w-3.5 accent-[var(--color-primary)]"
+              className="mt-0.5 h-3.5 w-3.5"
             />
             <span>
               <span className="font-medium text-foreground">Fix</span>
@@ -227,12 +227,11 @@ export function AddTaskForm({ projectId }: Props) {
           </label>
         </div>
         <label className="flex items-start gap-2 text-xs text-muted-foreground">
-          <input
-            type="checkbox"
+          <Checkbox
             aria-label="Auto mode"
             checked={autoMode}
             onChange={(e) => setAutoMode(e.target.checked)}
-            className="mt-0.5 h-3.5 w-3.5 accent-[var(--color-primary)]"
+            className="mt-0.5 h-3.5 w-3.5"
           />
           <span>
             <span className="font-medium text-foreground">Auto mode</span>
@@ -266,22 +265,20 @@ export function AddTaskForm({ projectId }: Props) {
                 ) : (
                   <div className="flex gap-3">
                     <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                      <input
-                        type="radio"
+                      <Radio
                         name="plannerMode"
                         checked={plannerMode === "full"}
                         onChange={() => handleModeChange("full")}
-                        className="h-3.5 w-3.5 accent-[var(--color-primary)]"
+                        className="h-3.5 w-3.5"
                       />
                       <span className="font-medium text-foreground">Full</span>
                     </label>
                     <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                      <input
-                        type="radio"
+                      <Radio
                         name="plannerMode"
                         checked={plannerMode === "fast"}
                         onChange={() => handleModeChange("fast")}
-                        className="h-3.5 w-3.5 accent-[var(--color-primary)]"
+                        className="h-3.5 w-3.5"
                       />
                       <span className="font-medium text-foreground">Fast</span>
                     </label>
@@ -320,20 +317,18 @@ export function AddTaskForm({ projectId }: Props) {
               </div>
               <div className="flex gap-4">
                 <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                  <input
-                    type="checkbox"
+                  <Checkbox
                     checked={planDocs}
                     onChange={(e) => setPlanDocs(e.target.checked)}
-                    className="h-3.5 w-3.5 accent-[var(--color-primary)]"
+                    className="h-3.5 w-3.5"
                   />
                   <span className="font-medium text-foreground">Docs</span>
                 </label>
                 <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                  <input
-                    type="checkbox"
+                  <Checkbox
                     checked={planTests}
                     onChange={(e) => setPlanTests(e.target.checked)}
-                    className="h-3.5 w-3.5 accent-[var(--color-primary)]"
+                    className="h-3.5 w-3.5"
                   />
                   <span className="font-medium text-foreground">Tests</span>
                 </label>
@@ -344,11 +339,10 @@ export function AddTaskForm({ projectId }: Props) {
       )}
       <div className="space-y-1">
         <label className="flex items-start gap-2 text-xs text-muted-foreground">
-          <input
-            type="checkbox"
+          <Checkbox
             checked={skipReview}
             onChange={(e) => setSkipReview(e.target.checked)}
-            className="mt-0.5 h-3.5 w-3.5 accent-[var(--color-primary)]"
+            className="mt-0.5 h-3.5 w-3.5"
           />
           <span>
             <span className="font-medium text-foreground">Skip review</span>
@@ -356,11 +350,10 @@ export function AddTaskForm({ projectId }: Props) {
           </span>
         </label>
         <label className="flex items-start gap-2 text-xs text-muted-foreground">
-          <input
-            type="checkbox"
+          <Checkbox
             checked={useSubagents}
             onChange={(e) => setUseSubagents(e.target.checked)}
-            className="mt-0.5 h-3.5 w-3.5 accent-[var(--color-primary)]"
+            className="mt-0.5 h-3.5 w-3.5"
           />
           <span>
             <span className="font-medium text-foreground">Use subagents</span>

--- a/packages/web/src/components/task/TaskSettings.tsx
+++ b/packages/web/src/components/task/TaskSettings.tsx
@@ -1,7 +1,9 @@
 import { useState } from "react";
 import { Settings2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
+import { Radio } from "@/components/ui/radio";
 import { useProjects } from "@/hooks/useProjects";
 import type { Task, UpdateTaskInput } from "@aif/shared/browser";
 
@@ -102,15 +104,15 @@ export function TaskSettings({ task, onSave }: Props) {
       </div>
 
       <div className="space-y-2">
-        <Checkbox label="Auto mode" checked={autoMode} onChange={setAutoMode}>
+        <CheckboxField label="Auto mode" checked={autoMode} onChange={setAutoMode}>
           AI moves tasks between statuses automatically.
-        </Checkbox>
-        <Checkbox label="Skip review" checked={skipReview} onChange={setSkipReview}>
+        </CheckboxField>
+        <CheckboxField label="Skip review" checked={skipReview} onChange={setSkipReview}>
           After implementation, move directly to done without code review.
-        </Checkbox>
-        <Checkbox label="Use subagents" checked={useSubagents} onChange={setUseSubagents}>
+        </CheckboxField>
+        <CheckboxField label="Use subagents" checked={useSubagents} onChange={setUseSubagents}>
           Run via custom subagents (plan-coordinator, implement-coordinator, sidecars).
-        </Checkbox>
+        </CheckboxField>
       </div>
 
       {autoMode && (
@@ -145,22 +147,20 @@ export function TaskSettings({ task, onSave }: Props) {
           ) : (
             <div className="flex gap-3">
               <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                <input
-                  type="radio"
+                <Radio
                   name="plannerModeDetail"
                   checked={plannerMode === "full"}
                   onChange={() => setPlannerMode("full")}
-                  className="h-3.5 w-3.5 accent-[var(--color-primary)]"
+                  className="h-3.5 w-3.5"
                 />
                 <span className="font-medium text-foreground">Full</span>
               </label>
               <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                <input
-                  type="radio"
+                <Radio
                   name="plannerModeDetail"
                   checked={plannerMode === "fast"}
                   onChange={() => setPlannerMode("fast")}
-                  className="h-3.5 w-3.5 accent-[var(--color-primary)]"
+                  className="h-3.5 w-3.5"
                 />
                 <span className="font-medium text-foreground">Fast</span>
               </label>
@@ -185,8 +185,8 @@ export function TaskSettings({ task, onSave }: Props) {
             )}
           </div>
           <div className="flex gap-4">
-            <Checkbox label="Docs" checked={planDocs} onChange={setPlanDocs} />
-            <Checkbox label="Tests" checked={planTests} onChange={setPlanTests} />
+            <CheckboxField label="Docs" checked={planDocs} onChange={setPlanDocs} />
+            <CheckboxField label="Tests" checked={planTests} onChange={setPlanTests} />
           </div>
         </div>
       )}
@@ -207,12 +207,11 @@ function Checkbox({
 }) {
   return (
     <label className="flex items-start gap-2 text-xs text-muted-foreground">
-      <input
-        type="checkbox"
+      <Checkbox
         aria-label={label}
         checked={checked}
         onChange={(e) => onChange(e.target.checked)}
-        className="mt-0.5 h-3.5 w-3.5 accent-[var(--color-primary)]"
+        className="mt-0.5 h-3.5 w-3.5"
       />
       <span>
         <span className="font-medium text-foreground">{label}</span>

--- a/packages/web/src/components/ui/checkbox.tsx
+++ b/packages/web/src/components/ui/checkbox.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Checkbox = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
+  ({ className, ...props }, ref) => {
+    return (
+      <input
+        type="checkbox"
+        className={cn(
+          "h-4 w-4 rounded-none border border-border bg-card accent-primary cursor-pointer focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Checkbox.displayName = "Checkbox";
+
+export { Checkbox };

--- a/packages/web/src/components/ui/label.tsx
+++ b/packages/web/src/components/ui/label.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
+  required?: boolean;
+}
+
+const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
+  ({ className, required, children, ...props }, ref) => {
+    return (
+      <label
+        className={cn("text-xs font-medium text-foreground tracking-wide", className)}
+        ref={ref}
+        {...props}
+      >
+        {children}
+        {required && <span className="text-destructive ml-0.5">*</span>}
+      </label>
+    );
+  },
+);
+Label.displayName = "Label";
+
+export { Label };

--- a/packages/web/src/components/ui/radio.tsx
+++ b/packages/web/src/components/ui/radio.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Radio = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
+  ({ className, ...props }, ref) => {
+    return (
+      <input
+        type="radio"
+        className={cn(
+          "h-4 w-4 rounded-full border border-border bg-card accent-primary cursor-pointer focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Radio.displayName = "Radio";
+
+export { Radio };

--- a/packages/web/src/components/ui/switch.tsx
+++ b/packages/web/src/components/ui/switch.tsx
@@ -1,0 +1,72 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const switchVariants = cva(
+  "relative inline-flex shrink-0 cursor-pointer items-center rounded-full border border-border transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+  {
+    variants: {
+      size: {
+        default: "h-5 w-9",
+        sm: "h-4 w-7",
+      },
+    },
+    defaultVariants: {
+      size: "default",
+    },
+  },
+);
+
+const thumbVariants = cva(
+  "pointer-events-none block rounded-full bg-foreground transition-transform",
+  {
+    variants: {
+      size: {
+        default: "h-3.5 w-3.5",
+        sm: "h-2.5 w-2.5",
+      },
+    },
+    defaultVariants: {
+      size: "default",
+    },
+  },
+);
+
+export interface SwitchProps
+  extends
+    Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "onChange">,
+    VariantProps<typeof switchVariants> {
+  checked?: boolean;
+  onCheckedChange?: (checked: boolean) => void;
+}
+
+const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
+  ({ className, size, checked = false, onCheckedChange, disabled, ...props }, ref) => {
+    const translateClass =
+      size === "sm"
+        ? checked
+          ? "translate-x-3.5"
+          : "translate-x-0.5"
+        : checked
+          ? "translate-x-4.5"
+          : "translate-x-0.5";
+
+    return (
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        disabled={disabled}
+        className={cn(switchVariants({ size }), checked ? "bg-primary" : "bg-input", className)}
+        onClick={() => onCheckedChange?.(!checked)}
+        ref={ref}
+        {...props}
+      >
+        <span className={cn(thumbVariants({ size }), translateClass)} />
+      </button>
+    );
+  },
+);
+Switch.displayName = "Switch";
+
+export { Switch, switchVariants };


### PR DESCRIPTION
## Summary
- Add 4 form control atoms: Label, Checkbox, Switch, Radio
- Include tests for all components
- Migrate TaskSettings and AddTaskForm to use new primitives

## Components
- `ui/label.tsx` — Label with required asterisk support
- `ui/checkbox.tsx` — Styled checkbox with forwardRef
- `ui/switch.tsx` — Toggle switch with aria-checked
- `ui/radio.tsx` — Styled radio with forwardRef