### PR TITLE
feat(ui): add TimestampLabel, IconLabel, AuthorBadge, SourceIcon atoms

### DIFF
--- a/packages/web/src/__tests__/AuthorBadge.test.tsx
+++ b/packages/web/src/__tests__/AuthorBadge.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { AuthorBadge } from "@/components/ui/author-badge";
+
+describe("AuthorBadge", () => {
+  it('renders "User" for human author', () => {
+    render(<AuthorBadge author="human" />);
+    expect(screen.getByText("User")).toBeInTheDocument();
+  });
+
+  it('renders "Agent" for agent author', () => {
+    render(<AuthorBadge author="agent" />);
+    expect(screen.getByText("Agent")).toBeInTheDocument();
+  });
+
+  it("renders User icon for human", () => {
+    const { container } = render(<AuthorBadge author="human" />);
+    const svg = container.querySelector("svg");
+    expect(svg).toBeInTheDocument();
+  });
+
+  it("renders Bot icon for agent", () => {
+    const { container } = render(<AuthorBadge author="agent" />);
+    const svg = container.querySelector("svg");
+    expect(svg).toBeInTheDocument();
+  });
+
+  it("uses custom label override", () => {
+    render(<AuthorBadge author="human" label="Admin" />);
+    expect(screen.getByText("Admin")).toBeInTheDocument();
+    expect(screen.queryByText("User")).toBeNull();
+  });
+
+  it("applies text-blue-400 for human", () => {
+    const { container } = render(<AuthorBadge author="human" />);
+    expect(container.firstElementChild!.className).toContain("text-blue-400");
+  });
+
+  it("applies text-agent for agent", () => {
+    const { container } = render(<AuthorBadge author="agent" />);
+    expect(container.firstElementChild!.className).toContain("text-agent");
+  });
+});

--- a/packages/web/src/__tests__/IconLabel.test.tsx
+++ b/packages/web/src/__tests__/IconLabel.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { IconLabel } from "@/components/ui/icon-label";
+
+describe("IconLabel", () => {
+  it("renders icon and text", () => {
+    render(<IconLabel icon={<span data-testid="icon">I</span>}>Hello</IconLabel>);
+    expect(screen.getByTestId("icon")).toBeInTheDocument();
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+  });
+
+  it("uses default gap", () => {
+    const { container } = render(<IconLabel icon={<span>I</span>}>text</IconLabel>);
+    expect(container.firstElementChild!.className).toContain("gap-1.5");
+  });
+
+  it("uses sm gap", () => {
+    const { container } = render(
+      <IconLabel icon={<span>I</span>} gap="sm">
+        text
+      </IconLabel>,
+    );
+    expect(container.firstElementChild!.className).toContain("gap-1");
+    expect(container.firstElementChild!.className).not.toContain("gap-1.5");
+  });
+
+  it("merges custom className", () => {
+    const { container } = render(
+      <IconLabel icon={<span>I</span>} className="text-red-500">
+        text
+      </IconLabel>,
+    );
+    expect(container.firstElementChild!.className).toContain("text-red-500");
+  });
+});

--- a/packages/web/src/__tests__/SourceIcon.test.tsx
+++ b/packages/web/src/__tests__/SourceIcon.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { SourceIcon } from "@/components/ui/source-icon";
+
+describe("SourceIcon", () => {
+  it("renders Terminal icon for cli", () => {
+    const { container } = render(<SourceIcon source="cli" />);
+    const svg = container.querySelector("svg");
+    expect(svg).toBeInTheDocument();
+    expect(svg!.className.baseVal || svg!.getAttribute("class")).toContain("h-3.5");
+  });
+
+  it("renders Bot icon for agent", () => {
+    const { container } = render(<SourceIcon source="agent" />);
+    const svg = container.querySelector("svg");
+    expect(svg).toBeInTheDocument();
+  });
+
+  it("renders MessageSquare icon for web", () => {
+    const { container } = render(<SourceIcon source="web" />);
+    const svg = container.querySelector("svg");
+    expect(svg).toBeInTheDocument();
+  });
+
+  it("renders fallback Circle icon for unknown source", () => {
+    const { container } = render(<SourceIcon source="email" />);
+    const svg = container.querySelector("svg");
+    expect(svg).toBeInTheDocument();
+  });
+
+  it("applies custom className", () => {
+    const { container } = render(<SourceIcon source="cli" className="text-red-500" />);
+    const svg = container.querySelector("svg");
+    expect(svg!.getAttribute("class")).toContain("text-red-500");
+  });
+});

