### PR TITLE
feat(ui): add ScrollableContainer, AttachmentChip, FileInput atoms

### DIFF
--- a/packages/web/src/__tests__/AttachmentChip.test.tsx
+++ b/packages/web/src/__tests__/AttachmentChip.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { AttachmentChip } from "@/components/ui/attachment-chip";
+
+describe("AttachmentChip", () => {
+  it("renders file name", () => {
+    render(<AttachmentChip name="readme.md" />);
+    expect(screen.getByText("readme.md")).toBeDefined();
+  });
+
+  it("shows paperclip icon", () => {
+    const { container } = render(<AttachmentChip name="file.txt" />);
+    const svg = container.querySelector("svg");
+    expect(svg).toBeTruthy();
+  });
+
+  it("shows remove button when onRemove is provided", () => {
+    const onRemove = vi.fn();
+    render(<AttachmentChip name="file.txt" onRemove={onRemove} />);
+    const removeBtn = screen.getByRole("button", { name: "Remove" });
+    expect(removeBtn).toBeDefined();
+    fireEvent.click(removeBtn);
+    expect(onRemove).toHaveBeenCalledOnce();
+  });
+
+  it("hides remove button when no onRemove", () => {
+    render(<AttachmentChip name="file.txt" />);
+    expect(screen.queryByRole("button", { name: "Remove" })).toBeNull();
+  });
+
+  it("truncates long names", () => {
+    const { container } = render(
+      <AttachmentChip name="this-is-a-very-long-filename-that-should-be-truncated.tsx" />,
+    );
+    const nameSpan = container.querySelector(".truncate");
+    expect(nameSpan).toBeTruthy();
+    expect(nameSpan?.className).toContain("max-w-[150px]");
+  });
+
+  it("merges className", () => {
+    const { container } = render(<AttachmentChip name="file.txt" className="ml-2" />);
+    const chip = container.firstElementChild as HTMLElement;
+    expect(chip.className).toContain("ml-2");
+    expect(chip.className).toContain("border-border");
+  });
+});

--- a/packages/web/src/__tests__/FileInput.test.tsx
+++ b/packages/web/src/__tests__/FileInput.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { FileInput } from "@/components/ui/file-input";
+
+describe("FileInput", () => {
+  it("renders styled button with default label", () => {
+    render(<FileInput />);
+    expect(screen.getByRole("button", { name: /Choose file/i })).toBeDefined();
+  });
+
+  it("has a hidden file input", () => {
+    const { container } = render(<FileInput />);
+    const hiddenInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    expect(hiddenInput).toBeTruthy();
+    expect(hiddenInput.className).toContain("hidden");
+  });
+
+  it("accepts custom label text", () => {
+    render(<FileInput label="Upload image" />);
+    expect(screen.getByRole("button", { name: /Upload image/i })).toBeDefined();
+  });
+
+  it("forwards ref to the hidden input", () => {
+    const ref = createRef<HTMLInputElement>();
+    render(<FileInput ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLInputElement);
+    expect(ref.current?.type).toBe("file");
+  });
+
+  it("merges className onto the button", () => {
+    render(<FileInput className="mt-4" />);
+    const button = screen.getByRole("button");
+    expect(button.className).toContain("mt-4");
+    expect(button.className).toContain("border-border");
+  });
+
+  it("passes accept prop to hidden input", () => {
+    const { container } = render(<FileInput accept="image/*" />);
+    const hiddenInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    expect(hiddenInput.getAttribute("accept")).toBe("image/*");
+  });
+});

