### PR TITLE
feat(ui): add FormField, FormDialog, InlineEditor molecules

### DIFF
--- a/packages/web/src/__tests__/FormDialog.test.tsx
+++ b/packages/web/src/__tests__/FormDialog.test.tsx
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { FormDialog } from "@/components/ui/form-dialog";
+
+describe("FormDialog", () => {
+  it("renders title", () => {
+    render(
+      <FormDialog
+        open={true}
+        onOpenChange={() => {}}
+        title="Create Task"
+        actions={<button>Submit</button>}
+      >
+        <div>form content</div>
+      </FormDialog>,
+    );
+
+    expect(screen.getByText("Create Task")).toBeInTheDocument();
+  });
+
+  it("renders form content (children)", () => {
+    render(
+      <FormDialog
+        open={true}
+        onOpenChange={() => {}}
+        title="Edit Task"
+        actions={<button>Save</button>}
+      >
+        <div data-testid="form-body">fields here</div>
+      </FormDialog>,
+    );
+
+    expect(screen.getByTestId("form-body")).toBeInTheDocument();
+  });
+
+  it("renders actions footer", () => {
+    render(
+      <FormDialog
+        open={true}
+        onOpenChange={() => {}}
+        title="Confirm"
+        actions={<button data-testid="submit-btn">Submit</button>}
+      >
+        <div>content</div>
+      </FormDialog>,
+    );
+
+    expect(screen.getByTestId("submit-btn")).toBeInTheDocument();
+  });
+
+  it("shows error message when error prop is provided", () => {
+    render(
+      <FormDialog
+        open={true}
+        onOpenChange={() => {}}
+        title="Create"
+        error="Something went wrong"
+        actions={<button>OK</button>}
+      >
+        <div>content</div>
+      </FormDialog>,
+    );
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+  });
+
+  it("does not show error when no error prop", () => {
+    render(
+      <FormDialog open={true} onOpenChange={() => {}} title="Create" actions={<button>OK</button>}>
+        <div>content</div>
+      </FormDialog>,
+    );
+
+    expect(screen.queryByText("Something went wrong")).not.toBeInTheDocument();
+  });
+
+  it("delegates open/onOpenChange to Dialog", () => {
+    const onOpenChange = vi.fn();
+
+    const { rerender } = render(
+      <FormDialog
+        open={false}
+        onOpenChange={onOpenChange}
+        title="Hidden"
+        actions={<button>OK</button>}
+      >
+        <div>content</div>
+      </FormDialog>,
+    );
+
+    // When open is false, Dialog does not render content
+    expect(screen.queryByText("Hidden")).not.toBeInTheDocument();
+
+    // When open is true, Dialog renders content
+    rerender(
+      <FormDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        title="Hidden"
+        actions={<button>OK</button>}
+      >
+        <div>content</div>
+      </FormDialog>,
+    );
+
+    expect(screen.getByText("Hidden")).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/__tests__/FormField.test.tsx
+++ b/packages/web/src/__tests__/FormField.test.tsx
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { FormField } from "@/components/ui/form-field";
+
+describe("FormField", () => {
+  it("renders label text", () => {
+    render(
+      <FormField label="Email">
+        <input />
+      </FormField>,
+    );
+
+    expect(screen.getByText("Email")).toBeInTheDocument();
+  });
+
+  it("renders children (input slot)", () => {
+    render(
+      <FormField label="Name">
+        <input data-testid="name-input" />
+      </FormField>,
+    );
+
+    expect(screen.getByTestId("name-input")).toBeInTheDocument();
+  });
+
+  it("shows error message when error prop is provided", () => {
+    render(
+      <FormField label="Email" error="Email is required">
+        <input />
+      </FormField>,
+    );
+
+    expect(screen.getByText("Email is required")).toBeInTheDocument();
+  });
+
+  it("does not show error message when no error prop", () => {
+    render(
+      <FormField label="Email">
+        <input />
+      </FormField>,
+    );
+
+    expect(screen.queryByText("Email is required")).not.toBeInTheDocument();
+  });
+
+  it("shows required asterisk when required is true", () => {
+    render(
+      <FormField label="Email" required>
+        <input />
+      </FormField>,
+    );
+
+    expect(screen.getByText("*")).toBeInTheDocument();
+  });
+
+  it("does not show asterisk when not required", () => {
+    render(
+      <FormField label="Email">
+        <input />
+      </FormField>,
+    );
+
+    expect(screen.queryByText("*")).not.toBeInTheDocument();
+  });
+
+  it("htmlFor connects label to input", () => {
+    render(
+      <FormField label="Email" htmlFor="email-field">
+        <input id="email-field" />
+      </FormField>,
+    );
+
+    const label = screen.getByText("Email");
+    expect(label).toHaveAttribute("for", "email-field");
+  });
+
+  it("merges className onto wrapper", () => {
+    const { container } = render(
+      <FormField label="Email" className="custom-class">
+        <input />
+      </FormField>,
+    );
+
+    expect(container.firstChild).toHaveClass("custom-class");
+    expect(container.firstChild).toHaveClass("space-y-1.5");
+  });
+});

--- a/packages/web/src/__tests__/InlineEditor.test.tsx
+++ b/packages/web/src/__tests__/InlineEditor.test.tsx
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { InlineEditor } from "@/components/ui/inline-editor";
+
+describe("InlineEditor", () => {
+  it("starts in view mode (renderView called)", () => {
+    render(
+      <InlineEditor
+        value="hello"
+        onSave={() => {}}
+        renderView={({ value }) => <span data-testid="view">{value}</span>}
+        renderEdit={() => <input data-testid="edit" />}
+      />,
+    );
+
+    expect(screen.getByTestId("view")).toBeInTheDocument();
+    expect(screen.getByText("hello")).toBeInTheDocument();
+    expect(screen.queryByTestId("edit")).not.toBeInTheDocument();
+  });
+
+  it("clicking edit enters edit mode (renderEdit called)", () => {
+    render(
+      <InlineEditor
+        value="hello"
+        onSave={() => {}}
+        renderView={({ onEdit }) => (
+          <button data-testid="edit-btn" onClick={onEdit}>
+            Edit
+          </button>
+        )}
+        renderEdit={({ draft }) => <input data-testid="edit" defaultValue={draft} />}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("edit-btn"));
+
+    expect(screen.getByTestId("edit")).toBeInTheDocument();
+    expect(screen.queryByTestId("edit-btn")).not.toBeInTheDocument();
+  });
+
+  it("save calls onSave with draft value", () => {
+    const onSave = vi.fn();
+
+    render(
+      <InlineEditor
+        value="hello"
+        onSave={onSave}
+        renderView={({ onEdit }) => (
+          <button data-testid="edit-btn" onClick={onEdit}>
+            Edit
+          </button>
+        )}
+        renderEdit={({ draft, onChange, onSave: doSave }) => (
+          <div>
+            <input
+              data-testid="edit-input"
+              value={draft}
+              onChange={(e) => onChange(e.target.value)}
+            />
+            <button data-testid="save-btn" onClick={doSave}>
+              Save
+            </button>
+          </div>
+        )}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("edit-btn"));
+    fireEvent.change(screen.getByTestId("edit-input"), { target: { value: "world" } });
+    fireEvent.click(screen.getByTestId("save-btn"));
+
+    expect(onSave).toHaveBeenCalledWith("world");
+    // Returns to view mode after save
+    expect(screen.getByTestId("edit-btn")).toBeInTheDocument();
+  });
+
+  it("cancel resets to view mode", () => {
+    render(
+      <InlineEditor
+        value="hello"
+        onSave={() => {}}
+        renderView={({ value, onEdit }) => (
+          <button data-testid="edit-btn" onClick={onEdit}>
+            {value}
+          </button>
+        )}
+        renderEdit={({ onCancel }) => (
+          <button data-testid="cancel-btn" onClick={onCancel}>
+            Cancel
+          </button>
+        )}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("edit-btn"));
+    expect(screen.queryByTestId("edit-btn")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("cancel-btn"));
+    expect(screen.getByTestId("edit-btn")).toBeInTheDocument();
+  });
+
+  it("draft changes are tracked", () => {
+    const onSave = vi.fn();
+
+    render(
+      <InlineEditor
+        value="initial"
+        onSave={onSave}
+        renderView={({ onEdit }) => (
+          <button data-testid="edit-btn" onClick={onEdit}>
+            Edit
+          </button>
+        )}
+        renderEdit={({ draft, onChange, onSave: doSave }) => (
+          <div>
+            <input
+              data-testid="edit-input"
+              value={draft}
+              onChange={(e) => onChange(e.target.value)}
+            />
+            <button data-testid="save-btn" onClick={doSave}>
+              Save
+            </button>
+          </div>
+        )}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("edit-btn"));
+
+    // Draft starts with initial value
+    expect(screen.getByTestId("edit-input")).toHaveValue("initial");
+
+    // Update draft multiple times
+    fireEvent.change(screen.getByTestId("edit-input"), { target: { value: "step1" } });
+    expect(screen.getByTestId("edit-input")).toHaveValue("step1");
+
+    fireEvent.change(screen.getByTestId("edit-input"), { target: { value: "step2" } });
+    expect(screen.getByTestId("edit-input")).toHaveValue("step2");
+
+    fireEvent.click(screen.getByTestId("save-btn"));
+    expect(onSave).toHaveBeenCalledWith("step2");
+  });
+});

--- a/packages/web/src/components/task/TaskDescription.tsx
+++ b/packages/web/src/components/task/TaskDescription.tsx
@@ -1,8 +1,8 @@
-import { useState } from "react";
 import { Pencil, Check, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Markdown } from "@/components/ui/markdown";
 import { Textarea } from "@/components/ui/textarea";
+import { InlineEditor } from "@/components/ui/inline-editor";
 
 interface TaskDescriptionProps {
   description: string;
@@ -10,84 +10,72 @@ interface TaskDescriptionProps {
 }
 
 export function TaskDescription({ description, onSave }: TaskDescriptionProps) {
-  const [isEditing, setIsEditing] = useState(false);
-  const [draft, setDraft] = useState(description);
   const markdownClassName = "text-sm text-foreground/85";
 
-  const handleSave = () => {
-    onSave(draft);
-    setIsEditing(false);
-  };
-
-  if (isEditing) {
-    return (
-      <div className="space-y-2">
-        <div className="grid gap-3 md:grid-cols-2">
-          <div className="space-y-1">
-            <p className="text-[11px] uppercase tracking-wider text-muted-foreground">Editor</p>
-            <Textarea
-              value={draft}
-              onChange={(e) => setDraft(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-                  e.preventDefault();
-                  handleSave();
-                }
-              }}
-              rows={10}
-              autoFocus
-            />
-          </div>
-          <div className="space-y-1">
-            <p className="text-[11px] uppercase tracking-wider text-muted-foreground">Preview</p>
-            <div className="min-h-[13rem] border border-border bg-secondary/25 p-2">
-              {draft.trim().length > 0 ? (
-                <Markdown content={draft} className={markdownClassName} />
-              ) : (
-                <span className="text-xs italic text-muted-foreground">Preview will appear here</span>
-              )}
-            </div>
-          </div>
-        </div>
-        <div className="flex gap-2">
-          <Button size="sm" onClick={handleSave}>
-            <Check className="h-3 w-3 mr-1" /> Save
-          </Button>
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={() => {
-              setDraft(description);
-              setIsEditing(false);
-            }}
-          >
-            <X className="h-3 w-3 mr-1" /> Cancel
-          </Button>
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <div className="group relative">
-      {description ? (
-        <Markdown content={description} className={markdownClassName} />
-      ) : (
-        <div className={markdownClassName}>
-          <span className="text-muted-foreground italic">No description</span>
+    <InlineEditor
+      value={description}
+      onSave={onSave}
+      renderView={({ value, onEdit }) => (
+        <div className="group relative">
+          {value ? (
+            <Markdown content={value} className={markdownClassName} />
+          ) : (
+            <div className={markdownClassName}>
+              <span className="text-muted-foreground italic">No description</span>
+            </div>
+          )}
+          <Button
+            size="icon"
+            variant="ghost"
+            className="absolute right-0 top-0 h-6 w-6 border border-border bg-background opacity-0 transition-opacity group-hover:opacity-100"
+            onClick={onEdit}
+          >
+            <Pencil className="h-3 w-3" />
+          </Button>
         </div>
       )}
-      <Button
-        size="icon"
-        variant="ghost"
-        className="absolute right-0 top-0 h-6 w-6 border border-border bg-background opacity-0 transition-opacity group-hover:opacity-100"
-        onClick={() => {
-          setDraft(description);
-          setIsEditing(true);
-        }}
-      >
-        <Pencil className="h-3 w-3" />
-      </Button>
-    </div>
+      renderEdit={({ draft, onChange, onSave: doSave, onCancel }) => (
+        <div className="space-y-2">
+          <div className="grid gap-3 md:grid-cols-2">
+            <div className="space-y-1">
+              <p className="text-[11px] uppercase tracking-wider text-muted-foreground">Editor</p>
+              <Textarea
+                value={draft}
+                onChange={(e) => onChange(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                    e.preventDefault();
+                    doSave();
+                  }
+                }}
+                rows={10}
+                autoFocus
+              />
+            </div>
+            <div className="space-y-1">
+              <p className="text-[11px] uppercase tracking-wider text-muted-foreground">Preview</p>
+              <div className="min-h-[13rem] border border-border bg-secondary/25 p-2">
+                {draft.trim().length > 0 ? (
+                  <Markdown content={draft} className={markdownClassName} />
+                ) : (
+                  <span className="text-xs italic text-muted-foreground">
+                    Preview will appear here
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <Button size="sm" onClick={doSave}>
+              <Check className="h-3 w-3 mr-1" /> Save
+            </Button>
+            <Button size="sm" variant="ghost" onClick={onCancel}>
+              <X className="h-3 w-3 mr-1" /> Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+    />
   );
 }

--- a/packages/web/src/components/ui/form-dialog.tsx
+++ b/packages/web/src/components/ui/form-dialog.tsx
@@ -1,0 +1,38 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+
+interface FormDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  error?: string;
+  children: React.ReactNode;
+  actions: React.ReactNode;
+  className?: string;
+}
+
+function FormDialog({
+  open,
+  onOpenChange,
+  title,
+  error,
+  children,
+  actions,
+  className,
+}: FormDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className={cn(className)}>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        {children}
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        <div className="flex justify-end gap-2">{actions}</div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export { FormDialog };

--- a/packages/web/src/components/ui/form-field.tsx
+++ b/packages/web/src/components/ui/form-field.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface FormFieldProps {
+  label: string;
+  error?: string;
+  required?: boolean;
+  htmlFor?: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+function FormField({ label, error, required, htmlFor, children, className }: FormFieldProps) {
+  return (
+    <div className={cn("space-y-1.5", className)}>
+      <label htmlFor={htmlFor} className="text-xs font-medium text-foreground tracking-wide">
+        {label}
+        {required && <span className="text-destructive"> *</span>}
+      </label>
+      {children}
+      {error && <p className="mt-1 text-xs text-destructive">{error}</p>}
+    </div>
+  );
+}
+
+export { FormField };

--- a/packages/web/src/components/ui/inline-editor.tsx
+++ b/packages/web/src/components/ui/inline-editor.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+
+interface InlineEditorProps {
+  value: string;
+  onSave: (value: string) => void;
+  renderView: (props: { value: string; onEdit: () => void }) => React.ReactNode;
+  renderEdit: (props: {
+    draft: string;
+    onChange: (v: string) => void;
+    onSave: () => void;
+    onCancel: () => void;
+  }) => React.ReactNode;
+  className?: string;
+}
+
+function InlineEditor({ value, onSave, renderView, renderEdit, className }: InlineEditorProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState(value);
+
+  const handleSave = () => {
+    onSave(draft);
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setDraft(value);
+    setIsEditing(false);
+  };
+
+  const handleEdit = () => {
+    setDraft(value);
+    setIsEditing(true);
+  };
+
+  return (
+    <div className={cn(className)}>
+      {isEditing
+        ? renderEdit({
+            draft,
+            onChange: setDraft,
+            onSave: handleSave,
+            onCancel: handleCancel,
+          })
+        : renderView({ value, onEdit: handleEdit })}
+    </div>
+  );
+}
+
+export { InlineEditor };


### PR DESCRIPTION
## Summary
- Add 3 form composition molecules
- FormField: Label + input slot + error message
- FormDialog: Dialog wrapper with form layout
- Migrate TaskDescription to use InlineEditor

## Components
- `ui/form-field.tsx` — Label + input + error composition
- `ui/form-dialog.tsx` — Dialog wrapper for forms
- `ui/inline-editor.tsx` — View/edit mode switch with save/cancel