### PR TITLE
fix(runtime): escape Windows codex MCP paths

### DIFF
--- a/packages/runtime/src/__tests__/codexMcp.test.ts
+++ b/packages/runtime/src/__tests__/codexMcp.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const readFileMock = vi.fn();
+const writeFileMock = vi.fn();
+const mkdirMock = vi.fn();
+const existsSyncMock = vi.fn();
+const homedirMock = vi.fn(() => "C:\\Users\\Daniil");
+
+vi.mock("node:fs/promises", () => ({
+  readFile: (...args: unknown[]) => readFileMock(...args),
+  writeFile: (...args: unknown[]) => writeFileMock(...args),
+  mkdir: (...args: unknown[]) => mkdirMock(...args),
+}));
+
+vi.mock("node:fs", () => ({
+  existsSync: (...args: unknown[]) => existsSyncMock(...args),
+}));
+
+vi.mock("node:os", () => ({
+  homedir: () => homedirMock(),
+}));
+
+const { getCodexMcpStatus, installCodexMcpServer } = await import("../adapters/codex/mcp.js");
+
+describe("Codex MCP config", () => {
+  beforeEach(() => {
+    readFileMock.mockReset();
+    writeFileMock.mockReset();
+    mkdirMock.mockReset();
+    existsSyncMock.mockReset();
+    readFileMock.mockRejectedValue(new Error("missing"));
+    writeFileMock.mockResolvedValue(undefined);
+    mkdirMock.mockResolvedValue(undefined);
+    existsSyncMock.mockReturnValue(true);
+  });
+
+  it("escapes Windows paths in args when writing TOML", async () => {
+    await installCodexMcpServer({
+      serverName: "handoff",
+      command: "npx",
+      args: [
+        "tsx",
+        "E:\\Users\\Daniil\\PhpstormProjects\\aif-handoff\\packages\\mcp\\src\\index.ts",
+      ],
+    });
+
+    expect(writeFileMock).toHaveBeenCalledTimes(1);
+    const [, content] = writeFileMock.mock.calls[0] as [string, string];
+    expect(content).toContain(
+      'args = [ "tsx", "E:\\\\Users\\\\Daniil\\\\PhpstormProjects\\\\aif-handoff\\\\packages\\\\mcp\\\\src\\\\index.ts" ]',
+    );
+  });
+
+  it("reads escaped Windows paths back from TOML", async () => {
+    readFileMock.mockResolvedValue(`[mcp_servers.handoff]
+command = "npx"
+args = [ "tsx", "E:\\\\Users\\\\Daniil\\\\PhpstormProjects\\\\aif-handoff\\\\packages\\\\mcp\\\\src\\\\index.ts" ]
+`);
+
+    const status = await getCodexMcpStatus({ serverName: "handoff" });
+
+    expect(status.installed).toBe(true);
+    expect(status.config).toEqual({
+      command: "npx",
+      args: [
+        "tsx",
+        "E:\\Users\\Daniil\\PhpstormProjects\\aif-handoff\\packages\\mcp\\src\\index.ts",
+      ],
+    });
+  });
+});

--- a/packages/runtime/src/adapters/codex/mcp.ts
+++ b/packages/runtime/src/adapters/codex/mcp.ts
@@ -12,6 +12,18 @@ const CODEX_CONFIG_PATH = join(homedir(), ".codex", "config.toml");
  * Does not depend on a full TOML library.
  */
 
+function parseTomlString(rawValue: string): string {
+  try {
+    return JSON.parse(rawValue);
+  } catch {
+    return rawValue.replace(/^"(.*)"$/, "$1");
+  }
+}
+
+function serializeTomlString(value: string): string {
+  return JSON.stringify(value);
+}
+
 function parseMcpServers(toml: string): Record<string, { command: string; args: string[] }> {
   const servers: Record<string, { command: string; args: string[] }> = {};
   const sectionRegex = /^\[mcp_servers\.([^\]]+)\]\s*$/;
@@ -36,7 +48,7 @@ function parseMcpServers(toml: string): Record<string, { command: string; args: 
     if (!kvMatch) continue;
     const [, key, rawValue] = kvMatch;
     if (key === "command") {
-      currentCommand = rawValue.replace(/^"(.*)"$/, "$1");
+      currentCommand = parseTomlString(rawValue);
     } else if (key === "args") {
       try {
         currentArgs = JSON.parse(rawValue.replace(/'/g, '"'));
@@ -53,9 +65,9 @@ function parseMcpServers(toml: string): Record<string, { command: string; args: 
 
 function serializeMcpSection(name: string, entry: { command: string; args?: string[] }): string {
   const lines = [`[mcp_servers.${name}]`];
-  lines.push(`command = "${entry.command}"`);
+  lines.push(`command = ${serializeTomlString(entry.command)}`);
   if (entry.args && entry.args.length > 0) {
-    const argsStr = entry.args.map((a) => `"${a}"`).join(", ");
+    const argsStr = entry.args.map((a) => serializeTomlString(a)).join(", ");
     lines.push(`args = [ ${argsStr} ]`);
   }
   return lines.join("\n");


### PR DESCRIPTION
## Summary

- При установке mcp на windows возникала ошибка с обратным слешем

## Changes

Describe what was changed and why.

## AI Model

Which AI model was used to generate or assist with this code?

- [ ] Claude Opus 4.6
- [ ] Claude Sonnet 4.6
- [ ] Claude Haiku 4.5
- [x] Other: gpt-5.4
- [ ] No AI used

## Test Plan

- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable)
- [x] Manually verified the change works as expected
