### PR TITLE
fix: improve api runtime timeouts and codex summaries

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,6 +38,8 @@ Node packages (`@aif/api`, `@aif/agent`, `@aif/data`, `@aif/shared`) auto-load e
 | `AGENT_STAGE_RUN_TIMEOUT_MS`       | number  | `3600000`                      | Per-stage hard timeout (planner/plan-checker/implementer/reviewer) before the coordinator treats it as failed                                                                                                                                                           |
 | `AGENT_QUERY_START_TIMEOUT_MS`     | number  | `60000`                        | Timeout waiting for the first message from Claude query stream before treating startup as hung                                                                                                                                                                          |
 | `AGENT_QUERY_START_RETRY_DELAY_MS` | number  | `1000`                         | Delay before one automatic retry after `query_start_timeout`                                                                                                                                                                                                            |
+| `API_RUNTIME_START_TIMEOUT_MS`     | number  | `60000`                        | Timeout waiting for first output from API-triggered one-shot runtime calls (`0` disables)                                                                                                                                                                               |
+| `API_RUNTIME_RUN_TIMEOUT_MS`       | number  | `120000`                       | Hard timeout for API-triggered one-shot runtime calls such as roadmap/fast-fix/commit generation (`0` disables)                                                                                                                                                         |
 | `DATABASE_URL`                     | string  | `./data/aif.sqlite`            | Path to the SQLite database file                                                                                                                                                                                                                                        |
 | `AGENT_QUERY_AUDIT_ENABLED`        | boolean | `true`                         | Enable/disable writing agent query audit logs to `logs/*.log`                                                                                                                                                                                                           |
 | `LOG_LEVEL`                        | string  | `debug`                        | Pino log level: `fatal`, `error`, `warn`, `info`, `debug`, `trace`                                                                                                                                                                                                      |
@@ -71,6 +73,7 @@ Optional runtime defaults:
 
 - `CODEX_CLI_PATH` for CLI transport adapters
 - `AIF_RUNTIME_MODULES` for loading additional runtime modules at startup (`registerRuntimeModule(registry)`)
+- `API_RUNTIME_START_TIMEOUT_MS` / `API_RUNTIME_RUN_TIMEOUT_MS` for API one-shot runtime calls
 
 ### Runtime Readiness Check
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -103,6 +103,8 @@ cp .env.example .env
 | `AGENT_STAGE_STALE_TIMEOUT_MS` | `5400000`           | Stale-stage watchdog timeout (ms) before auto-recovery                                        |
 | `AGENT_STAGE_STALE_MAX_RETRY`  | `3`                 | Max stale auto-recover attempts before quarantine in `blocked_external`                       |
 | `AGENT_STAGE_RUN_TIMEOUT_MS`   | `3600000`           | Per-stage timeout (ms) before coordinator marks run as failed                                 |
+| `API_RUNTIME_START_TIMEOUT_MS` | `60000`             | Timeout waiting for first output from API one-shot runtime calls                              |
+| `API_RUNTIME_RUN_TIMEOUT_MS`   | `120000`            | Hard timeout for API one-shot runtime calls                                                   |
 | `AGENT_USE_SUBAGENTS`          | `true`              | Default for per-task "Use subagents" toggle. `true`: custom subagents, `false`: aif-\* skills |
 | `DATABASE_URL`                 | `./data/aif.sqlite` | SQLite database path                                                                          |
 | `AGENT_QUERY_AUDIT_ENABLED`    | `true`              | Enable/disable query audit logs in `logs/*.log`                                               |

