### PR TITLE
feat(ui): add Card, Collapsible, ListButton molecules

### DIFF
--- a/packages/web/src/__tests__/Card.test.tsx
+++ b/packages/web/src/__tests__/Card.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { Card } from "@/components/ui/card";
+
+describe("Card", () => {
+  it("renders children", () => {
+    render(<Card>Card content</Card>);
+    expect(screen.getByText("Card content")).toBeInTheDocument();
+  });
+
+  it("applies default variant classes", () => {
+    render(<Card data-testid="card">content</Card>);
+    const el = screen.getByTestId("card");
+    expect(el.className).toContain("border-border");
+    expect(el.className).toContain("bg-card");
+  });
+
+  it("applies muted variant classes", () => {
+    render(
+      <Card variant="muted" data-testid="card">
+        content
+      </Card>,
+    );
+    const el = screen.getByTestId("card");
+    expect(el.className).toContain("bg-card/65");
+  });
+
+  it("applies ghost variant classes", () => {
+    render(
+      <Card variant="ghost" data-testid="card">
+        content
+      </Card>,
+    );
+    const el = screen.getByTestId("card");
+    expect(el.className).toContain("border-transparent");
+    expect(el.className).toContain("bg-transparent");
+  });
+
+  it("merges custom className", () => {
+    render(
+      <Card className="custom-class" data-testid="card">
+        content
+      </Card>,
+    );
+    const el = screen.getByTestId("card");
+    expect(el.className).toContain("custom-class");
+  });
+
+  it("forwards ref", () => {
+    const ref = createRef<HTMLDivElement>();
+    render(<Card ref={ref}>content</Card>);
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+});

--- a/packages/web/src/__tests__/Collapsible.test.tsx
+++ b/packages/web/src/__tests__/Collapsible.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Collapsible } from "@/components/ui/collapsible";
+
+describe("Collapsible", () => {
+  it("renders trigger text", () => {
+    render(
+      <Collapsible open={false} onOpenChange={() => {}} trigger="Toggle">
+        <div>body</div>
+      </Collapsible>,
+    );
+    expect(screen.getByText("Toggle")).toBeInTheDocument();
+  });
+
+  it("hides children when closed", () => {
+    render(
+      <Collapsible open={false} onOpenChange={() => {}} trigger="Toggle">
+        <div>hidden content</div>
+      </Collapsible>,
+    );
+    expect(screen.queryByText("hidden content")).not.toBeInTheDocument();
+  });
+
+  it("shows children when open", () => {
+    render(
+      <Collapsible open={true} onOpenChange={() => {}} trigger="Toggle">
+        <div>visible content</div>
+      </Collapsible>,
+    );
+    expect(screen.getByText("visible content")).toBeInTheDocument();
+  });
+
+  it("renders ChevronRight icon when closed", () => {
+    const { container } = render(
+      <Collapsible open={false} onOpenChange={() => {}} trigger="Toggle">
+        <div>body</div>
+      </Collapsible>,
+    );
+    const svg = container.querySelector("svg");
+    expect(svg).toBeTruthy();
+    // ChevronRight has a specific path; ChevronDown has a different one.
+    // We check via the aria-expanded attribute on the button instead.
+    const button = screen.getByRole("button");
+    expect(button).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("renders ChevronDown icon when open", () => {
+    render(
+      <Collapsible open={true} onOpenChange={() => {}} trigger="Toggle">
+        <div>body</div>
+      </Collapsible>,
+    );
+    const button = screen.getByRole("button");
+    expect(button).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("sets aria-expanded correctly", () => {
+    const { rerender } = render(
+      <Collapsible open={false} onOpenChange={() => {}} trigger="Toggle">
+        <div>body</div>
+      </Collapsible>,
+    );
+    expect(screen.getByRole("button")).toHaveAttribute("aria-expanded", "false");
+
+    rerender(
+      <Collapsible open={true} onOpenChange={() => {}} trigger="Toggle">
+        <div>body</div>
+      </Collapsible>,
+    );
+    expect(screen.getByRole("button")).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("calls onOpenChange on click", () => {
+    const onOpenChange = vi.fn();
+    render(
+      <Collapsible open={false} onOpenChange={onOpenChange} trigger="Toggle">
+        <div>body</div>
+      </Collapsible>,
+    );
+    fireEvent.click(screen.getByRole("button"));
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+  });
+
+  it("calls onOpenChange with false when open", () => {
+    const onOpenChange = vi.fn();
+    render(
+      <Collapsible open={true} onOpenChange={onOpenChange} trigger="Toggle">
+        <div>body</div>
+      </Collapsible>,
+    );
+    fireEvent.click(screen.getByRole("button"));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/packages/web/src/__tests__/ListButton.test.tsx
+++ b/packages/web/src/__tests__/ListButton.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { createRef } from "react";
+import { ListButton } from "@/components/ui/list-button";
+
+describe("ListButton", () => {
+  it("renders children", () => {
+    render(<ListButton>Click me</ListButton>);
+    expect(screen.getByText("Click me")).toBeInTheDocument();
+  });
+
+  it("fires onClick", () => {
+    const onClick = vi.fn();
+    render(<ListButton onClick={onClick}>Click me</ListButton>);
+    fireEvent.click(screen.getByRole("button"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies active state styling", () => {
+    render(
+      <ListButton active data-testid="btn">
+        Item
+      </ListButton>,
+    );
+    const el = screen.getByTestId("btn");
+    expect(el.className).toContain("bg-accent/60");
+  });
+
+  it("does not apply active styling when inactive", () => {
+    render(<ListButton data-testid="btn">Item</ListButton>);
+    const el = screen.getByTestId("btn");
+    expect(el.className).not.toContain("bg-accent/60");
+  });
+
+  it("merges custom className", () => {
+    render(
+      <ListButton className="extra" data-testid="btn">
+        Item
+      </ListButton>,
+    );
+    const el = screen.getByTestId("btn");
+    expect(el.className).toContain("extra");
+  });
+
+  it("forwards ref", () => {
+    const ref = createRef<HTMLButtonElement>();
+    render(<ListButton ref={ref}>Item</ListButton>);
+    expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+  });
+});

--- a/packages/web/src/components/task/TaskPlan.tsx
+++ b/packages/web/src/components/task/TaskPlan.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { ChevronDown, ChevronRight } from "lucide-react";
 import { Markdown } from "@/components/ui/markdown";
+import { Collapsible } from "@/components/ui/collapsible";
 
 interface TaskPlanProps {
   plan: string | null;
@@ -14,17 +14,13 @@ export function TaskPlan({ plan }: TaskPlanProps) {
   }
 
   return (
-    <div className="space-y-3">
-      <button
-        type="button"
-        className="inline-flex items-center gap-1 border border-border bg-background/60 px-2 py-1 text-[11px] text-muted-foreground transition-colors hover:text-foreground"
-        onClick={() => setExpanded((prev) => !prev)}
-      >
-        {expanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-        {expanded ? "Hide plan" : "Show plan"}
-      </button>
-
-      {expanded && <Markdown content={plan} className="text-sm text-foreground/90" />}
-    </div>
+    <Collapsible
+      open={expanded}
+      onOpenChange={setExpanded}
+      trigger={expanded ? "Hide plan" : "Show plan"}
+      className="space-y-3"
+    >
+      <Markdown content={plan} className="text-sm text-foreground/90" />
+    </Collapsible>
   );
 }

--- a/packages/web/src/components/ui/card.tsx
+++ b/packages/web/src/components/ui/card.tsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const cardVariants = cva("border rounded-none p-3", {
+  variants: {
+    variant: {
+      default: "border-border bg-card",
+      muted: "border-border bg-card/65",
+      ghost: "border-transparent bg-transparent",
+    },
+  },
+  defaultVariants: {
+    variant: "default",
+  },
+});
+
+export interface CardProps
+  extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof cardVariants> {}
+
+const Card = React.forwardRef<HTMLDivElement, CardProps>(
+  ({ className, variant, ...props }, ref) => {
+    return <div className={cn(cardVariants({ variant, className }))} ref={ref} {...props} />;
+  },
+);
+Card.displayName = "Card";
+
+export { Card, cardVariants };

--- a/packages/web/src/components/ui/collapsible.tsx
+++ b/packages/web/src/components/ui/collapsible.tsx
@@ -1,0 +1,33 @@
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface CollapsibleProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  trigger: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function Collapsible({
+  open,
+  onOpenChange,
+  trigger,
+  children,
+  className,
+}: CollapsibleProps) {
+  return (
+    <div className={cn(className)}>
+      <button
+        type="button"
+        className="inline-flex items-center gap-1 border border-border bg-background/60 px-2 py-1 text-[11px] text-muted-foreground transition-colors hover:text-foreground rounded-none"
+        aria-expanded={open}
+        onClick={() => onOpenChange(!open)}
+      >
+        {open ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+        {trigger}
+      </button>
+      {open && children}
+    </div>
+  );
+}

--- a/packages/web/src/components/ui/list-button.tsx
+++ b/packages/web/src/components/ui/list-button.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface ListButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  active?: boolean;
+}
+
+const ListButton = React.forwardRef<HTMLButtonElement, ListButtonProps>(
+  ({ className, active, ...props }, ref) => {
+    return (
+      <button
+        className={cn(
+          "flex w-full items-center gap-2 px-2 py-1.5 text-sm text-foreground transition-colors hover:bg-accent/50 rounded-none text-left",
+          active && "bg-accent/60 text-foreground",
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+ListButton.displayName = "ListButton";
+
+export { ListButton };


### PR DESCRIPTION
## Summary
- Add 3 composition molecules
- Card with CVA variants (default/muted/ghost)
- Collapsible with chevron toggle and aria-expanded
- Migrate TaskPlan to use Collapsible

## Components
- `ui/card.tsx` — Bordered container with variant support
- `ui/collapsible.tsx` — Expand/collapse section with trigger
- `ui/list-button.tsx` — Borderless clickable list item