### PR TITLE
feat(ui): add Badge semantic variants and design tokens

### DIFF
--- a/packages/web/src/__tests__/Badge.test.tsx
+++ b/packages/web/src/__tests__/Badge.test.tsx
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Badge, badgeVariants } from "@/components/ui/badge";
+
+describe("Badge", () => {
+  describe("existing variants", () => {
+    it("renders default variant", () => {
+      render(<Badge>Default</Badge>);
+      const badge = screen.getByText("Default");
+      expect(badge).toBeInTheDocument();
+      expect(badge.className).toContain("bg-primary/15");
+    });
+
+    it("renders secondary variant", () => {
+      render(<Badge variant="secondary">Secondary</Badge>);
+      const badge = screen.getByText("Secondary");
+      expect(badge).toBeInTheDocument();
+      expect(badge.className).toContain("bg-secondary");
+    });
+
+    it("renders destructive variant", () => {
+      render(<Badge variant="destructive">Destructive</Badge>);
+      const badge = screen.getByText("Destructive");
+      expect(badge).toBeInTheDocument();
+      expect(badge.className).toContain("bg-destructive/15");
+    });
+
+    it("renders outline variant", () => {
+      render(<Badge variant="outline">Outline</Badge>);
+      const badge = screen.getByText("Outline");
+      expect(badge).toBeInTheDocument();
+      expect(badge.className).toContain("text-foreground");
+    });
+  });
+
+  describe("priority variants", () => {
+    it.each(["low", "medium", "high", "urgent"] as const)(
+      "renders priority-%s variant",
+      (level) => {
+        const variant = `priority-${level}` as const;
+        render(<Badge variant={variant}>{level}</Badge>);
+        const badge = screen.getByText(level);
+        expect(badge).toBeInTheDocument();
+        expect(badge.className).toContain(`text-priority-${level}`);
+        expect(badge.className).toContain(`bg-priority-${level}/15`);
+        expect(badge.className).toContain(`border-priority-${level}/30`);
+      },
+    );
+  });
+
+  describe("semantic variants", () => {
+    it("renders tool variant", () => {
+      render(<Badge variant="tool">Tool</Badge>);
+      const badge = screen.getByText("Tool");
+      expect(badge).toBeInTheDocument();
+      expect(badge.className).toContain("bg-cyan-500/10");
+      expect(badge.className).toContain("border-cyan-500/30");
+    });
+
+    it("renders agent variant", () => {
+      render(<Badge variant="agent">Agent</Badge>);
+      const badge = screen.getByText("Agent");
+      expect(badge).toBeInTheDocument();
+      expect(badge.className).toContain("bg-violet-500/10");
+      expect(badge.className).toContain("border-violet-500/30");
+    });
+
+    it("renders error variant", () => {
+      render(<Badge variant="error">Error</Badge>);
+      const badge = screen.getByText("Error");
+      expect(badge).toBeInTheDocument();
+      expect(badge.className).toContain("bg-destructive/15");
+      expect(badge.className).toContain("border-destructive/30");
+    });
+  });
+
+  describe("custom className", () => {
+    it("merges custom className with variant classes", () => {
+      render(<Badge className="mt-4">Styled</Badge>);
+      const badge = screen.getByText("Styled");
+      expect(badge.className).toContain("mt-4");
+      expect(badge.className).toContain("bg-primary/15");
+    });
+  });
+
+  describe("children", () => {
+    it("renders string children", () => {
+      render(<Badge>Hello</Badge>);
+      expect(screen.getByText("Hello")).toBeInTheDocument();
+    });
+
+    it("renders element children", () => {
+      render(
+        <Badge>
+          <span data-testid="inner">Nested</span>
+        </Badge>,
+      );
+      expect(screen.getByTestId("inner")).toBeInTheDocument();
+      expect(screen.getByTestId("inner").textContent).toBe("Nested");
+    });
+  });
+
+  describe("accessibility", () => {
+    it("renders as a div element", () => {
+      render(<Badge data-testid="badge">Content</Badge>);
+      const badge = screen.getByTestId("badge");
+      expect(badge.tagName).toBe("DIV");
+    });
+
+    it("forwards aria attributes", () => {
+      render(
+        <Badge aria-label="status badge" role="status">
+          Active
+        </Badge>,
+      );
+      const badge = screen.getByRole("status");
+      expect(badge).toHaveAttribute("aria-label", "status badge");
+    });
+  });
+
+  describe("badgeVariants", () => {
+    it("exports badgeVariants for external use", () => {
+      expect(badgeVariants).toBeDefined();
+      expect(typeof badgeVariants).toBe("function");
+    });
+
+    it("generates class string for each variant", () => {
+      const variants = [
+        "default",
+        "secondary",
+        "destructive",
+        "outline",
+        "priority-low",
+        "priority-medium",
+        "priority-high",
+        "priority-urgent",
+        "tool",
+        "agent",
+        "error",
+      ] as const;
+
+      for (const variant of variants) {
+        const classes = badgeVariants({ variant });
+        expect(classes).toBeTruthy();
+        expect(typeof classes).toBe("string");
+      }
+    });
+  });
+});

