### PR TITLE
feat(ui): add Metric, MetadataRow, ActionButtonGroup, StickyActionBar

### DIFF
--- a/packages/web/src/components/settings/ConfigEditor.tsx
+++ b/packages/web/src/components/settings/ConfigEditor.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Loader2, Save, Check, AlertTriangle, RotateCcw } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
+import { StickyActionBar } from "@/components/ui/sticky-action-bar";
 import { api, type AifConfig } from "@/lib/api";
 
 const LANGUAGE_OPTIONS = [
@@ -285,7 +286,10 @@ export function ConfigEditor({ config, onConfigChange }: Props) {
       </Field>
 
       {/* Save bar */}
-      <div className="sticky bottom-0 -mb-2 -mx-3 flex items-center justify-between border-t border-border bg-card/50 px-3 pt-3 pb-2 mt-4">
+      <StickyActionBar
+        visible={isDirty || saved || !!error}
+        className="-mb-2 -mx-3 justify-between px-3 pt-3 pb-2 mt-4"
+      >
         <div className="flex items-center gap-2">
           {saved && (
             <span className="text-xs text-green-400 flex items-center gap-1">
@@ -321,7 +325,7 @@ export function ConfigEditor({ config, onConfigChange }: Props) {
             Save
           </button>
         </div>
-      </div>
+      </StickyActionBar>
     </div>
   );
 }

--- a/packages/web/src/components/ui/action-button-group.tsx
+++ b/packages/web/src/components/ui/action-button-group.tsx
@@ -1,0 +1,10 @@
+import { cn } from "@/lib/utils";
+
+interface ActionButtonGroupProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function ActionButtonGroup({ children, className }: ActionButtonGroupProps) {
+  return <div className={cn("inline-flex items-center gap-1", className)}>{children}</div>;
+}

--- a/packages/web/src/components/ui/metadata-row.tsx
+++ b/packages/web/src/components/ui/metadata-row.tsx
@@ -1,0 +1,18 @@
+import { cn } from "@/lib/utils";
+
+interface MetadataRowProps {
+  icon?: React.ReactNode;
+  label: string;
+  value: React.ReactNode;
+  className?: string;
+}
+
+export function MetadataRow({ icon, label, value, className }: MetadataRowProps) {
+  return (
+    <div className={cn("flex items-center gap-2 text-[11px] text-muted-foreground", className)}>
+      {icon && <span className="shrink-0 h-3.5 w-3.5">{icon}</span>}
+      <span className="text-muted-foreground">{label}</span>
+      <span className="text-foreground ml-auto">{value}</span>
+    </div>
+  );
+}

--- a/packages/web/src/components/ui/metric.tsx
+++ b/packages/web/src/components/ui/metric.tsx
@@ -1,0 +1,18 @@
+import { cn } from "@/lib/utils";
+
+interface MetricProps {
+  label: string;
+  value: React.ReactNode;
+  description?: string;
+  className?: string;
+}
+
+export function Metric({ label, value, description, className }: MetricProps) {
+  return (
+    <div className={cn("border border-border bg-card/50 px-3 py-2 rounded-none", className)}>
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="text-lg font-semibold text-foreground">{value}</p>
+      {description && <p className="text-xs text-muted-foreground">{description}</p>}
+    </div>
+  );
+}

--- a/packages/web/src/components/ui/sticky-action-bar.tsx
+++ b/packages/web/src/components/ui/sticky-action-bar.tsx
@@ -1,0 +1,22 @@
+import { cn } from "@/lib/utils";
+
+interface StickyActionBarProps {
+  children: React.ReactNode;
+  visible?: boolean;
+  className?: string;
+}
+
+export function StickyActionBar({ children, visible = true, className }: StickyActionBarProps) {
+  if (!visible) return null;
+
+  return (
+    <div
+      className={cn(
+        "sticky bottom-0 flex items-center gap-2 border-t border-border bg-card/95 px-4 py-3 backdrop-blur-sm rounded-none",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add 4 display/layout molecules
- Migrate ConfigEditor to use StickyActionBar

## Components
- `ui/metric.tsx` — Stat display box (label + value + description)
- `ui/metadata-row.tsx` — Icon + label + value row
- `ui/action-button-group.tsx` — Icon button cluster wrapper
- `ui/sticky-action-bar.tsx` — Sticky bottom bar for form actions