### PR TITLE
feat(shared): support configurable Telegram Bot API URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -136,5 +136,6 @@ LOG_LEVEL=debug
 # Telegram Notifications (optional)
 # ----------------------------------------------------------
 # Best-effort messages on task status changes. If not set, disabled silently.
+# TELEGRAM_BOT_API_URL=https://api.telegram.org
 # TELEGRAM_BOT_TOKEN=123456:ABC-DEF...
 # TELEGRAM_USER_ID=987654321

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -260,11 +260,11 @@ TELEGRAM_BOT_TOKEN=123456:ABC-DEF...
 TELEGRAM_USER_ID=987654321
 ```
 
-| Variable               | Type   | Default                    | Description                                                             |
-| ---------------------- | ------ | -------------------------- | ----------------------------------------------------------------------- |
-| `TELEGRAM_BOT_API_URL` | string | `https://api.telegram.org` | Telegram Bot API base URL or proxy, for example `https://mytgserver.ru` |
-| `TELEGRAM_BOT_TOKEN`   | string | _(optional)_               | Bot token from [@BotFather](https://t.me/BotFather)                     |
-| `TELEGRAM_USER_ID`     | string | _(optional)_               | Your Telegram user ID (the bot sends direct messages to this user)      |
+| Variable               | Type   | Default                    | Description                                                        |
+| ---------------------- | ------ | -------------------------- | ------------------------------------------------------------------ |
+| `TELEGRAM_BOT_API_URL` | string | `https://api.telegram.org` | Telegram Bot API base URL or custom proxy endpoint                 |
+| `TELEGRAM_BOT_TOKEN`   | string | _(optional)_               | Bot token from [@BotFather](https://t.me/BotFather)                |
+| `TELEGRAM_USER_ID`     | string | _(optional)_               | Your Telegram user ID (the bot sends direct messages to this user) |
 
 When both variables are set, every `task:moved` event sends a short message with the task title and status transition. If delivery fails (network error, invalid token, etc.), nothing breaks — failures are logged at `debug` level and silently ignored.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,6 +49,7 @@ Node packages (`@aif/api`, `@aif/agent`, `@aif/data`, `@aif/shared`) auto-load e
 | `COORDINATOR_MAX_CONCURRENT_TASKS` | number  | `3`                            | Max concurrent tasks per stage for parallel-enabled projects. Non-parallel projects always process 1 task at a time regardless of this value. Range 1–10                                                                                                                |
 | `AGENT_BYPASS_PERMISSIONS`         | boolean | `true`                         | Bypass all Claude permission checks for subagents. When `false`, configure permissions via `.claude/settings.json` allow rules                                                                                                                                          |
 | `AGENT_USE_SUBAGENTS`              | boolean | `true`                         | Default for the per-task "Use subagents" setting. Each task can override this in Planner settings. `true`: custom agents (`plan-coordinator`, `implement-coordinator`, sidecars). `false`: `aif-plan`, `aif-implement`, `aif-review`, `aif-security-checklist` directly |
+| `TELEGRAM_BOT_API_URL`             | string  | `https://api.telegram.org`     | Optional Telegram Bot API base URL or proxy endpoint                                                                                                                                                                                                                    |
 | `TELEGRAM_BOT_TOKEN`               | string  | _(optional)_                   | Telegram bot token for task status notifications (see [Telegram Notifications](#telegram-notifications))                                                                                                                                                                |
 | `TELEGRAM_USER_ID`                 | string  | _(optional)_                   | Telegram user ID to receive notifications                                                                                                                                                                                                                               |
 
@@ -254,14 +255,16 @@ If any of these values are not set, that agent runs without SDK budget limit.
 Best-effort Telegram messages on task status changes. Add to `.env`:
 
 ```
+TELEGRAM_BOT_API_URL=https://api.telegram.org
 TELEGRAM_BOT_TOKEN=123456:ABC-DEF...
 TELEGRAM_USER_ID=987654321
 ```
 
-| Variable             | Type   | Default      | Description                                                        |
-| -------------------- | ------ | ------------ | ------------------------------------------------------------------ |
-| `TELEGRAM_BOT_TOKEN` | string | _(optional)_ | Bot token from [@BotFather](https://t.me/BotFather)                |
-| `TELEGRAM_USER_ID`   | string | _(optional)_ | Your Telegram user ID (the bot sends direct messages to this user) |
+| Variable               | Type   | Default                    | Description                                                             |
+| ---------------------- | ------ | -------------------------- | ----------------------------------------------------------------------- |
+| `TELEGRAM_BOT_API_URL` | string | `https://api.telegram.org` | Telegram Bot API base URL or proxy, for example `https://mytgserver.ru` |
+| `TELEGRAM_BOT_TOKEN`   | string | _(optional)_               | Bot token from [@BotFather](https://t.me/BotFather)                     |
+| `TELEGRAM_USER_ID`     | string | _(optional)_               | Your Telegram user ID (the bot sends direct messages to this user)      |
 
 When both variables are set, every `task:moved` event sends a short message with the task title and status transition. If delivery fails (network error, invalid token, etc.), nothing breaks — failures are logged at `debug` level and silently ignored.
 

--- a/packages/shared/src/__tests__/env.test.ts
+++ b/packages/shared/src/__tests__/env.test.ts
@@ -47,6 +47,7 @@ describe("env validation", () => {
     expect(result.OPENAI_MODEL).toBeUndefined();
     expect(result.CODEX_CLI_PATH).toBeUndefined();
     expect(result.AIF_RUNTIME_MODULES).toEqual([]);
+    expect(result.TELEGRAM_BOT_API_URL).toBeUndefined();
     expect(result.AGENT_QUERY_AUDIT_ENABLED).toBe(true);
     expect(result.LOG_LEVEL).toBe("debug");
     expect(result.ACTIVITY_LOG_MODE).toBe("sync");

--- a/packages/shared/src/__tests__/telegram.test.ts
+++ b/packages/shared/src/__tests__/telegram.test.ts
@@ -15,6 +15,7 @@ describe("sendTelegramNotification", () => {
   });
 
   it("uses the default Telegram API URL", async () => {
+    delete process.env.TELEGRAM_BOT_API_URL;
     vi.stubEnv("TELEGRAM_BOT_TOKEN", "123:ABC");
     vi.stubEnv("TELEGRAM_USER_ID", "999");
 
@@ -38,7 +39,7 @@ describe("sendTelegramNotification", () => {
   });
 
   it("uses TELEGRAM_BOT_API_URL when configured", async () => {
-    vi.stubEnv("TELEGRAM_BOT_API_URL", "https://telega.ie0.ru/");
+    vi.stubEnv("TELEGRAM_BOT_API_URL", "https://telegram-proxy.invalid/");
     vi.stubEnv("TELEGRAM_BOT_TOKEN", "123:ABC");
     vi.stubEnv("TELEGRAM_USER_ID", "999");
 
@@ -52,7 +53,7 @@ describe("sendTelegramNotification", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://api.telegram.org/bot123:ABC/sendMessage",
+      "https://telegram-proxy.invalid/bot123:ABC/sendMessage",
       expect.objectContaining({
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/packages/shared/src/__tests__/telegram.test.ts
+++ b/packages/shared/src/__tests__/telegram.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sendTelegramNotification } from "../telegram.js";
+
+describe("sendTelegramNotification", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.unstubAllEnvs();
+  });
+
+  it("uses the default Telegram API URL", async () => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "123:ABC");
+    vi.stubEnv("TELEGRAM_USER_ID", "999");
+
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    global.fetch = fetchMock as typeof fetch;
+
+    await sendTelegramNotification({
+      taskId: "task-default",
+      title: "Default URL",
+      fromStatus: "planning",
+      toStatus: "plan_ready",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.telegram.org/bot123:ABC/sendMessage",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  });
+
+  it("uses TELEGRAM_BOT_API_URL when configured", async () => {
+    vi.stubEnv("TELEGRAM_BOT_API_URL", "https://telega.ie0.ru/");
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "123:ABC");
+    vi.stubEnv("TELEGRAM_USER_ID", "999");
+
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    global.fetch = fetchMock as typeof fetch;
+
+    await sendTelegramNotification({
+      taskId: "task-custom",
+      title: "Custom URL",
+      toStatus: "done",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.telegram.org/bot123:ABC/sendMessage",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  });
+});

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -107,6 +107,7 @@ const envSchema = z.object({
       return value;
     }, z.boolean())
     .default(true),
+  TELEGRAM_BOT_API_URL: z.string().optional(),
   TELEGRAM_BOT_TOKEN: z.string().optional(),
   TELEGRAM_USER_ID: z.string().optional(),
 });

--- a/packages/shared/src/telegram.ts
+++ b/packages/shared/src/telegram.ts
@@ -29,6 +29,9 @@ export async function sendTelegramNotification(
 ): Promise<void> {
   const botToken = process.env.TELEGRAM_BOT_TOKEN;
   const userId = process.env.TELEGRAM_USER_ID;
+  const apiBaseUrl = (process.env.TELEGRAM_BOT_API_URL ?? "https://api.telegram.org")
+    .trim()
+    .replace(/\/+$/, "");
   if (!botToken || !userId) return;
 
   const displayTitle = options.title ?? options.taskId.slice(0, 8);
@@ -40,7 +43,7 @@ export async function sendTelegramNotification(
   const text = `📋 *${escapeMarkdown(displayTitle)}*\n${escapeMarkdown(transition)}`;
 
   try {
-    const res = await fetch(`https://api.telegram.org/bot${botToken}/sendMessage`, {
+    const res = await fetch(`${apiBaseUrl}/bot${botToken}/sendMessage`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ chat_id: userId, text, parse_mode: "MarkdownV2" }),


### PR DESCRIPTION
This PR adds support for a configurable Telegram Bot API base URL via `TELEGRAM_BOT_API_URL`.

Changes:
- use `TELEGRAM_BOT_API_URL` in the shared Telegram notification helper
- keep `https://api.telegram.org` as the default value
- add tests for both default and custom Telegram API URLs
- document the new env variable in `.env.example` and `docs/configuration.md`

This makes Telegram notifications work in environments where direct access to `api.telegram.org` is blocked and a proxy endpoint such as `https://telega.ie0.ru` is required.

Validation:
- `npm run lint`
- `npm run build`
- `npm --workspace @aif/shared test`