### PR TITLE
feat(ui): add FilterButton, ToggleButton, Tabs atoms

### DIFF
--- a/packages/web/src/__tests__/FilterButton.test.tsx
+++ b/packages/web/src/__tests__/FilterButton.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { FilterButton } from "@/components/ui/filter-button";
+
+describe("FilterButton", () => {
+  it("renders children text", () => {
+    render(
+      <FilterButton active={false} onClick={vi.fn()}>
+        All
+      </FilterButton>,
+    );
+    expect(screen.getByText("All")).toBeDefined();
+  });
+
+  it("applies active styling when active", () => {
+    render(
+      <FilterButton active={true} onClick={vi.fn()}>
+        Active
+      </FilterButton>,
+    );
+    const button = screen.getByText("Active");
+    expect(button.className).toContain("bg-primary/15");
+    expect(button.className).toContain("text-primary");
+    expect(button.className).toContain("border-primary/45");
+  });
+
+  it("applies inactive styling when not active", () => {
+    render(
+      <FilterButton active={false} onClick={vi.fn()}>
+        Inactive
+      </FilterButton>,
+    );
+    const button = screen.getByText("Inactive");
+    expect(button.className).toContain("bg-background/45");
+    expect(button.className).toContain("text-muted-foreground");
+    expect(button.className).toContain("border-border");
+  });
+
+  it("fires onClick when clicked", () => {
+    const onClick = vi.fn();
+    render(
+      <FilterButton active={false} onClick={onClick}>
+        Click me
+      </FilterButton>,
+    );
+    fireEvent.click(screen.getByText("Click me"));
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("renders sm size variant", () => {
+    render(
+      <FilterButton active={false} onClick={vi.fn()} size="sm">
+        Small
+      </FilterButton>,
+    );
+    const button = screen.getByText("Small");
+    expect(button.className).toContain("py-0.5");
+    expect(button.className).toContain("text-[10px]");
+  });
+
+  it("renders default size variant", () => {
+    render(
+      <FilterButton active={false} onClick={vi.fn()} size="default">
+        Default
+      </FilterButton>,
+    );
+    const button = screen.getByText("Default");
+    expect(button.className).toContain("py-1");
+    expect(button.className).toContain("text-[11px]");
+  });
+
+  it("merges custom className", () => {
+    render(
+      <FilterButton active={false} onClick={vi.fn()} className="ml-4">
+        Custom
+      </FilterButton>,
+    );
+    const button = screen.getByText("Custom");
+    expect(button.className).toContain("ml-4");
+  });
+});

--- a/packages/web/src/__tests__/Tabs.test.tsx
+++ b/packages/web/src/__tests__/Tabs.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Tabs } from "@/components/ui/tabs";
+
+const items = [
+  { value: "impl", label: "Implementation" },
+  { value: "review", label: "Review" },
+  { value: "comments", label: "Comments" },
+];
+
+describe("Tabs", () => {
+  it("renders all tab items", () => {
+    render(<Tabs items={items} value="impl" onValueChange={vi.fn()} />);
+    expect(screen.getByText("Implementation")).toBeDefined();
+    expect(screen.getByText("Review")).toBeDefined();
+    expect(screen.getByText("Comments")).toBeDefined();
+  });
+
+  it("highlights active tab with primary styling", () => {
+    render(<Tabs items={items} value="impl" onValueChange={vi.fn()} />);
+    const activeTab = screen.getByText("Implementation");
+    expect(activeTab.className).toContain("bg-primary/15");
+    expect(activeTab.className).toContain("text-primary");
+    expect(activeTab.className).toContain("border-primary/45");
+  });
+
+  it("applies inactive styling to non-active tabs", () => {
+    render(<Tabs items={items} value="impl" onValueChange={vi.fn()} />);
+    const inactiveTab = screen.getByText("Review");
+    expect(inactiveTab.className).toContain("text-muted-foreground");
+    expect(inactiveTab.className).toContain("border-border/40");
+  });
+
+  it("fires onValueChange with clicked tab value", () => {
+    const onValueChange = vi.fn();
+    render(<Tabs items={items} value="impl" onValueChange={onValueChange} />);
+    fireEvent.click(screen.getByText("Review"));
+    expect(onValueChange).toHaveBeenCalledWith("review");
+  });
+
+  it("renders tablist role on container", () => {
+    render(<Tabs items={items} value="impl" onValueChange={vi.fn()} />);
+    const tablist = screen.getByRole("tablist");
+    expect(tablist).toBeDefined();
+  });
+
+  it("sets role=tab on each button", () => {
+    render(<Tabs items={items} value="impl" onValueChange={vi.fn()} />);
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs).toHaveLength(3);
+  });
+
+  it("sets aria-selected on active tab only", () => {
+    render(<Tabs items={items} value="review" onValueChange={vi.fn()} />);
+    const tabs = screen.getAllByRole("tab");
+    const selected = tabs.map((tab) => tab.getAttribute("aria-selected"));
+    expect(selected).toEqual(["false", "true", "false"]);
+  });
+});

