### PR TITLE
feat(ui): add DropdownMenu and SegmentedControl molecules

### DIFF
--- a/packages/web/src/__tests__/DropdownMenu.test.tsx
+++ b/packages/web/src/__tests__/DropdownMenu.test.tsx
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
+
+function DropdownHarness({ defaultOpen = false }: { defaultOpen?: boolean }) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  return (
+    <>
+      <div data-testid="state">{open ? "open" : "closed"}</div>
+      <DropdownMenu open={open} onOpenChange={setOpen}>
+        <DropdownMenuTrigger>
+          <span>Open menu</span>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem data-testid="item-edit">Edit</DropdownMenuItem>
+          <DropdownMenuItem data-testid="item-delete" destructive>
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </>
+  );
+}
+
+describe("DropdownMenu", () => {
+  it("renders trigger", () => {
+    render(<DropdownHarness />);
+    expect(screen.getByText("Open menu")).toBeTruthy();
+  });
+
+  it("opens on click", () => {
+    render(<DropdownHarness />);
+    expect(screen.getByTestId("state").textContent).toBe("closed");
+    fireEvent.click(screen.getByText("Open menu"));
+    expect(screen.getByTestId("state").textContent).toBe("open");
+  });
+
+  it("shows content when open", () => {
+    render(<DropdownHarness defaultOpen />);
+    expect(screen.getByTestId("item-edit")).toBeTruthy();
+    expect(screen.getByText("Edit")).toBeTruthy();
+    expect(screen.getByText("Delete")).toBeTruthy();
+  });
+
+  it("closes on ESC", () => {
+    render(<DropdownHarness defaultOpen />);
+    expect(screen.getByTestId("state").textContent).toBe("open");
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.getByTestId("state").textContent).toBe("closed");
+  });
+
+  it("closes on outside click", () => {
+    render(<DropdownHarness defaultOpen />);
+    expect(screen.getByTestId("state").textContent).toBe("open");
+    fireEvent.mouseDown(document.body);
+    expect(screen.getByTestId("state").textContent).toBe("closed");
+  });
+
+  it("closes on item click", () => {
+    render(<DropdownHarness defaultOpen />);
+    expect(screen.getByTestId("state").textContent).toBe("open");
+    fireEvent.click(screen.getByTestId("item-edit"));
+    expect(screen.getByTestId("state").textContent).toBe("closed");
+  });
+
+  it("applies destructive variant styles", () => {
+    render(<DropdownHarness defaultOpen />);
+    const deleteItem = screen.getByTestId("item-delete");
+    expect(deleteItem.className).toContain("text-destructive");
+    expect(deleteItem.className).toContain("hover:bg-destructive/10");
+  });
+
+  it("merges className on content", () => {
+    const [open, setOpen] = [true, vi.fn()];
+
+    function CustomHarness() {
+      return (
+        <DropdownMenu open={open} onOpenChange={setOpen}>
+          <DropdownMenuTrigger>Trigger</DropdownMenuTrigger>
+          <DropdownMenuContent className="custom-class">
+            <DropdownMenuItem>Item</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      );
+    }
+
+    render(<CustomHarness />);
+    const menu = screen.getByRole("menu");
+    expect(menu.className).toContain("custom-class");
+    expect(menu.className).toContain("border");
+  });
+});

