### PR TITLE
feat(ui): add Spinner, Separator, Avatar, Icon atoms

### DIFF
--- a/packages/web/src/__tests__/Avatar.test.tsx
+++ b/packages/web/src/__tests__/Avatar.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { Avatar } from "@/components/ui/avatar";
+
+describe("Avatar", () => {
+  it("shows initial from name", () => {
+    render(<Avatar name="Alice" />);
+    expect(screen.getByText("A")).toBeInTheDocument();
+  });
+
+  it("uppercases the initial", () => {
+    render(<Avatar name="bob" />);
+    expect(screen.getByText("B")).toBeInTheDocument();
+  });
+
+  it("shows User icon when no name", () => {
+    const { container } = render(<Avatar />);
+    const svg = container.querySelector("svg");
+    expect(svg).toBeInTheDocument();
+  });
+
+  it("applies sm size variant", () => {
+    const { container } = render(<Avatar name="X" size="sm" />);
+    const el = container.firstElementChild as HTMLElement;
+    expect(el).toHaveClass("h-6", "w-6");
+  });
+
+  it("applies default size variant", () => {
+    const { container } = render(<Avatar name="X" />);
+    const el = container.firstElementChild as HTMLElement;
+    expect(el).toHaveClass("h-8", "w-8");
+  });
+
+  it("applies lg size variant", () => {
+    const { container } = render(<Avatar name="X" size="lg" />);
+    const el = container.firstElementChild as HTMLElement;
+    expect(el).toHaveClass("h-10", "w-10");
+  });
+});

--- a/packages/web/src/__tests__/Icon.test.tsx
+++ b/packages/web/src/__tests__/Icon.test.tsx
@@ -1,0 +1,42 @@
+import { render } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { Icon } from "@/components/ui/icon";
+import { Star } from "lucide-react";
+
+describe("Icon", () => {
+  it("renders the icon component", () => {
+    const { container } = render(<Icon icon={Star} />);
+    const svg = container.querySelector("svg");
+    expect(svg).toBeInTheDocument();
+  });
+
+  it("applies xs size variant", () => {
+    const { container } = render(<Icon icon={Star} size="xs" />);
+    const svg = container.querySelector("svg");
+    expect(svg).toHaveClass("h-3", "w-3");
+  });
+
+  it("applies sm size variant", () => {
+    const { container } = render(<Icon icon={Star} size="sm" />);
+    const svg = container.querySelector("svg");
+    expect(svg).toHaveClass("h-3.5", "w-3.5");
+  });
+
+  it("applies default size variant", () => {
+    const { container } = render(<Icon icon={Star} />);
+    const svg = container.querySelector("svg");
+    expect(svg).toHaveClass("h-4", "w-4");
+  });
+
+  it("applies lg size variant", () => {
+    const { container } = render(<Icon icon={Star} size="lg" />);
+    const svg = container.querySelector("svg");
+    expect(svg).toHaveClass("h-5", "w-5");
+  });
+
+  it("merges custom className", () => {
+    const { container } = render(<Icon icon={Star} className="text-red-500" />);
+    const svg = container.querySelector("svg");
+    expect(svg).toHaveClass("text-red-500");
+  });
+});

--- a/packages/web/src/__tests__/Separator.test.tsx
+++ b/packages/web/src/__tests__/Separator.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { Separator } from "@/components/ui/separator";
+
+describe("Separator", () => {
+  it("renders horizontal by default", () => {
+    render(<Separator />);
+    const el = screen.getByRole("separator");
+    expect(el).toHaveClass("h-px", "w-full");
+  });
+
+  it("renders vertical variant", () => {
+    render(<Separator orientation="vertical" />);
+    const el = screen.getByRole("separator");
+    expect(el).toHaveClass("w-px", "h-full");
+  });
+
+  it("has role separator", () => {
+    render(<Separator />);
+    expect(screen.getByRole("separator")).toBeInTheDocument();
+  });
+
+  it("has aria-orientation horizontal by default", () => {
+    render(<Separator />);
+    expect(screen.getByRole("separator")).toHaveAttribute("aria-orientation", "horizontal");
+  });
+
+  it("has aria-orientation vertical when vertical", () => {
+    render(<Separator orientation="vertical" />);
+    expect(screen.getByRole("separator")).toHaveAttribute("aria-orientation", "vertical");
+  });
+});

