### PR TITLE
feat(hooks): add useDensityClasses, useTaskFiltering, useFormState and formatFileSize

### DIFF
--- a/packages/web/src/hooks/useDensityClasses.ts
+++ b/packages/web/src/hooks/useDensityClasses.ts
@@ -1,0 +1,30 @@
+import { useMemo } from "react";
+
+export type Density = "compact" | "comfortable";
+
+export interface DensityClasses {
+  isCompact: boolean;
+  px: string;
+  py: string;
+  gap: string;
+  text: string;
+  textSm: string;
+  space: string;
+  width: string;
+}
+
+export function useDensityClasses(density: Density): DensityClasses {
+  return useMemo(
+    () => ({
+      isCompact: density === "compact",
+      px: density === "compact" ? "px-2" : "px-3",
+      py: density === "compact" ? "py-1.5" : "py-2",
+      gap: density === "compact" ? "gap-2" : "gap-3",
+      text: density === "compact" ? "text-[10px]" : "text-[11px]",
+      textSm: density === "compact" ? "text-[9px]" : "text-[10px]",
+      space: density === "compact" ? "space-y-2" : "space-y-3",
+      width: density === "compact" ? "w-72" : "w-80",
+    }),
+    [density],
+  );
+}

--- a/packages/web/src/hooks/useFormState.ts
+++ b/packages/web/src/hooks/useFormState.ts
@@ -1,0 +1,37 @@
+import { useState, useCallback, useMemo } from "react";
+
+export interface UseFormStateResult<T extends Record<string, unknown>> {
+  values: T;
+  setValue: <K extends keyof T>(key: K, value: T[K]) => void;
+  setValues: (partial: Partial<T>) => void;
+  isDirty: boolean;
+  reset: () => void;
+  getValues: () => T;
+}
+
+export function useFormState<T extends Record<string, unknown>>(
+  initialValues: T,
+): UseFormStateResult<T> {
+  const [values, setValuesState] = useState<T>(initialValues);
+
+  const isDirty = useMemo(() => {
+    const keys = Object.keys(initialValues) as (keyof T)[];
+    return keys.some((key) => values[key] !== initialValues[key]);
+  }, [values, initialValues]);
+
+  const setValue = useCallback(<K extends keyof T>(key: K, value: T[K]) => {
+    setValuesState((prev) => ({ ...prev, [key]: value }));
+  }, []);
+
+  const setValues = useCallback((partial: Partial<T>) => {
+    setValuesState((prev) => ({ ...prev, ...partial }));
+  }, []);
+
+  const reset = useCallback(() => {
+    setValuesState(initialValues);
+  }, [initialValues]);
+
+  const getValues = useCallback(() => values, [values]);
+
+  return { values, setValue, setValues, isDirty, reset, getValues };
+}

--- a/packages/web/src/hooks/useTaskFiltering.ts
+++ b/packages/web/src/hooks/useTaskFiltering.ts
@@ -1,0 +1,99 @@
+import { useMemo, useState, useCallback } from "react";
+import type { Task } from "@aif/shared/browser";
+
+export type SortField = "updatedAt" | "priority" | "position" | "title";
+export type SortDirection = "asc" | "desc";
+
+export interface UseTaskFilteringOptions {
+  defaultSort?: SortField;
+  defaultDirection?: SortDirection;
+}
+
+export interface UseTaskFilteringResult {
+  filteredTasks: Task[];
+  searchQuery: string;
+  setSearchQuery: (query: string) => void;
+  sortField: SortField;
+  setSortField: (field: SortField) => void;
+  sortDirection: SortDirection;
+  setSortDirection: (direction: SortDirection) => void;
+  activeFilters: string[];
+  toggleFilter: (tag: string) => void;
+  clearFilters: () => void;
+}
+
+export function useTaskFiltering(
+  tasks: Task[],
+  options?: UseTaskFilteringOptions,
+): UseTaskFilteringResult {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [sortField, setSortField] = useState<SortField>(options?.defaultSort ?? "updatedAt");
+  const [sortDirection, setSortDirection] = useState<SortDirection>(
+    options?.defaultDirection ?? "desc",
+  );
+  const [activeFilters, setActiveFilters] = useState<string[]>([]);
+
+  const toggleFilter = useCallback((tag: string) => {
+    setActiveFilters((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag],
+    );
+  }, []);
+
+  const clearFilters = useCallback(() => {
+    setActiveFilters([]);
+  }, []);
+
+  const filteredTasks = useMemo(() => {
+    let result = tasks;
+
+    // Filter by search query (title, description)
+    const query = searchQuery.trim().toLowerCase();
+    if (query) {
+      result = result.filter(
+        (task) =>
+          task.title.toLowerCase().includes(query) ||
+          (task.description ?? "").toLowerCase().includes(query),
+      );
+    }
+
+    // Filter by active tag filters
+    if (activeFilters.length > 0) {
+      result = result.filter((task) => activeFilters.every((tag) => task.tags?.includes(tag)));
+    }
+
+    // Sort
+    const sorted = [...result].sort((a, b) => {
+      let cmp = 0;
+      switch (sortField) {
+        case "updatedAt":
+          cmp = new Date(a.updatedAt).getTime() - new Date(b.updatedAt).getTime();
+          break;
+        case "priority":
+          cmp = a.priority - b.priority;
+          break;
+        case "position":
+          cmp = a.position - b.position;
+          break;
+        case "title":
+          cmp = a.title.localeCompare(b.title);
+          break;
+      }
+      return sortDirection === "desc" ? -cmp : cmp;
+    });
+
+    return sorted;
+  }, [tasks, searchQuery, activeFilters, sortField, sortDirection]);
+
+  return {
+    filteredTasks,
+    searchQuery,
+    setSearchQuery,
+    sortField,
+    setSortField,
+    sortDirection,
+    setSortDirection,
+    activeFilters,
+    toggleFilter,
+    clearFilters,
+  };
+}

--- a/packages/web/src/lib/formatFileSize.ts
+++ b/packages/web/src/lib/formatFileSize.ts
@@ -1,0 +1,7 @@
+export function formatFileSize(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const k = 1024;
+  const sizes = ["B", "KB", "MB", "GB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(1))} ${sizes[i]}`;
+}


### PR DESCRIPTION
## Summary
- Add 3 custom hooks and 1 utility function
- useDensityClasses: Density-aware Tailwind class mapping
- useTaskFiltering: Filter/sort/search logic extraction
- useFormState: Multi-field form state with dirty tracking

## Files
- `hooks/useDensityClasses.ts` — Compact/comfortable class mapping
- `hooks/useTaskFiltering.ts` — Task filter/sort/search hook
- `hooks/useFormState.ts` — Form state management with reset
- `lib/formatFileSize.ts` — Byte formatter (B/KB/MB/GB)