### PR TITLE
fix(runtime): send codex cli prompt via stdin

### DIFF
--- a/packages/runtime/src/__tests__/codexCli.test.ts
+++ b/packages/runtime/src/__tests__/codexCli.test.ts
@@ -63,7 +63,7 @@ describe("codex cli transport", () => {
     vi.unstubAllEnvs();
   });
 
-  it("runs codex cli with default args and passes prompt as positional arg", async () => {
+  it("runs codex cli with default args and passes prompt via stdin", async () => {
     const child = createMockChildProcess();
     spawnMock.mockReturnValueOnce(child);
 
@@ -72,8 +72,8 @@ describe("codex cli transport", () => {
     expect(spawnMock).toHaveBeenCalledTimes(1);
     const { cliPath, cliArgs: args } = getSpawnInvocation();
     expect(cliPath).toBe("codex");
-    expect(args).toEqual(["exec", "--json", "--model", "gpt-5.4", "Implement feature"]);
-    expect(child.stdin.write).not.toHaveBeenCalled();
+    expect(args).toEqual(["exec", "--json", "--model", "gpt-5.4"]);
+    expect(child.stdin.write).toHaveBeenCalledWith("Implement feature");
 
     child.stdout.emit("data", "plain output");
     child.emit("close", 0);
@@ -91,15 +91,8 @@ describe("codex cli transport", () => {
     const runPromise = runCodexCli(createRunInput({ resume: true, sessionId: "thread-abc" }));
 
     const { cliArgs: args } = getSpawnInvocation();
-    expect(args).toEqual([
-      "exec",
-      "resume",
-      "thread-abc",
-      "--json",
-      "--model",
-      "gpt-5.4",
-      "Implement feature",
-    ]);
+    expect(args).toEqual(["exec", "resume", "thread-abc", "--json", "--model", "gpt-5.4"]);
+    expect(child.stdin.write).toHaveBeenCalledWith("Implement feature");
 
     child.stdout.emit("data", "resumed output");
     child.emit("close", 0);

--- a/packages/runtime/src/adapters/codex/cli.ts
+++ b/packages/runtime/src/adapters/codex/cli.ts
@@ -58,9 +58,6 @@ function normalizeCliArgs(input: RuntimeRunInput): string[] {
   if (input.model) {
     args.push("--model", input.model);
   }
-  if (input.prompt) {
-    args.push(input.prompt);
-  }
   return args;
 }
 


### PR DESCRIPTION
## Summary

- в Windows-ветке Codex CLI промпт передаётся прямо в командную строку cmd.exe, а для длинных задач это упирается в лимит длины строк. Обычный prompt уже и так уходит по умолчанию в stdin.

## Changes

Describe what was changed and why.

## AI Model

Which AI model was used to generate or assist with this code?

- [ ] Claude Opus 4.6
- [ ] Claude Sonnet 4.6
- [ ] Claude Haiku 4.5
- [x] Other: gpt-5.4
- [ ] No AI used

## Test Plan

- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable)
- [x] Manually verified the change works as expected