--- a/packages/web/src/__tests__/SegmentedControl.test.tsx
+++ b/packages/web/src/__tests__/SegmentedControl.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { SegmentedControl } from "@/components/ui/segmented-control";
+
+const items = [
+  { value: "board", label: "Board" },
+  { value: "list", label: "List" },
+  { value: "timeline", label: "Timeline" },
+];
+
+describe("SegmentedControl", () => {
+  it("renders all items", () => {
+    render(<SegmentedControl items={items} value="board" onValueChange={vi.fn()} />);
+    expect(screen.getByText("Board")).toBeTruthy();
+    expect(screen.getByText("List")).toBeTruthy();
+    expect(screen.getByText("Timeline")).toBeTruthy();
+  });
+
+  it("highlights active item", () => {
+    render(<SegmentedControl items={items} value="list" onValueChange={vi.fn()} />);
+    const listButton = screen.getByText("List").closest("button")!;
+    const boardButton = screen.getByText("Board").closest("button")!;
+    expect(listButton.className).toContain("bg-primary/15");
+    expect(listButton.className).toContain("text-primary");
+    expect(boardButton.className).toContain("text-muted-foreground");
+  });
+
+  it("fires onValueChange on click", () => {
+    const onChange = vi.fn();
+    render(<SegmentedControl items={items} value="board" onValueChange={onChange} />);
+    fireEvent.click(screen.getByText("Timeline"));
+    expect(onChange).toHaveBeenCalledWith("timeline");
+  });
+
+  it("merges className", () => {
+    const { container } = render(
+      <SegmentedControl
+        items={items}
+        value="board"
+        onValueChange={vi.fn()}
+        className="my-custom"
+      />,
+    );
+    const root = container.firstChild as HTMLElement;
+    expect(root.className).toContain("my-custom");
+    expect(root.className).toContain("inline-flex");
+  });
+
+  it("renders icon when provided", () => {
+    const itemsWithIcon = [
+      { value: "a", label: "Alpha", icon: <span data-testid="icon-alpha">IC</span> },
+      { value: "b", label: "Beta" },
+    ];
+    render(<SegmentedControl items={itemsWithIcon} value="a" onValueChange={vi.fn()} />);
+    expect(screen.getByTestId("icon-alpha")).toBeTruthy();
+  });
+});

