### PR TITLE
feat(ui): add EmptyState and Skeleton atoms

### DIFF
--- a/packages/web/src/components/task/AgentTimeline.tsx
+++ b/packages/web/src/components/task/AgentTimeline.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Bot } from "lucide-react";
+import { EmptyState } from "@/components/ui/empty-state";
 
 interface AgentTimelineProps {
   activityLog: string | null;
@@ -95,7 +96,7 @@ export function AgentTimeline({ activityLog }: AgentTimelineProps) {
   }, [activityLog, filter]);
 
   if (!activityLog) {
-    return <div className="text-sm text-muted-foreground italic">No agent activity yet</div>;
+    return <EmptyState message="No agent activity yet" />;
   }
 
   return (

--- a/packages/web/src/components/task/TaskComments.tsx
+++ b/packages/web/src/components/task/TaskComments.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { Bot, Download, User } from "lucide-react";
 import { useTaskComments } from "@/hooks/useTasks";
 import { Markdown } from "@/components/ui/markdown";
+import { EmptyState } from "@/components/ui/empty-state";
 
 interface TaskCommentsProps {
   taskId: string;
@@ -18,11 +19,11 @@ export function TaskComments({ taskId }: TaskCommentsProps) {
   const reversedComments = useMemo(() => (comments ? [...comments].reverse() : []), [comments]);
 
   if (isLoading) {
-    return <div className="text-sm text-muted-foreground italic">Loading comments...</div>;
+    return <EmptyState message="Loading comments..." />;
   }
 
   if (!comments || comments.length === 0) {
-    return <div className="text-sm text-muted-foreground italic">No comments yet</div>;
+    return <EmptyState message="No comments yet" />;
   }
 
   return (

--- a/packages/web/src/components/task/TaskLog.tsx
+++ b/packages/web/src/components/task/TaskLog.tsx
@@ -1,4 +1,5 @@
 import { Markdown } from "@/components/ui/markdown";
+import { EmptyState } from "@/components/ui/empty-state";
 
 interface TaskLogProps {
   log: string | null;
@@ -7,11 +8,7 @@ interface TaskLogProps {
 
 export function TaskLog({ log, label }: TaskLogProps) {
   if (!log) {
-    return (
-      <div className="text-sm text-muted-foreground italic">
-        No {label.toLowerCase()} yet
-      </div>
-    );
+    return <EmptyState message={`No ${label.toLowerCase()} yet`} />;
   }
 
   return (

--- a/packages/web/src/components/task/TaskPlan.tsx
+++ b/packages/web/src/components/task/TaskPlan.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { Markdown } from "@/components/ui/markdown";
+import { EmptyState } from "@/components/ui/empty-state";
 
 interface TaskPlanProps {
   plan: string | null;
@@ -10,7 +11,7 @@ export function TaskPlan({ plan }: TaskPlanProps) {
   const [expanded, setExpanded] = useState(false);
 
   if (!plan) {
-    return <div className="text-sm text-muted-foreground italic">No plan generated yet</div>;
+    return <EmptyState message="No plan generated yet" />;
   }
 
   return (

--- a/packages/web/src/components/ui/__tests__/EmptyState.test.tsx
+++ b/packages/web/src/components/ui/__tests__/EmptyState.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { EmptyState } from "../empty-state";
+
+describe("EmptyState", () => {
+  it("renders message", () => {
+    render(<EmptyState message="No items found" />);
+    expect(screen.getByText("No items found")).toBeInTheDocument();
+  });
+
+  it("renders description when provided", () => {
+    render(<EmptyState message="Empty" description="Try adding something" />);
+    expect(screen.getByText("Try adding something")).toBeInTheDocument();
+  });
+
+  it("renders icon slot", () => {
+    render(<EmptyState message="Empty" icon={<span data-testid="icon">icon</span>} />);
+    expect(screen.getByTestId("icon")).toBeInTheDocument();
+  });
+
+  it("renders action slot", () => {
+    render(<EmptyState message="Empty" action={<button type="button">Add</button>} />);
+    expect(screen.getByRole("button", { name: "Add" })).toBeInTheDocument();
+  });
+
+  it("merges className", () => {
+    const { container } = render(<EmptyState message="Empty" className="custom-class" />);
+    expect(container.firstChild).toHaveClass("custom-class");
+  });
+
+  it("renders without optional props", () => {
+    const { container } = render(<EmptyState message="Just a message" />);
+    expect(screen.getByText("Just a message")).toBeInTheDocument();
+    expect(container.querySelectorAll("p")).toHaveLength(1);
+  });
+});

--- a/packages/web/src/components/ui/__tests__/Skeleton.test.tsx
+++ b/packages/web/src/components/ui/__tests__/Skeleton.test.tsx
@@ -1,0 +1,28 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Skeleton } from "../skeleton";
+
+describe("Skeleton", () => {
+  it("renders single block by default", () => {
+    const { container } = render(<Skeleton />);
+    const blocks = container.querySelectorAll("div.animate-pulse");
+    expect(blocks).toHaveLength(1);
+  });
+
+  it("renders multiple blocks with count prop", () => {
+    const { container } = render(<Skeleton count={3} />);
+    const blocks = container.querySelectorAll("div.animate-pulse");
+    expect(blocks).toHaveLength(3);
+  });
+
+  it("has animate-pulse class", () => {
+    const { container } = render(<Skeleton />);
+    expect(container.firstChild).toHaveClass("animate-pulse");
+  });
+
+  it("merges className for custom sizing", () => {
+    const { container } = render(<Skeleton className="h-20 w-full" />);
+    expect(container.firstChild).toHaveClass("h-20");
+    expect(container.firstChild).toHaveClass("w-full");
+  });
+});

--- a/packages/web/src/components/ui/empty-state.tsx
+++ b/packages/web/src/components/ui/empty-state.tsx
@@ -1,0 +1,24 @@
+import { cn } from "@/lib/utils";
+
+interface EmptyStateProps {
+  icon?: React.ReactNode;
+  message: string;
+  description?: string;
+  action?: React.ReactNode;
+  className?: string;
+}
+
+function EmptyState({ icon, message, description, action, className }: EmptyStateProps) {
+  return (
+    <div
+      className={cn("rounded-none border border-dashed border-border py-8 text-center", className)}
+    >
+      {icon && <div className="mb-2">{icon}</div>}
+      <p className="text-sm font-medium text-foreground">{message}</p>
+      {description && <p className="mt-1 text-xs text-muted-foreground">{description}</p>}
+      {action && <div className="mt-3">{action}</div>}
+    </div>
+  );
+}
+
+export { EmptyState };

--- a/packages/web/src/components/ui/skeleton.tsx
+++ b/packages/web/src/components/ui/skeleton.tsx
@@ -1,0 +1,35 @@
+import { cn } from "@/lib/utils";
+
+interface SkeletonProps {
+  className?: string;
+  count?: number;
+}
+
+const bgByIndex = [
+  "bg-secondary/40",
+  "bg-secondary/25",
+  "bg-secondary/20",
+  "bg-secondary/15",
+] as const;
+
+function bgForIndex(index: number): string {
+  return bgByIndex[Math.min(index, bgByIndex.length - 1)];
+}
+
+const base = "rounded-none border border-border animate-pulse";
+
+function Skeleton({ className, count = 1 }: SkeletonProps) {
+  if (count <= 1) {
+    return <div className={cn(base, "bg-secondary/25", className)} />;
+  }
+
+  return (
+    <div className="space-y-2">
+      {Array.from({ length: count }, (_, i) => (
+        <div key={i} className={cn(base, bgForIndex(i), className)} />
+      ))}
+    </div>
+  );
+}
+
+export { Skeleton };

--- a/packages/web/src/test-setup.ts
+++ b/packages/web/src/test-setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import path from "path";
@@ -50,6 +50,11 @@ export default defineConfig({
     alias: {
       "@": path.resolve(__dirname, "./src"),
     },
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./src/test-setup.ts"],
   },
   server: {
     port: WEB_PORT,


### PR DESCRIPTION
## Summary
- Add EmptyState and Skeleton loading atoms
- Migrate TaskPlan, TaskLog, TaskComments, AgentTimeline to use EmptyState
- Skeleton with staggered opacity pulse effect

## Components
- `ui/empty-state.tsx` — Dashed border empty content placeholder with icon/action slots
- `ui/skeleton.tsx` — Loading placeholder blocks with staggered opacity