--- a/packages/web/src/__tests__/TimestampLabel.test.tsx
+++ b/packages/web/src/__tests__/TimestampLabel.test.tsx
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TimestampLabel } from "@/components/ui/timestamp-label";
+
+describe("TimestampLabel", () => {
+  it("renders children", () => {
+    render(<TimestampLabel>2m ago</TimestampLabel>);
+    expect(screen.getByText("2m ago")).toBeInTheDocument();
+  });
+
+  it("applies monospace font class", () => {
+    render(<TimestampLabel>abc-123</TimestampLabel>);
+    const el = screen.getByText("abc-123");
+    expect(el.className).toContain("font-mono");
+  });
+
+  it("merges custom className", () => {
+    render(<TimestampLabel className="text-red-500">ts</TimestampLabel>);
+    const el = screen.getByText("ts");
+    expect(el.className).toContain("text-red-500");
+  });
+});

--- a/packages/web/src/components/chat/SessionList.tsx
+++ b/packages/web/src/components/chat/SessionList.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, type KeyboardEvent as ReactKeyboardEvent } from "react";
-import { MessageSquare, Plus, Trash2, Pencil, Check, X, Terminal, Bot } from "lucide-react";
+import { Plus, Trash2, Pencil, Check, X } from "lucide-react";
+import { SourceIcon } from "@/components/ui/source-icon";
 import { cn } from "@/lib/utils";
 import type { ChatSession } from "@aif/shared/browser";
 
@@ -94,13 +95,17 @@ export function SessionList({
               if (editingId !== session.id) onSelect(session.id);
             }}
           >