--- a/packages/web/src/__tests__/ToggleButton.test.tsx
+++ b/packages/web/src/__tests__/ToggleButton.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ToggleButton } from "@/components/ui/toggle-button";
+
+describe("ToggleButton", () => {
+  it("renders children text", () => {
+    render(
+      <ToggleButton expanded={false} onClick={vi.fn()}>
+        Show plan
+      </ToggleButton>,
+    );
+    expect(screen.getByText("Show plan")).toBeDefined();
+  });
+
+  it("shows ChevronRight when collapsed", () => {
+    const { container } = render(
+      <ToggleButton expanded={false} onClick={vi.fn()}>
+        Show plan
+      </ToggleButton>,
+    );
+    const svg = container.querySelector("svg");
+    expect(svg).toBeDefined();
+    const button = screen.getByRole("button");
+    expect(button.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("shows ChevronDown when expanded", () => {
+    const { container } = render(
+      <ToggleButton expanded={true} onClick={vi.fn()}>
+        Hide plan
+      </ToggleButton>,
+    );
+    const svg = container.querySelector("svg");
+    expect(svg).toBeDefined();
+    const button = screen.getByRole("button");
+    expect(button.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("sets aria-expanded to false when collapsed", () => {
+    render(
+      <ToggleButton expanded={false} onClick={vi.fn()}>
+        Toggle
+      </ToggleButton>,
+    );
+    const button = screen.getByRole("button");
+    expect(button.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("sets aria-expanded to true when expanded", () => {
+    render(
+      <ToggleButton expanded={true} onClick={vi.fn()}>
+        Toggle
+      </ToggleButton>,
+    );
+    const button = screen.getByRole("button");
+    expect(button.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("fires onClick when clicked", () => {
+    const onClick = vi.fn();
+    render(
+      <ToggleButton expanded={false} onClick={onClick}>
+        Click me
+      </ToggleButton>,
+    );
+    fireEvent.click(screen.getByText("Click me"));
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/web/src/components/task/AgentTimeline.tsx
+++ b/packages/web/src/components/task/AgentTimeline.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Bot } from "lucide-react";
+import { FilterButton } from "@/components/ui/filter-button";
 
 interface AgentTimelineProps {
   activityLog: string | null;
@@ -101,18 +102,18 @@ export function AgentTimeline({ activityLog }: AgentTimelineProps) {
   return (
     <div className="border border-border bg-secondary/35 p-3">
       <div className="mb-2 flex items-center gap-2">
-        <FilterButton label="All" active={filter === "all"} onClick={() => setFilter("all")} />
-        <FilterButton
-          label="Agents"
-          active={filter === "agent"}
-          onClick={() => setFilter("agent")}
-        />
-        <FilterButton label="Tools" active={filter === "tool"} onClick={() => setFilter("tool")} />
-        <FilterButton
-          label="Errors"
-          active={filter === "error"}
-          onClick={() => setFilter("error")}
-        />
+        <FilterButton size="sm" active={filter === "all"} onClick={() => setFilter("all")}>
+          All
+        </FilterButton>
+        <FilterButton size="sm" active={filter === "agent"} onClick={() => setFilter("agent")}>
+          Agents
+        </FilterButton>
+        <FilterButton size="sm" active={filter === "tool"} onClick={() => setFilter("tool")}>
+          Tools
+        </FilterButton>
+        <FilterButton size="sm" active={filter === "error"} onClick={() => setFilter("error")}>
+          Errors
+        </FilterButton>
         <span className="ml-auto text-[10px] text-muted-foreground">{visibleEntries.length}</span>
       </div>
 
@@ -154,29 +155,5 @@ export function AgentTimeline({ activityLog }: AgentTimelineProps) {
         })}
       </div>
     </div>
-  );
-}
-
-function FilterButton({
-  label,
-  active,
-  onClick,
-}: {
-  label: string;
-  active: boolean;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      className={`border px-2 py-0.5 text-[10px] transition-colors ${
-        active
-          ? "border-primary/40 bg-primary/15 text-primary"
-          : "border-border bg-background/50 text-muted-foreground hover:bg-background"
-      }`}
-      onClick={onClick}
-      type="button"
-    >
-      {label}
-    </button>
   );
 }

--- a/packages/web/src/components/task/Section.tsx
+++ b/packages/web/src/components/task/Section.tsx
@@ -19,27 +19,3 @@ export function Section({
     </div>
   );
 }
-
-export function TabButton({
-  active,
-  onClick,
-  children,
-}: {
-  active: boolean;
-  onClick: () => void;
-  children: React.ReactNode;
-}) {
-  return (
-    <button
-      className={`border px-2 py-1 text-[10px] transition-colors ${
-        active
-          ? "border-primary/40 bg-primary/15 text-primary"
-          : "border-border bg-background/50 text-muted-foreground hover:bg-background"
-      }`}
-      onClick={onClick}
-      type="button"
-    >
-      {children}
-    </button>
-  );
-}

--- a/packages/web/src/components/task/TaskAttachments.tsx
+++ b/packages/web/src/components/task/TaskAttachments.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
-import { ChevronDown, ChevronRight, Download } from "lucide-react";
+import { Download } from "lucide-react";
 import type { TaskCommentAttachment } from "@aif/shared/browser";
 import { Button } from "@/components/ui/button";
+import { ToggleButton } from "@/components/ui/toggle-button";
 
 interface TaskAttachmentsProps {
   taskId: string;
@@ -27,14 +28,9 @@ export function TaskAttachments({
 
   return (
     <div className="space-y-3">
-      <button
-        type="button"
-        className="inline-flex items-center gap-1 border border-border bg-background/60 px-2 py-1 text-[11px] text-muted-foreground transition-colors hover:text-foreground"
-        onClick={() => setExpanded((prev) => !prev)}
-      >
-        {expanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+      <ToggleButton expanded={expanded} onClick={() => setExpanded((prev) => !prev)}>
         {expanded ? "Hide attachments" : `Show attachments (${attachments.length})`}
-      </button>
+      </ToggleButton>
 
       {expanded && (
         <>

--- a/packages/web/src/components/task/TaskDetailHeader.tsx
+++ b/packages/web/src/components/task/TaskDetailHeader.tsx
@@ -5,7 +5,7 @@ import { SheetHeader, SheetTitle, SheetClose } from "@/components/ui/sheet";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { formatTokenCount, formatUsd } from "@/lib/formatters";
-import { TabButton } from "./Section";
+import { Tabs } from "@/components/ui/tabs";
 
 export type TaskDetailTab = "implementation" | "review" | "comments" | "activity";
 
@@ -178,23 +178,17 @@ export function TaskDetailHeader({
         </div>
       )}
 
-      <div className="mt-3 flex flex-wrap gap-2 border border-border bg-background/55 p-2">
-        <TabButton
-          active={activeTab === "implementation"}
-          onClick={() => onTabChange("implementation")}
-        >
-          Implementation
-        </TabButton>
-        <TabButton active={activeTab === "review"} onClick={() => onTabChange("review")}>
-          Review
-        </TabButton>
-        <TabButton active={activeTab === "comments"} onClick={() => onTabChange("comments")}>
-          Comments
-        </TabButton>
-        <TabButton active={activeTab === "activity"} onClick={() => onTabChange("activity")}>
-          Activity
-        </TabButton>
-      </div>
+      <Tabs
+        className="mt-3 border border-border bg-background/55 p-2"
+        items={[
+          { value: "implementation", label: "Implementation" },
+          { value: "review", label: "Review" },
+          { value: "comments", label: "Comments" },
+          { value: "activity", label: "Activity" },
+        ]}
+        value={activeTab}
+        onValueChange={(v) => onTabChange(v as TaskDetailTab)}
+      />
     </div>
   );
 }

--- a/packages/web/src/components/task/TaskPlan.tsx
+++ b/packages/web/src/components/task/TaskPlan.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { ChevronDown, ChevronRight } from "lucide-react";
 import { Markdown } from "@/components/ui/markdown";
+import { ToggleButton } from "@/components/ui/toggle-button";
 
 interface TaskPlanProps {
   plan: string | null;
@@ -15,14 +15,9 @@ export function TaskPlan({ plan }: TaskPlanProps) {
 
   return (
     <div className="space-y-3">
-      <button
-        type="button"
-        className="inline-flex items-center gap-1 border border-border bg-background/60 px-2 py-1 text-[11px] text-muted-foreground transition-colors hover:text-foreground"
-        onClick={() => setExpanded((prev) => !prev)}
-      >
-        {expanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+      <ToggleButton expanded={expanded} onClick={() => setExpanded((prev) => !prev)}>
         {expanded ? "Hide plan" : "Show plan"}
-      </button>
+      </ToggleButton>
 
       {expanded && <Markdown content={plan} className="text-sm text-foreground/90" />}
     </div>

--- a/packages/web/src/components/ui/filter-button.tsx
+++ b/packages/web/src/components/ui/filter-button.tsx
@@ -1,0 +1,44 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const filterButtonVariants = cva(
+  "inline-flex items-center gap-1 border font-mono transition-colors cursor-pointer rounded-none",
+  {
+    variants: {
+      size: {
+        sm: "px-2 py-0.5 text-[10px]",
+        default: "px-2.5 py-1 text-[11px]",
+      },
+    },
+    defaultVariants: {
+      size: "default",
+    },
+  },
+);
+
+export interface FilterButtonProps extends VariantProps<typeof filterButtonVariants> {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function FilterButton({ active, onClick, children, size, className }: FilterButtonProps) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        filterButtonVariants({ size }),
+        active
+          ? "border-primary/45 bg-primary/15 text-primary"
+          : "border-border bg-background/45 text-muted-foreground hover:bg-background",
+        className,
+      )}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+}
+
+export { filterButtonVariants };

--- a/packages/web/src/components/ui/tabs.tsx
+++ b/packages/web/src/components/ui/tabs.tsx
@@ -1,0 +1,40 @@
+import { cn } from "@/lib/utils";
+
+export interface TabsItem {
+  value: string;
+  label: string;
+}
+
+export interface TabsProps {
+  items: TabsItem[];
+  value: string;
+  onValueChange: (value: string) => void;
+  className?: string;
+}
+
+export function Tabs({ items, value, onValueChange, className }: TabsProps) {
+  return (
+    <div role="tablist" className={cn("flex flex-wrap gap-2", className)}>
+      {items.map((item) => {
+        const isActive = item.value === value;
+        return (
+          <button
+            key={item.value}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            className={cn(
+              "border px-2 py-1 text-[10px] transition-colors rounded-none",
+              isActive
+                ? "border-primary/45 bg-primary/15 text-primary"
+                : "border-border/40 text-muted-foreground hover:text-foreground",
+            )}
+            onClick={() => onValueChange(item.value)}
+          >
+            {item.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/web/src/components/ui/toggle-button.tsx
+++ b/packages/web/src/components/ui/toggle-button.tsx
@@ -1,0 +1,26 @@
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface ToggleButtonProps {
+  expanded: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function ToggleButton({ expanded, onClick, children, className }: ToggleButtonProps) {
+  return (
+    <button
+      type="button"
+      aria-expanded={expanded}
+      className={cn(
+        "inline-flex items-center gap-1 border border-border bg-background/60 px-2 py-1 text-[11px] text-muted-foreground transition-colors hover:text-foreground rounded-none",
+        className,
+      )}
+      onClick={onClick}
+    >
+      {expanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+      {children}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- Add 3 interactive atoms: FilterButton, ToggleButton, Tabs
- Migrate Section.tsx TabButton, AgentTimeline FilterButton, TaskPlan/TaskAttachments expand buttons
- FilterButton has active/inactive + density awareness

## Components
- `ui/filter-button.tsx` — Active/inactive toggle chip
- `ui/toggle-button.tsx` — Expand/collapse chevron button
- `ui/tabs.tsx` — Controlled tab strip molecule