--- a/packages/web/src/__tests__/ScrollableContainer.test.tsx
+++ b/packages/web/src/__tests__/ScrollableContainer.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { ScrollableContainer } from "@/components/ui/scrollable-container";
+
+describe("ScrollableContainer", () => {
+  it("renders children", () => {
+    render(
+      <ScrollableContainer>
+        <p>Hello world</p>
+      </ScrollableContainer>,
+    );
+    expect(screen.getByText("Hello world")).toBeDefined();
+  });
+
+  it("applies overflow-y-auto by default", () => {
+    const { container } = render(
+      <ScrollableContainer>
+        <p>Content</p>
+      </ScrollableContainer>,
+    );
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.className).toContain("overflow-y-auto");
+  });
+
+  it("accepts maxHeight class", () => {
+    const { container } = render(
+      <ScrollableContainer maxHeight="max-h-96">
+        <p>Content</p>
+      </ScrollableContainer>,
+    );
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.className).toContain("max-h-96");
+  });
+
+  it("merges className", () => {
+    const { container } = render(
+      <ScrollableContainer className="bg-red-500">
+        <p>Content</p>
+      </ScrollableContainer>,
+    );
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.className).toContain("bg-red-500");
+    expect(wrapper.className).toContain("overflow-y-auto");
+  });
+
+  it("forwards ref", () => {
+    const ref = createRef<HTMLDivElement>();
+    render(
+      <ScrollableContainer ref={ref}>
+        <p>Content</p>
+      </ScrollableContainer>,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+});

--- a/packages/web/src/components/task/TaskAttachments.tsx
+++ b/packages/web/src/components/task/TaskAttachments.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { ChevronDown, ChevronRight, Download } from "lucide-react";
 import type { TaskCommentAttachment } from "@aif/shared/browser";
 import { Button } from "@/components/ui/button";
+import { FileInput } from "@/components/ui/file-input";
 
 interface TaskAttachmentsProps {
   taskId: string;
@@ -53,14 +54,13 @@ export function TaskAttachments({
           >
             Drag files here to attach
           </div>
-          <input
-            type="file"
+          <FileInput
             multiple
+            label="Attach files"
             onChange={(e) => {
               onFilesSelected(e.target.files);
               e.currentTarget.value = "";
             }}
-            className="block w-full text-xs text-muted-foreground file:mr-3 file:border file:border-border file:bg-secondary/40 file:px-3 file:py-1.5 file:text-xs"
           />
           {attachments.length === 0 ? (
             <p className="text-xs text-muted-foreground">No files attached to this task.</p>

--- a/packages/web/src/components/ui/attachment-chip.tsx
+++ b/packages/web/src/components/ui/attachment-chip.tsx
@@ -1,0 +1,34 @@
+import { Paperclip, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface AttachmentChipProps {
+  name: string;
+  onRemove?: () => void;
+  className?: string;
+}
+
+function AttachmentChip({ name, onRemove, className }: AttachmentChipProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 border border-border bg-card/80 px-2 py-1 text-xs text-foreground rounded-none",
+        className,
+      )}
+    >
+      <Paperclip className="h-3 w-3" />
+      <span className="max-w-[150px] truncate">{name}</span>
+      {onRemove && (
+        <button
+          type="button"
+          onClick={onRemove}
+          className="inline-flex items-center justify-center"
+          aria-label="Remove"
+        >
+          <X className="h-3 w-3" />
+        </button>
+      )}
+    </span>
+  );
+}
+
+export { AttachmentChip };

--- a/packages/web/src/components/ui/file-input.tsx
+++ b/packages/web/src/components/ui/file-input.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+import { Upload } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface FileInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+}
+
+const FileInput = React.forwardRef<HTMLInputElement, FileInputProps>(
+  ({ label = "Choose file", className, ...props }, ref) => {
+    const innerRef = React.useRef<HTMLInputElement | null>(null);
+
+    const assignRef = React.useCallback(
+      (node: HTMLInputElement | null) => {
+        innerRef.current = node;
+        if (typeof ref === "function") {
+          ref(node);
+        } else if (ref) {
+          (ref as React.MutableRefObject<HTMLInputElement | null>).current = node;
+        }
+      },
+      [ref],
+    );
+
+    return (
+      <>
+        <input ref={assignRef} type="file" className="hidden" {...props} />
+        <button
+          type="button"
+          className={cn(
+            "inline-flex items-center gap-1.5 border border-border bg-card px-3 py-1.5 text-xs text-foreground transition-colors hover:bg-accent cursor-pointer rounded-none",
+            className,
+          )}
+          onClick={() => innerRef.current?.click()}
+        >
+          <Upload className="h-3 w-3" />
+          {label}
+        </button>
+      </>
+    );
+  },
+);
+FileInput.displayName = "FileInput";
+
+export { FileInput };

--- a/packages/web/src/components/ui/scrollable-container.tsx
+++ b/packages/web/src/components/ui/scrollable-container.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface ScrollableContainerProps {
+  maxHeight?: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+const ScrollableContainer = React.forwardRef<HTMLDivElement, ScrollableContainerProps>(
+  ({ maxHeight, children, className }, ref) => {
+    return (
+      <div ref={ref} className={cn("overflow-y-auto", maxHeight, className)}>
+        {children}
+      </div>
+    );
+  },
+);
+ScrollableContainer.displayName = "ScrollableContainer";
+
+export { ScrollableContainer };


### PR DESCRIPTION
## Summary
- Add 3 layout/interaction atoms
- Migrate TaskAttachments to use FileInput
- Tests for all components

## Components
- `ui/scrollable-container.tsx` — Max-height overflow wrapper with forwardRef
- `ui/attachment-chip.tsx` — File badge with paperclip icon and remove button
- `ui/file-input.tsx` — Styled file input with custom trigger button