### PR TITLE
feat(ui): add Tooltip and Popover overlay atoms

### DIFF
--- a/packages/web/src/__tests__/Popover.test.tsx
+++ b/packages/web/src/__tests__/Popover.test.tsx
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { Popover } from "@/components/ui/popover";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+
+function PopoverHarness() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <div data-testid="state">{open ? "open" : "closed"}</div>
+      <Popover open={open} onOpenChange={setOpen} content={<div>Popover body</div>}>
+        <button data-testid="trigger">Open</button>
+      </Popover>
+    </>
+  );
+}
+
+function StackedOverlayHarness() {
+  const [popoverOpen, setPopoverOpen] = useState(true);
+  const [dialogOpen, setDialogOpen] = useState(true);
+
+  return (
+    <>
+      <div data-testid="popover-state">{popoverOpen ? "open" : "closed"}</div>
+      <div data-testid="dialog-state">{dialogOpen ? "open" : "closed"}</div>
+
+      <Popover open={popoverOpen} onOpenChange={setPopoverOpen} content={<div>Popover body</div>}>
+        <button>Trigger</button>
+      </Popover>
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent>
+          <div>Dialog body</div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+describe("Popover", () => {
+  it("renders trigger", () => {
+    render(<PopoverHarness />);
+    expect(screen.getByTestId("trigger")).toBeInTheDocument();
+  });
+
+  it("opens on click", () => {
+    render(<PopoverHarness />);
+
+    expect(screen.getByTestId("state").textContent).toBe("closed");
+    fireEvent.click(screen.getByTestId("trigger"));
+    expect(screen.getByTestId("state").textContent).toBe("open");
+    expect(screen.getByText("Popover body")).toBeInTheDocument();
+  });
+
+  it("closes on ESC", () => {
+    render(<PopoverHarness />);
+
+    fireEvent.click(screen.getByTestId("trigger"));
+    expect(screen.getByTestId("state").textContent).toBe("open");
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.getByTestId("state").textContent).toBe("closed");
+  });
+
+  it("closes on outside click", () => {
+    render(<PopoverHarness />);
+
+    fireEvent.click(screen.getByTestId("trigger"));
+    expect(screen.getByTestId("state").textContent).toBe("open");
+
+    fireEvent.mouseDown(document.body);
+    expect(screen.getByTestId("state").textContent).toBe("closed");
+  });
+
+  it("does not close when clicking inside popover content", () => {
+    render(<PopoverHarness />);
+
+    fireEvent.click(screen.getByTestId("trigger"));
+    expect(screen.getByTestId("state").textContent).toBe("open");
+
+    fireEvent.mouseDown(screen.getByText("Popover body"));
+    expect(screen.getByTestId("state").textContent).toBe("open");
+  });
+
+  it("respects overlay stack — ESC closes only top layer", () => {
+    render(<StackedOverlayHarness />);
+
+    expect(screen.getByTestId("popover-state").textContent).toBe("open");
+    expect(screen.getByTestId("dialog-state").textContent).toBe("open");
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.getByTestId("dialog-state").textContent).toBe("closed");
+    expect(screen.getByTestId("popover-state").textContent).toBe("open");
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.getByTestId("popover-state").textContent).toBe("closed");
+  });
+});