--- a/packages/web/src/components/ui/dropdown-menu.tsx
+++ b/packages/web/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,173 @@
+import * as React from "react";
+import { createPortal } from "react-dom";
+import { cn } from "@/lib/utils";
+import {
+  createOverlayLayerId,
+  isTopOverlayLayer,
+  pushOverlayLayer,
+} from "@/components/ui/overlayStack";
+
+interface DropdownMenuContextValue {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  triggerRef: React.RefObject<HTMLButtonElement | null>;
+}
+
+const DropdownMenuContext = React.createContext<DropdownMenuContextValue | null>(null);
+
+function useDropdownMenu() {
+  const ctx = React.useContext(DropdownMenuContext);
+  if (!ctx) throw new Error("DropdownMenu compound components must be used within <DropdownMenu>");
+  return ctx;
+}
+
+interface DropdownMenuProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: React.ReactNode;
+}
+
+function DropdownMenu({ open, onOpenChange, children }: DropdownMenuProps) {
+  const triggerRef = React.useRef<HTMLButtonElement | null>(null);
+  const overlayLayerId = React.useRef(createOverlayLayerId("dropdown-menu"));
+
+  React.useEffect(() => {
+    if (!open) return;
+    return pushOverlayLayer(overlayLayerId.current);
+  }, [open]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      if (!isTopOverlayLayer(overlayLayerId.current)) return;
+      onOpenChange(false);
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [open, onOpenChange]);
+
+  const value = React.useMemo(() => ({ open, onOpenChange, triggerRef }), [open, onOpenChange]);
+
+  return <DropdownMenuContext.Provider value={value}>{children}</DropdownMenuContext.Provider>;
+}
+
+interface DropdownMenuTriggerProps {
+  children: React.ReactNode;
+  asChild?: boolean;
+}
+
+function DropdownMenuTrigger({ children, asChild }: DropdownMenuTriggerProps) {
+  const { open, onOpenChange, triggerRef } = useDropdownMenu();
+
+  if (asChild && React.isValidElement(children)) {
+    return React.cloneElement(children as React.ReactElement<Record<string, unknown>>, {
+      ref: triggerRef,
+      onClick: () => onOpenChange(!open),
+    });
+  }
+
+  return (
+    <button ref={triggerRef} type="button" onClick={() => onOpenChange(!open)}>
+      {children}
+    </button>
+  );
+}
+
+interface DropdownMenuContentProps extends React.HTMLAttributes<HTMLDivElement> {
+  align?: "start" | "end";
+}
+
+function DropdownMenuContent({
+  align = "start",
+  className,
+  children,
+  ...props
+}: DropdownMenuContentProps) {
+  const { open, onOpenChange, triggerRef } = useDropdownMenu();
+  const contentRef = React.useRef<HTMLDivElement | null>(null);
+  const [position, setPosition] = React.useState<{ top: number; left: number }>({
+    top: 0,
+    left: 0,
+  });
+
+  React.useEffect(() => {
+    if (!open || !triggerRef.current) return;
+    const rect = triggerRef.current.getBoundingClientRect();
+    const left = align === "end" ? rect.right : rect.left;
+    setPosition({ top: rect.bottom, left });
+  }, [open, align, triggerRef]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (contentRef.current?.contains(target)) return;
+      if (triggerRef.current?.contains(target)) return;
+      onOpenChange(false);
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [open, onOpenChange, triggerRef]);
+
+  if (!open || typeof document === "undefined") return null;
+
+  const style: React.CSSProperties = {
+    position: "fixed",
+    top: position.top,
+    ...(align === "end" ? { right: window.innerWidth - position.left } : { left: position.left }),
+  };
+
+  return createPortal(
+    <div
+      ref={contentRef}
+      role="menu"
+      className={cn(
+        "border border-border bg-popover p-1 shadow-lg rounded-none z-50 min-w-[160px]",
+        className,
+      )}
+      style={style}
+      {...props}
+    >
+      {children}
+    </div>,
+    document.body,
+  );
+}
+
+interface DropdownMenuItemProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  destructive?: boolean;
+}
+
+function DropdownMenuItem({
+  destructive,
+  className,
+  onClick,
+  children,
+  ...props
+}: DropdownMenuItemProps) {
+  const { onOpenChange } = useDropdownMenu();
+
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    onClick?.(e);
+    onOpenChange(false);
+  };
+
+  return (
+    <button
+      role="menuitem"
+      type="button"
+      className={cn(
+        "flex w-full items-center gap-2 px-2 py-1.5 text-sm text-popover-foreground transition-colors hover:bg-accent/50 rounded-none cursor-pointer",
+        destructive && "text-destructive hover:bg-destructive/10",
+        className,
+      )}
+      onClick={handleClick}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+export { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem };

--- a/packages/web/src/components/ui/segmented-control.tsx
+++ b/packages/web/src/components/ui/segmented-control.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface SegmentedControlItem {
+  value: string;
+  label: string;
+  icon?: React.ReactNode;
+}
+
+interface SegmentedControlProps {
+  items: SegmentedControlItem[];
+  value: string;
+  onValueChange: (value: string) => void;
+  className?: string;
+}
+
+function SegmentedControl({ items, value, onValueChange, className }: SegmentedControlProps) {
+  return (
+    <div className={cn("inline-flex h-8 border border-border bg-card rounded-none", className)}>
+      {items.map((item, index) => (
+        <button
+          key={item.value}
+          type="button"
+          className={cn(
+            "h-full px-2 text-[10px] font-mono transition-colors",
+            index > 0 && "border-l border-border",
+            value === item.value
+              ? "bg-primary/15 text-primary"
+              : "text-muted-foreground hover:bg-accent",
+          )}
+          onClick={() => onValueChange(item.value)}
+        >
+          <span className="flex items-center gap-1">
+            {item.icon}
+            {item.label}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export { SegmentedControl };


### PR DESCRIPTION
## Summary
- Add DropdownMenu (portal-based, overlay stack) and SegmentedControl molecules
- DropdownMenu: Trigger, Content, MenuItem with destructive variant
- SegmentedControl: Connected toggle group with active state

## Components
- `ui/dropdown-menu.tsx` — Click-triggered dropdown with overlay stack
- `ui/segmented-control.tsx` — Connected toggle button group