--- a/packages/agent/src/__tests__/hooks.test.ts
+++ b/packages/agent/src/__tests__/hooks.test.ts
@@ -48,6 +48,8 @@ function makeEnv(overrides: Record<string, unknown> = {}) {
     AGENT_STAGE_RUN_TIMEOUT_MS: 3600000,
     AGENT_QUERY_START_TIMEOUT_MS: 60000,
     AGENT_QUERY_START_RETRY_DELAY_MS: 1000,
+    API_RUNTIME_START_TIMEOUT_MS: 60000,
+    API_RUNTIME_RUN_TIMEOUT_MS: 120000,
     DATABASE_URL: "./data/aif.sqlite",
     CORS_ORIGIN: "*",
     API_BASE_URL: "http://localhost:3009",

--- a/packages/api/src/__tests__/chat.test.ts
+++ b/packages/api/src/__tests__/chat.test.ts
@@ -12,17 +12,17 @@ const mockCreateChatMessage = vi.fn();
 const mockUpdateChatSessionTimestamp = vi.fn();
 const mockListChatMessages = vi.fn();
 const mockToChatMessageResponse = vi.fn();
-const mockGetApiRuntimeRegistry = vi.fn();
-const mockListSessionEvents = vi.fn();
 const mockSendToClient = vi.fn();
 const mockBroadcast = vi.fn();
 const mockInvalidateCache = vi.fn();
 const mockResolveApiRuntimeContext = vi.fn();
 const mockAssertApiRuntimeCapabilities = vi.fn();
+const mockGetApiRuntimeRegistry = vi.fn();
 const mockPersistAttachments = vi.fn();
 
 const mockAdapterRun = vi.fn();
 const mockAdapterResume = vi.fn();
+const mockListSessionEvents = vi.fn();
 
 const runtimeAdapter: RuntimeAdapter = {
   descriptor: {
@@ -162,6 +162,7 @@ describe("chat API", () => {
       outputText: "resumed output",
       sessionId: "runtime-session-1",
     });
+    mockListSessionEvents.mockResolvedValue([]);
     mockPersistAttachments.mockResolvedValue([]);
     mockListChatMessages.mockReturnValue([]);
     mockToChatMessageResponse.mockImplementation((row) => row);
@@ -463,7 +464,6 @@ describe("chat API", () => {
       ),
     ).toHaveLength(2);
   });
-
   it("persists incoming chat attachments and stores user message with attachment metadata", async () => {
     mockPersistAttachments.mockResolvedValue([
       {

--- a/packages/api/src/__tests__/runtimeService.test.ts
+++ b/packages/api/src/__tests__/runtimeService.test.ts
@@ -12,6 +12,8 @@ const mockGetEnv = vi.fn(() => ({
   AIF_RUNTIME_MODULES: [] as string[],
   AIF_DEFAULT_RUNTIME_ID: "claude",
   AIF_DEFAULT_PROVIDER_ID: "anthropic",
+  API_RUNTIME_START_TIMEOUT_MS: 60_000,
+  API_RUNTIME_RUN_TIMEOUT_MS: 120_000,
 }));
 
 const mockCheckRuntimeCapabilities = vi.fn(() => ({ ok: true, missing: [] as string[] }));
@@ -147,6 +149,8 @@ describe("runtime service", () => {
       AIF_RUNTIME_MODULES: [],
       AIF_DEFAULT_RUNTIME_ID: "claude",
       AIF_DEFAULT_PROVIDER_ID: "anthropic",
+      API_RUNTIME_START_TIMEOUT_MS: 60_000,
+      API_RUNTIME_RUN_TIMEOUT_MS: 120_000,
     });
     mockCheckRuntimeCapabilities.mockReturnValue({ ok: true, missing: [] });
     mockRegistryRegisterRuntimeModule.mockReset();
@@ -168,6 +172,8 @@ describe("runtime service", () => {
       AIF_RUNTIME_MODULES: ["@org/runtime-a", "file:///runtime-b.mjs"],
       AIF_DEFAULT_RUNTIME_ID: "claude",
       AIF_DEFAULT_PROVIDER_ID: "anthropic",
+      API_RUNTIME_START_TIMEOUT_MS: 60_000,
+      API_RUNTIME_RUN_TIMEOUT_MS: 120_000,
     });
     const runtimeService = await loadRuntimeService();
 
@@ -383,6 +389,8 @@ describe("runtime service", () => {
           apiKeyEnvVar: "OPENAI_API_KEY",
         }),
         execution: expect.objectContaining({
+          startTimeoutMs: 60_000,
+          runTimeoutMs: 120_000,
           includePartialMessages: true,
           maxTurns: 4,
           environment: {
@@ -408,6 +416,8 @@ describe("runtime service", () => {
       AIF_RUNTIME_MODULES: [],
       AIF_DEFAULT_RUNTIME_ID: "claude",
       AIF_DEFAULT_PROVIDER_ID: "anthropic",
+      API_RUNTIME_START_TIMEOUT_MS: 90_000,
+      API_RUNTIME_RUN_TIMEOUT_MS: 240_000,
     });
 
     await runtimeService.runApiRuntimeOneShot({
@@ -421,6 +431,8 @@ describe("runtime service", () => {
     expect(adapter.run).toHaveBeenCalledWith(
       expect.objectContaining({
         execution: expect.objectContaining({
+          startTimeoutMs: 90_000,
+          runTimeoutMs: 240_000,
           includePartialMessages: false,
           systemPromptAppend: "extra",
           environment: { HANDOFF_MODE: "1" },

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -263,6 +263,7 @@ function mergeRuntimeAndDbMessages(
     matchedRuntimeMessages[matchIndex] = true;
     merged[matchIndex] = {
       ...merged[matchIndex],
+      id: dbMessage.id,
       createdAt: dbMessage.createdAt,
       ...(dbMessage.attachments?.length ? { attachments: dbMessage.attachments } : {}),
     };

--- a/packages/api/src/services/runtime.ts
+++ b/packages/api/src/services/runtime.ts
@@ -242,6 +242,7 @@ export async function runApiRuntimeOneShot(input: {
   result: RuntimeRunResult;
   context: RuntimeExecutionContext;
 }> {
+  const env = getEnv();
   const workflow = createRuntimeWorkflowSpec({
     workflowKind: input.workflowKind ?? "oneshot",
     prompt: input.prompt,
@@ -282,6 +283,8 @@ export async function runApiRuntimeOneShot(input: {
         : {}),
     },
     execution: {
+      startTimeoutMs: env.API_RUNTIME_START_TIMEOUT_MS,
+      runTimeoutMs: env.API_RUNTIME_RUN_TIMEOUT_MS,
       includePartialMessages: input.includePartialMessages ?? false,
       maxTurns: input.maxTurns,
       systemPromptAppend: input.systemPromptAppend,

--- a/packages/runtime/src/__tests__/codexSdk.test.ts
+++ b/packages/runtime/src/__tests__/codexSdk.test.ts
@@ -294,6 +294,44 @@ describe("runCodexSdk", () => {
     expect(onToolUse).toHaveBeenCalledWith("FileChange", "update src/index.ts, add src/new.ts");
   });
 
+  it("serializes MCP tool arguments instead of coercing objects to [object Object]", async () => {
+    const onToolUse = vi.fn();
+    const onEvent = vi.fn();
+    mockRunStreamed.mockResolvedValue({
+      events: createMockEvents([
+        { type: "thread.started", thread_id: "thread-mcp-tools" },
+        {
+          type: "item.completed",
+          item: {
+            id: "mcp-1",
+            type: "mcp_tool_call",
+            server: "handoff",
+            tool: "list_mcp_resources",
+            arguments: { cursor: "abc", limit: 20 },
+            status: "completed",
+          },
+        },
+        {
+          type: "turn.completed",
+          usage: { input_tokens: 10, output_tokens: 5, cached_input_tokens: 0 },
+        },
+      ]),
+    });
+
+    await runCodexSdk(createRunInput({ execution: { onToolUse, onEvent } }));
+
+    expect(onToolUse).toHaveBeenCalledWith(
+      "MCP:handoff/list_mcp_resources",
+      '{"cursor":"abc","limit":20}',
+    );
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "tool:summary",
+        message: 'MCP:handoff/list_mcp_resources: {"cursor":"abc","limit":20}',
+      }),
+    );
+  });
+
   it("does not forward npm_ environment keys into Codex SDK env", async () => {
     vi.stubEnv("OPENAI_API_KEY", "sk-sdk");
     vi.stubEnv("npm_config_registry", "https://registry.npmjs.org");

--- a/packages/runtime/src/adapters/codex/sdk.ts
+++ b/packages/runtime/src/adapters/codex/sdk.ts
@@ -43,6 +43,25 @@ function readString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
+function formatToolDetail(value: unknown, maxLength = 200): string {
+  if (value == null) return "";
+
+  let text: string;
+  if (typeof value === "string") {
+    text = value;
+  } else if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    text = String(value);
+  } else {
+    try {
+      text = JSON.stringify(value);
+    } catch {
+      text = String(value);
+    }
+  }
+
+  return text.length > maxLength ? `${text.slice(0, maxLength - 1)}…` : text;
+}
+
 const ALLOWED_ENV_PREFIXES = [
   "OPENAI_",
   "CODEX_",
@@ -275,16 +294,19 @@ function normalizeUsage(usage: Usage | null): RuntimeUsage | null {
 function itemToToolUseSummary(item: ThreadItem): { toolName: string; detail: string } | null {
   switch (item.type) {
     case "command_execution":
-      return { toolName: "Bash", detail: item.command.slice(0, 200) };
+      return { toolName: "Bash", detail: formatToolDetail(item.command) };
     case "file_change":
       return {
         toolName: "FileChange",
-        detail: item.changes.map((c) => `${c.kind} ${c.path}`).join(", "),
+        detail: formatToolDetail(item.changes.map((c) => `${c.kind} ${c.path}`).join(", ")),
       };
     case "mcp_tool_call":
-      return { toolName: `MCP:${item.server}/${item.tool}`, detail: String(item.arguments ?? "") };
+      return {
+        toolName: `MCP:${item.server}/${item.tool}`,
+        detail: formatToolDetail(item.arguments),
+      };
     case "web_search":
-      return { toolName: "WebSearch", detail: item.query };
+      return { toolName: "WebSearch", detail: formatToolDetail(item.query) };
     default:
       return null;
   }

--- a/packages/shared/src/__tests__/env.test.ts
+++ b/packages/shared/src/__tests__/env.test.ts
@@ -13,6 +13,8 @@ describe("env validation", () => {
       POLL_INTERVAL_MS: "30000",
       AGENT_QUERY_START_TIMEOUT_MS: "20000",
       AGENT_QUERY_START_RETRY_DELAY_MS: "250",
+      API_RUNTIME_START_TIMEOUT_MS: "45000",
+      API_RUNTIME_RUN_TIMEOUT_MS: "240000",
       DATABASE_URL: "./data/test.sqlite",
       AGENT_QUERY_AUDIT_ENABLED: "false",
       LOG_LEVEL: "debug",
@@ -23,6 +25,8 @@ describe("env validation", () => {
     expect(result.POLL_INTERVAL_MS).toBe(30000);
     expect(result.AGENT_QUERY_START_TIMEOUT_MS).toBe(20000);
     expect(result.AGENT_QUERY_START_RETRY_DELAY_MS).toBe(250);
+    expect(result.API_RUNTIME_START_TIMEOUT_MS).toBe(45000);
+    expect(result.API_RUNTIME_RUN_TIMEOUT_MS).toBe(240000);
     expect(result.DATABASE_URL).toBe("./data/test.sqlite");
     expect(result.AGENT_QUERY_AUDIT_ENABLED).toBe(false);
     expect(result.LOG_LEVEL).toBe("debug");
@@ -41,6 +45,8 @@ describe("env validation", () => {
     expect(result.AGENT_STAGE_RUN_TIMEOUT_MS).toBe(60 * 60 * 1000);
     expect(result.AGENT_QUERY_START_TIMEOUT_MS).toBe(60 * 1000);
     expect(result.AGENT_QUERY_START_RETRY_DELAY_MS).toBe(1000);
+    expect(result.API_RUNTIME_START_TIMEOUT_MS).toBe(60 * 1000);
+    expect(result.API_RUNTIME_RUN_TIMEOUT_MS).toBe(120 * 1000);
     expect(result.DATABASE_URL).toBe("./data/aif.sqlite");
     expect(result.OPENAI_API_KEY).toBeUndefined();
     expect(result.OPENAI_BASE_URL).toBeUndefined();

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -44,6 +44,8 @@ const envSchema = z.object({
   AGENT_STAGE_RUN_TIMEOUT_MS: z.coerce.number().default(60 * 60 * 1000),
   AGENT_QUERY_START_TIMEOUT_MS: z.coerce.number().default(60 * 1000),
   AGENT_QUERY_START_RETRY_DELAY_MS: z.coerce.number().default(1000),
+  API_RUNTIME_START_TIMEOUT_MS: z.coerce.number().default(60 * 1000),
+  API_RUNTIME_RUN_TIMEOUT_MS: z.coerce.number().default(120 * 1000),
   DATABASE_URL: z.string().default("./data/aif.sqlite"),
   CORS_ORIGIN: z.string().default("*"),
   API_BASE_URL: z.string().default("http://localhost:3009"),


### PR DESCRIPTION
## Summary

- add env-driven timeouts for API one-shot runtime calls
- serialize structured Codex MCP tool arguments in runtime summaries instead of `[object Object]`
- preserve DB message ids when merging runtime chat history

## Changes

- add `API_RUNTIME_START_TIMEOUT_MS` and `API_RUNTIME_RUN_TIMEOUT_MS` in `packages/shared/src/env.ts`
- pass those timeouts into API one-shot runtime execution in `packages/api/src/services/runtime.ts`
- update docs and tests for the new env vars
- format structured Codex tool arguments in `packages/runtime/src/adapters/codex/sdk.t`
- preserve DB message ids in merged chat history in `packages/api/src/routes/chat.ts`

## AI Model

- [x] Other: GPT-5.4

