### PR TITLE
feat(ui): add KeyHint, SectionHeader atoms and Button xs variant

### DIFF
--- a/packages/web/src/__tests__/Button.test.tsx
+++ b/packages/web/src/__tests__/Button.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Button } from "@/components/ui/button";
+
+describe("Button", () => {
+  it("renders with default variant and size", () => {
+    render(<Button>Click me</Button>);
+    const btn = screen.getByRole("button", { name: "Click me" });
+    expect(btn).toBeInTheDocument();
+    expect(btn.className).toContain("h-9");
+  });
+
+  it("renders xs size variant", () => {
+    render(<Button size="xs">Tiny</Button>);
+    const btn = screen.getByRole("button", { name: "Tiny" });
+    expect(btn.className).toContain("h-6");
+    expect(btn.className).toContain("px-2");
+    expect(btn.className).toContain("text-[10px]");
+  });
+
+  it("xs size does not include default size classes", () => {
+    render(<Button size="xs">Tiny</Button>);
+    const btn = screen.getByRole("button", { name: "Tiny" });
+    expect(btn.className).not.toContain("h-9");
+    expect(btn.className).not.toContain("px-4");
+  });
+
+  it("merges className with xs size", () => {
+    render(
+      <Button size="xs" className="ml-2">
+        Tiny
+      </Button>,
+    );
+    const btn = screen.getByRole("button", { name: "Tiny" });
+    expect(btn.className).toContain("ml-2");
+    expect(btn.className).toContain("h-6");
+  });
+});

--- a/packages/web/src/__tests__/KeyHint.test.tsx
+++ b/packages/web/src/__tests__/KeyHint.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { KeyHint } from "@/components/ui/key-hint";
+
+describe("KeyHint", () => {
+  it("renders key labels", () => {
+    render(<KeyHint keys={["Cmd", "K"]} />);
+    const kbds = screen.getAllByRole("generic").filter((el) => el.tagName === "KBD");
+    expect(kbds).toHaveLength(2);
+    expect(kbds[0].textContent).toBe("Cmd");
+    expect(kbds[1].textContent).toBe("K");
+  });
+
+  it("renders + separator between keys", () => {
+    const { container } = render(<KeyHint keys={["Ctrl", "Shift", "P"]} />);
+    const separators = container.querySelectorAll("span.text-\\[10px\\]");
+    expect(separators).toHaveLength(2);
+    separators.forEach((sep) => expect(sep.textContent).toBe("+"));
+  });
+
+  it("single key works without separator", () => {
+    const { container } = render(<KeyHint keys={["Esc"]} />);
+    const kbds = container.querySelectorAll("kbd");
+    expect(kbds).toHaveLength(1);
+    expect(kbds[0].textContent).toBe("Esc");
+    const separators = container.querySelectorAll("span.text-\\[10px\\]");
+    expect(separators).toHaveLength(0);
+  });
+
+  it("merges className", () => {
+    const { container } = render(<KeyHint keys={["A"]} className="ml-2" />);
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.className).toContain("ml-2");
+    expect(wrapper.className).toContain("inline-flex");
+  });
+});

--- a/packages/web/src/__tests__/SectionHeader.test.tsx
+++ b/packages/web/src/__tests__/SectionHeader.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SectionHeader } from "@/components/ui/section-header";
+
+describe("SectionHeader", () => {
+  it("renders title text", () => {
+    render(<SectionHeader>Tasks</SectionHeader>);
+    expect(screen.getByText("Tasks")).toBeInTheDocument();
+  });
+
+  it("renders action slot", () => {
+    render(
+      <SectionHeader action={<button data-testid="action-btn">Add</button>}>Tasks</SectionHeader>,
+    );
+    expect(screen.getByTestId("action-btn")).toBeInTheDocument();
+    expect(screen.getByText("Tasks")).toBeInTheDocument();
+  });
+
+  it("action slot is right-aligned with flex justify-between", () => {
+    const { container } = render(
+      <SectionHeader action={<button>Add</button>}>Tasks</SectionHeader>,
+    );
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.className).toContain("flex");
+    expect(wrapper.className).toContain("justify-between");
+  });
+
+  it("merges className", () => {
+    const { container } = render(<SectionHeader className="mb-4">Title</SectionHeader>);
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.className).toContain("mb-4");
+    expect(el.className).toContain("uppercase");
+  });
+
+  it("renders without action", () => {
+    const { container } = render(<SectionHeader>Simple</SectionHeader>);
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.tagName).toBe("H3");
+    expect(el.className).not.toContain("justify-between");
+  });
+});

--- a/packages/web/src/components/ui/button.tsx
+++ b/packages/web/src/components/ui/button.tsx
@@ -17,6 +17,7 @@ const buttonVariants = cva(
       },
       size: {
         default: "h-9 px-4 py-2",
+        xs: "h-6 px-2 py-1 text-[10px]",
         sm: "h-8 px-3 text-xs",
         lg: "h-10 px-8",
         icon: "h-9 w-9",

--- a/packages/web/src/components/ui/key-hint.tsx
+++ b/packages/web/src/components/ui/key-hint.tsx
@@ -1,0 +1,21 @@
+import { cn } from "@/lib/utils";
+
+interface KeyHintProps {
+  keys: string[];
+  className?: string;
+}
+
+export function KeyHint({ keys, className }: KeyHintProps) {
+  return (
+    <span className={cn("inline-flex items-center gap-0.5", className)}>
+      {keys.map((key, i) => (
+        <span key={i} className="inline-flex items-center gap-0.5">
+          {i > 0 && <span className="text-[10px] text-muted-foreground">+</span>}
+          <kbd className="border border-border bg-card/80 px-1.5 py-0.5 text-[10px] font-mono text-muted-foreground rounded-none">
+            {key}
+          </kbd>
+        </span>
+      ))}
+    </span>
+  );
+}

--- a/packages/web/src/components/ui/section-header.tsx
+++ b/packages/web/src/components/ui/section-header.tsx
@@ -1,0 +1,22 @@
+import { cn } from "@/lib/utils";
+
+const headingStyles = "text-xs font-semibold uppercase tracking-wider text-muted-foreground";
+
+interface SectionHeaderProps {
+  children: React.ReactNode;
+  action?: React.ReactNode;
+  className?: string;
+}
+
+export function SectionHeader({ children, action, className }: SectionHeaderProps) {
+  if (action) {
+    return (
+      <div className={cn("flex items-center justify-between gap-2", className)}>
+        <h3 className={headingStyles}>{children}</h3>
+        {action}
+      </div>
+    );
+  }
+
+  return <h3 className={cn(headingStyles, className)}>{children}</h3>;
+}


### PR DESCRIPTION
## Summary
- Add KeyHint and SectionHeader display atoms
- Add `xs` size variant to existing Button component
- Tests for all new components and variant

## Components
- `ui/key-hint.tsx` — Keyboard shortcut display (e.g., Cmd+K)
- `ui/section-header.tsx` — Uppercase section title with action slot
- `ui/button.tsx` — New `xs` size: h-6 px-2 py-1 text-[10px]