--- a/packages/web/src/components/ui/badge.tsx
+++ b/packages/web/src/components/ui/badge.tsx
@@ -11,22 +11,26 @@ const badgeVariants = cva(
         secondary: "border-border bg-secondary text-secondary-foreground",
         destructive: "border-destructive/30 bg-destructive/15 text-destructive",
         outline: "border-border text-foreground",
+        "priority-low": "border-priority-low/30 bg-priority-low/15 text-priority-low",
+        "priority-medium": "border-priority-medium/30 bg-priority-medium/15 text-priority-medium",
+        "priority-high": "border-priority-high/30 bg-priority-high/15 text-priority-high",
+        "priority-urgent": "border-priority-urgent/30 bg-priority-urgent/15 text-priority-urgent",
+        tool: "border-cyan-500/30 bg-cyan-500/10 text-cyan-400 dark:text-cyan-300",
+        agent: "border-violet-500/30 bg-violet-500/10 text-violet-400 dark:text-violet-300",
+        error: "border-destructive/30 bg-destructive/15 text-destructive",
       },
     },
     defaultVariants: {
       variant: "default",
     },
-  }
+  },
 );
 
 export interface BadgeProps
-  extends React.HTMLAttributes<HTMLDivElement>,
-    VariantProps<typeof badgeVariants> {}
+  extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof badgeVariants> {}
 
 function Badge({ className, variant, ...props }: BadgeProps) {
-  return (
-    <div className={cn(badgeVariants({ variant }), className)} {...props} />
-  );
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
 }
 
 export { Badge, badgeVariants };

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -22,6 +22,19 @@
   --color-input: #2a2a2a;
   --color-ring: #10b981;
   --radius: 0rem;
+  /* Status colors */
+  --color-status-backlog: #6b7280;
+  --color-status-planning: #8b5cf6;
+  --color-status-ready: #06b6d4;
+  --color-status-implementing: #f59e0b;
+  --color-status-review: #3b82f6;
+  --color-status-done: #10b981;
+  --color-status-failed: #ef4444;
+  /* Priority colors */
+  --color-priority-low: #06b6d4;
+  --color-priority-medium: #f59e0b;
+  --color-priority-high: #f97316;
+  --color-priority-urgent: #ef4444;
 }
 
 :root.light {
@@ -44,6 +57,19 @@
   --color-border: #b7c4bc;
   --color-input: #b7c4bc;
   --color-ring: #0f766e;
+  /* Status colors */
+  --color-status-backlog: #6b7280;
+  --color-status-planning: #7c3aed;
+  --color-status-ready: #0891b2;
+  --color-status-implementing: #d97706;
+  --color-status-review: #2563eb;
+  --color-status-done: #059669;
+  --color-status-failed: #dc2626;
+  /* Priority colors */
+  --color-priority-low: #0891b2;
+  --color-priority-medium: #d97706;
+  --color-priority-high: #ea580c;
+  --color-priority-urgent: #dc2626;
 }
 
 body {


### PR DESCRIPTION
## Summary
- Extend Badge with semantic variants: priority-low/med/high/urgent, tool, agent, error
- Add status and priority color tokens to index.css (dark + light themes)

## Changes
- `ui/badge.tsx` — 7 new CVA variants
- `index.css` — Status + priority color CSS custom properties
- `Badge.test.tsx` — Comprehensive variant coverage