--- a/packages/web/src/__tests__/Spinner.test.tsx
+++ b/packages/web/src/__tests__/Spinner.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { Spinner } from "@/components/ui/spinner";
+
+describe("Spinner", () => {
+  it("renders with animate-spin class", () => {
+    render(<Spinner />);
+    const el = screen.getByRole("status");
+    expect(el).toHaveClass("animate-spin");
+  });
+
+  it("has aria-label Loading", () => {
+    render(<Spinner />);
+    expect(screen.getByLabelText("Loading")).toBeInTheDocument();
+  });
+
+  it("has role status", () => {
+    render(<Spinner />);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("applies sm size variant", () => {
+    render(<Spinner size="sm" />);
+    const el = screen.getByRole("status");
+    expect(el).toHaveClass("h-3", "w-3");
+  });
+
+  it("applies default size variant", () => {
+    render(<Spinner />);
+    const el = screen.getByRole("status");
+    expect(el).toHaveClass("h-4", "w-4");
+  });
+
+  it("applies lg size variant", () => {
+    render(<Spinner size="lg" />);
+    const el = screen.getByRole("status");
+    expect(el).toHaveClass("h-6", "w-6");
+  });
+});

--- a/packages/web/src/components/task/PlanChangeDialog.tsx
+++ b/packages/web/src/components/task/PlanChangeDialog.tsx
@@ -1,5 +1,5 @@
-import { Loader2 } from "lucide-react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import type { PlanChangeMode } from "./useTaskDetailActions";
@@ -103,7 +103,7 @@ export function PlanChangeDialog({
           </div>
           {isSubmitting && (
             <div className="flex items-center gap-2 text-xs text-muted-foreground">
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              <Spinner size="sm" />
               {MODE_LOADING_LABELS[mode]}
             </div>
           )}
@@ -120,7 +120,7 @@ export function PlanChangeDialog({
           <Button size="sm" onClick={onSubmit} disabled={!comment.trim() || isSubmitting}>
             {isSubmitting ? (
               <>
-                <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
+                <Spinner size="sm" className="mr-1" />
                 Sending...
               </>
             ) : (

--- a/packages/web/src/components/ui/avatar.tsx
+++ b/packages/web/src/components/ui/avatar.tsx
@@ -1,0 +1,44 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import { User } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const avatarVariants = cva(
+  "inline-flex items-center justify-center rounded-full bg-muted text-muted-foreground border border-border",
+  {
+    variants: {
+      size: {
+        sm: "h-6 w-6 text-[10px]",
+        default: "h-8 w-8 text-xs",
+        lg: "h-10 w-10 text-sm",
+      },
+    },
+    defaultVariants: {
+      size: "default",
+    },
+  },
+);
+
+const iconSizeMap = {
+  sm: "h-3 w-3",
+  default: "h-4 w-4",
+  lg: "h-5 w-5",
+} as const;
+
+export interface AvatarProps extends VariantProps<typeof avatarVariants> {
+  name?: string;
+  className?: string;
+}
+
+function Avatar({ name, size, className }: AvatarProps) {
+  return (
+    <div className={cn(avatarVariants({ size }), className)}>
+      {name ? (
+        <span className="font-medium leading-none">{name.charAt(0).toUpperCase()}</span>
+      ) : (
+        <User className={iconSizeMap[size ?? "default"]} />
+      )}
+    </div>
+  );
+}
+
+export { Avatar, avatarVariants };

--- a/packages/web/src/components/ui/icon.tsx
+++ b/packages/web/src/components/ui/icon.tsx
@@ -1,0 +1,27 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const iconVariants = cva("rounded-none", {
+  variants: {
+    size: {
+      xs: "h-3 w-3",
+      sm: "h-3.5 w-3.5",
+      default: "h-4 w-4",
+      lg: "h-5 w-5",
+    },
+  },
+  defaultVariants: {
+    size: "default",
+  },
+});
+
+export interface IconProps extends VariantProps<typeof iconVariants> {
+  icon: React.ElementType;
+  className?: string;
+}
+
+function Icon({ icon: IconComponent, size, className }: IconProps) {
+  return <IconComponent className={cn(iconVariants({ size }), className)} />;
+}
+
+export { Icon, iconVariants };

--- a/packages/web/src/components/ui/separator.tsx
+++ b/packages/web/src/components/ui/separator.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const separatorVariants = cva("rounded-none bg-border", {
+  variants: {
+    orientation: {
+      horizontal: "h-px w-full",
+      vertical: "w-px h-full",
+    },
+  },
+  defaultVariants: {
+    orientation: "horizontal",
+  },
+});
+
+export interface SeparatorProps
+  extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof separatorVariants> {}
+
+const Separator = React.forwardRef<HTMLDivElement, SeparatorProps>(
+  ({ className, orientation, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        role="separator"
+        aria-orientation={orientation ?? "horizontal"}
+        className={cn(separatorVariants({ orientation, className }))}
+        {...props}
+      />
+    );
+  },
+);
+Separator.displayName = "Separator";
+
+export { Separator, separatorVariants };

--- a/packages/web/src/components/ui/spinner.tsx
+++ b/packages/web/src/components/ui/spinner.tsx
@@ -1,0 +1,37 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const spinnerVariants = cva("animate-spin rounded-none", {
+  variants: {
+    size: {
+      sm: "h-3 w-3",
+      default: "h-4 w-4",
+      lg: "h-6 w-6",
+    },
+  },
+  defaultVariants: {
+    size: "default",
+  },
+});
+
+export interface SpinnerProps
+  extends React.SVGAttributes<SVGSVGElement>, VariantProps<typeof spinnerVariants> {}
+
+const Spinner = React.forwardRef<SVGSVGElement, SpinnerProps>(
+  ({ className, size, ...props }, ref) => {
+    return (
+      <Loader2
+        ref={ref}
+        className={cn(spinnerVariants({ size, className }))}
+        role="status"
+        aria-label="Loading"
+        {...props}
+      />
+    );
+  },
+);
+Spinner.displayName = "Spinner";
+
+export { Spinner, spinnerVariants };


### PR DESCRIPTION
## Summary
- Add 4 visual atoms: Spinner, Separator, Avatar, Icon wrapper
- CVA size variants for Spinner and Icon
- Horizontal/vertical variants for Separator
- Migrate PlanChangeDialog to use Spinner

## Components
- `ui/spinner.tsx` — Animated loading spinner (wraps Loader2)
- `ui/separator.tsx` — Horizontal/vertical divider
- `ui/avatar.tsx` — Circle avatar with initials fallback
- `ui/icon.tsx` — Standardized icon size wrapper