--- a/packages/web/src/__tests__/Tooltip.test.tsx
+++ b/packages/web/src/__tests__/Tooltip.test.tsx
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { Tooltip } from "@/components/ui/tooltip";
+
+describe("Tooltip", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders children", () => {
+    render(
+      <Tooltip content="Tip text">
+        <button>Hover me</button>
+      </Tooltip>,
+    );
+
+    expect(screen.getByText("Hover me")).toBeInTheDocument();
+  });
+
+  it("shows content on hover after delay", () => {
+    render(
+      <Tooltip content="Tip text">
+        <button>Hover me</button>
+      </Tooltip>,
+    );
+
+    fireEvent.mouseEnter(screen.getByText("Hover me").parentElement!);
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Tip text");
+  });
+
+  it("hides content on mouse leave", () => {
+    render(
+      <Tooltip content="Tip text">
+        <button>Hover me</button>
+      </Tooltip>,
+    );
+
+    const trigger = screen.getByText("Hover me").parentElement!;
+    fireEvent.mouseEnter(trigger);
+
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+
+    fireEvent.mouseLeave(trigger);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("shows content on focus and hides on blur", () => {
+    render(
+      <Tooltip content="Tip text">
+        <button>Focus me</button>
+      </Tooltip>,
+    );
+
+    const trigger = screen.getByText("Focus me").parentElement!;
+    fireEvent.focus(trigger);
+
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Tip text");
+
+    fireEvent.blur(trigger);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("merges className", () => {
+    render(
+      <Tooltip content="Tip" className="custom-class">
+        <button>Hover</button>
+      </Tooltip>,
+    );
+
+    fireEvent.mouseEnter(screen.getByText("Hover").parentElement!);
+
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+
+    const tooltip = screen.getByRole("tooltip");
+    expect(tooltip.className).toContain("custom-class");
+  });
+
+  it("cancels show if mouse leaves before delay", () => {
+    render(
+      <Tooltip content="Tip">
+        <button>Hover</button>
+      </Tooltip>,
+    );
+
+    const trigger = screen.getByText("Hover").parentElement!;
+    fireEvent.mouseEnter(trigger);
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    fireEvent.mouseLeave(trigger);
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/ui/popover.tsx
+++ b/packages/web/src/components/ui/popover.tsx
@@ -1,0 +1,115 @@
+import * as React from "react";
+import { createPortal } from "react-dom";
+import { cn } from "@/lib/utils";
+import {
+  createOverlayLayerId,
+  isTopOverlayLayer,
+  pushOverlayLayer,
+} from "@/components/ui/overlayStack";
+
+interface PopoverProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: React.ReactNode;
+  content: React.ReactNode;
+  side?: "top" | "bottom";
+  align?: "start" | "center" | "end";
+  className?: string;
+}
+
+function Popover({
+  open,
+  onOpenChange,
+  children,
+  content,
+  side = "bottom",
+  align = "start",
+  className,
+}: PopoverProps) {
+  const triggerRef = React.useRef<HTMLSpanElement>(null);
+  const panelRef = React.useRef<HTMLDivElement>(null);
+  const overlayLayerId = React.useRef(createOverlayLayerId("popover"));
+  const [coords, setCoords] = React.useState<{ top: number; left: number }>({ top: 0, left: 0 });
+
+  React.useEffect(() => {
+    if (!open) return;
+    return pushOverlayLayer(overlayLayerId.current);
+  }, [open]);
+
+  React.useEffect(() => {
+    if (!open || !triggerRef.current) return;
+    const rect = triggerRef.current.getBoundingClientRect();
+    setCoords(computePosition(rect, side, align));
+  }, [open, side, align]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      if (!isTopOverlayLayer(overlayLayerId.current)) return;
+      onOpenChange(false);
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [open, onOpenChange]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const onMouseDown = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (triggerRef.current?.contains(target)) return;
+      if (panelRef.current?.contains(target)) return;
+      onOpenChange(false);
+    };
+    document.addEventListener("mousedown", onMouseDown);
+    return () => document.removeEventListener("mousedown", onMouseDown);
+  }, [open, onOpenChange]);
+
+  return (
+    <>
+      <span ref={triggerRef} onClick={() => onOpenChange(!open)}>
+        {children}
+      </span>
+      {open &&
+        typeof document !== "undefined" &&
+        createPortal(
+          <div
+            ref={panelRef}
+            className={cn(
+              "fixed z-50 bg-popover text-popover-foreground border border-border p-3 rounded-none shadow-lg",
+              className,
+            )}
+            style={{ top: coords.top, left: coords.left }}
+          >
+            {content}
+          </div>,
+          document.body,
+        )}
+    </>
+  );
+}
+
+function computePosition(
+  rect: DOMRect,
+  side: "top" | "bottom",
+  align: "start" | "center" | "end",
+): { top: number; left: number } {
+  const gap = 4;
+  const top = side === "bottom" ? rect.bottom + gap : rect.top - gap;
+  let left: number;
+  switch (align) {
+    case "start":
+      left = rect.left;
+      break;
+    case "center":
+      left = rect.left + rect.width / 2;
+      break;
+    case "end":
+      left = rect.right;
+      break;
+  }
+  return { top, left };
+}
+
+export { Popover };
+export type { PopoverProps };

--- a/packages/web/src/components/ui/tooltip.tsx
+++ b/packages/web/src/components/ui/tooltip.tsx
@@ -1,0 +1,84 @@
+import * as React from "react";
+import { createPortal } from "react-dom";
+import { cn } from "@/lib/utils";
+
+interface TooltipProps {
+  content: React.ReactNode;
+  side?: "top" | "bottom" | "left" | "right";
+  className?: string;
+  children: React.ReactElement;
+}
+
+function Tooltip({ content, side = "top", className, children }: TooltipProps) {
+  const [visible, setVisible] = React.useState(false);
+  const [coords, setCoords] = React.useState<{ top: number; left: number }>({ top: 0, left: 0 });
+  const triggerRef = React.useRef<HTMLSpanElement>(null);
+  const showTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const show = React.useCallback(() => {
+    showTimer.current = setTimeout(() => {
+      if (!triggerRef.current) return;
+      const rect = triggerRef.current.getBoundingClientRect();
+      const pos = computePosition(rect, side);
+      setCoords(pos);
+      setVisible(true);
+    }, 150);
+  }, [side]);
+
+  const hide = React.useCallback(() => {
+    if (showTimer.current) {
+      clearTimeout(showTimer.current);
+      showTimer.current = null;
+    }
+    setVisible(false);
+  }, []);
+
+  React.useEffect(() => {
+    return () => {
+      if (showTimer.current) clearTimeout(showTimer.current);
+    };
+  }, []);
+
+  return (
+    <>
+      <span ref={triggerRef} onMouseEnter={show} onMouseLeave={hide} onFocus={show} onBlur={hide}>
+        {children}
+      </span>
+      {visible &&
+        typeof document !== "undefined" &&
+        createPortal(
+          <div
+            role="tooltip"
+            className={cn(
+              "fixed z-50 bg-popover text-popover-foreground border border-border px-2 py-1 text-xs rounded-none shadow-md",
+              className,
+            )}
+            style={{ top: coords.top, left: coords.left }}
+          >
+            {content}
+          </div>,
+          document.body,
+        )}
+    </>
+  );
+}
+
+function computePosition(
+  rect: DOMRect,
+  side: "top" | "bottom" | "left" | "right",
+): { top: number; left: number } {
+  const gap = 6;
+  switch (side) {
+    case "top":
+      return { top: rect.top - gap, left: rect.left + rect.width / 2 };
+    case "bottom":
+      return { top: rect.bottom + gap, left: rect.left + rect.width / 2 };
+    case "left":
+      return { top: rect.top + rect.height / 2, left: rect.left - gap };
+    case "right":
+      return { top: rect.top + rect.height / 2, left: rect.right + gap };
+  }
+}
+
+export { Tooltip };
+export type { TooltipProps };


### PR DESCRIPTION
## Summary
- Add Tooltip (hover/focus) and Popover (click-triggered) overlay atoms
- Portal-based rendering with overlay stack integration
- ESC handling respects overlay stacking order

## Components
- `ui/tooltip.tsx` — Hover tooltip with side positioning
- `ui/popover.tsx` — Click popover with overlay stack support