-            {session.source === "cli" ? (
-              <Terminal className="h-3.5 w-3.5 shrink-0 text-amber-500" />
-            ) : session.source === "agent" ? (
-              <Bot className="h-3.5 w-3.5 shrink-0 text-violet-500" />
-            ) : (
-              <MessageSquare className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-            )}
+            <SourceIcon
+              source={session.source}
+              className={cn(
+                "shrink-0",
+                session.source === "cli"
+                  ? "text-amber-500"
+                  : session.source === "agent"
+                    ? "text-violet-500"
+                    : "text-muted-foreground",
+              )}
+            />
             <div className="flex-1 min-w-0">
               {editingId === session.id ? (
                 <div className="flex items-center gap-1">

--- a/packages/web/src/components/task/TaskComments.tsx
+++ b/packages/web/src/components/task/TaskComments.tsx
@@ -1,7 +1,8 @@
 import { useMemo } from "react";
-import { Bot, Download, User } from "lucide-react";
+import { Download } from "lucide-react";
 import { useTaskComments } from "@/hooks/useTasks";
 import { Markdown } from "@/components/ui/markdown";
+import { AuthorBadge } from "@/components/ui/author-badge";
 
 interface TaskCommentsProps {
   taskId: string;
@@ -37,18 +38,7 @@ export function TaskComments({ taskId }: TaskCommentsProps) {
           }`}
         >
           <div className="mb-2 flex items-center justify-between text-[11px] text-muted-foreground">
-            <span
-              className={`flex items-center gap-1.5 ${
-                comment.author === "human" ? "text-blue-400" : "text-violet-400"
-              }`}
-            >
-              {comment.author === "human" ? (
-                <User className="h-3.5 w-3.5" />
-              ) : (
-                <Bot className="h-3.5 w-3.5" />
-              )}
-              {comment.author === "human" ? "Human" : "Agent"}
-            </span>
+            <AuthorBadge author={comment.author} />
             <span>{formatWhen(comment.createdAt)}</span>
           </div>
           <Markdown content={comment.message} className="text-sm text-foreground/90" />

--- a/packages/web/src/components/ui/author-badge.tsx
+++ b/packages/web/src/components/ui/author-badge.tsx
@@ -1,0 +1,27 @@
+import { Bot, User } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export function AuthorBadge({
+  author,
+  label,
+  className,
+}: {
+  author: "human" | "agent";
+  label?: string;
+  className?: string;
+}) {
+  const isHuman = author === "human";
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 text-xs font-medium",
+        isHuman ? "text-blue-400 dark:text-blue-400" : "text-agent",
+        className,
+      )}
+    >
+      {isHuman ? <User className="h-3.5 w-3.5" /> : <Bot className="h-3.5 w-3.5" />}
+      {label ?? (isHuman ? "User" : "Agent")}
+    </span>
+  );
+}

--- a/packages/web/src/components/ui/icon-label.tsx
+++ b/packages/web/src/components/ui/icon-label.tsx
@@ -1,0 +1,31 @@
+import { cn } from "@/lib/utils";
+
+const gapMap = {
+  sm: "gap-1",
+  default: "gap-1.5",
+} as const;
+
+export function IconLabel({
+  icon,
+  children,
+  className,
+  gap = "default",
+}: {
+  icon: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+  gap?: "sm" | "default";
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center text-sm text-muted-foreground",
+        gapMap[gap],
+        className,
+      )}
+    >
+      <span className="shrink-0 h-3.5 w-3.5">{icon}</span>
+      {children}
+    </span>
+  );
+}

--- a/packages/web/src/components/ui/source-icon.tsx
+++ b/packages/web/src/components/ui/source-icon.tsx
@@ -1,0 +1,19 @@
+import { Bot, Circle, MessageSquare, Terminal } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const iconMap: Record<string, React.ComponentType<React.SVGProps<SVGSVGElement>>> = {
+  cli: Terminal,
+  agent: Bot,
+  web: MessageSquare,
+};
+
+export function SourceIcon({
+  source,
+  className,
+}: {
+  source: "cli" | "agent" | "web" | string;
+  className?: string;
+}) {
+  const Icon = iconMap[source] ?? Circle;
+  return <Icon className={cn("h-3.5 w-3.5", className)} />;
+}

--- a/packages/web/src/components/ui/timestamp-label.tsx
+++ b/packages/web/src/components/ui/timestamp-label.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/lib/utils";
+
+export function TimestampLabel({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <span className={cn("text-[10px] font-mono text-muted-foreground tracking-tight", className)}>
+      {children}
+    </span>
+  );
+}

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -22,6 +22,13 @@
   --color-input: #2a2a2a;
   --color-ring: #10b981;
   --radius: 0rem;
+
+  /* Agent/tool colors */
+  --color-agent: #8b5cf6;
+  --color-agent-foreground: #c4b5fd;
+  --color-tool: #06b6d4;
+  --color-tool-foreground: #a5f3fc;
+  --color-tool-error: #ef4444;
 }
 
 :root.light {
@@ -44,6 +51,12 @@
   --color-border: #b7c4bc;
   --color-input: #b7c4bc;
   --color-ring: #0f766e;
+
+  --color-agent: #7c3aed;
+  --color-agent-foreground: #5b21b6;
+  --color-tool: #0891b2;
+  --color-tool-foreground: #155e75;
+  --color-tool-error: #dc2626;
 }
 
 body {


### PR DESCRIPTION
## Summary
- Add 4 text display atoms + agent/tool color tokens
- Migrate SessionList (SourceIcon) and TaskComments (AuthorBadge)
- Add --color-agent/tool tokens

## Components
- `ui/timestamp-label.tsx` — Monospace timestamp display
- `ui/icon-label.tsx` — Inline icon + text pair
- `ui/author-badge.tsx` — Human/agent author indicator
- `ui/source-icon.tsx` — Conditional icon by source type