### PR TITLE
feat(chat): add HTTP fallback and scope chat to the current project

### DIFF
--- a/packages/api/src/__tests__/chat.test.ts
+++ b/packages/api/src/__tests__/chat.test.ts
@@ -229,6 +229,31 @@ describe("chat API", () => {
     );
   });
 
+  it("returns assistant text in HTTP response when websocket clientId is absent", async () => {
+    mockAdapterRun.mockResolvedValueOnce({
+      outputText: "runtime output without ws",
+      sessionId: "runtime-session-1",
+    });
+
+    const res = await app.request("/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        projectId: "project-1",
+        message: "plain prompt",
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(
+      expect.objectContaining({
+        sessionId: "session-1",
+        assistantMessage: "runtime output without ws",
+      }),
+    );
+    expect(mockSendToClient).not.toHaveBeenCalled();
+  });
+
   it("uses adapter.resume and prefixes prompt with /aif-explore", async () => {
     mockFindChatSessionById.mockReturnValue({
       id: "session-1",

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -742,7 +742,7 @@ chatRouter.post("/", jsonValidator(chatRequestSchema), async (c) => {
   log.info(
     {
       projectId,
-      clientId,
+      clientId: clientId ?? null,
       conversationId: chatConversationId,
       sessionId: chatSessionId,
       runtimeId,
@@ -801,6 +801,7 @@ chatRouter.post("/", jsonValidator(chatRequestSchema), async (c) => {
     let hasStreamedTokens = false;
 
     const sendToken = (text: string) => {
+      if (!clientId) return;
       const tokenEvent: WsEvent = {
         type: "chat:token",
         payload: { conversationId: chatConversationId, token: text },
@@ -927,11 +928,14 @@ chatRouter.post("/", jsonValidator(chatRequestSchema), async (c) => {
       type: "chat:done",
       payload: { conversationId: chatConversationId },
     };
-    sendToClient(clientId, doneEvent);
+    if (clientId) {
+      sendToClient(clientId, doneEvent);
+    }
 
     return c.json({
       conversationId: chatConversationId,
       sessionId: chatSessionId,
+      assistantMessage: fullAssistantResponse || null,
       runtime: {
         runtimeId,
         profileId: runtimeProfileId,
@@ -954,13 +958,17 @@ chatRouter.post("/", jsonValidator(chatRequestSchema), async (c) => {
         code: classified.code,
       },
     };
-    sendToClient(clientId, errorEvent);
+    if (clientId) {
+      sendToClient(clientId, errorEvent);
+    }
 
     const doneEvent: WsEvent = {
       type: "chat:done",
       payload: { conversationId: chatConversationId },
     };
-    sendToClient(clientId, doneEvent);
+    if (clientId) {
+      sendToClient(clientId, doneEvent);
+    }
 
     return c.json({ error: classified.message, code: classified.code }, classified.status);
   }

--- a/packages/api/src/schemas.ts
+++ b/packages/api/src/schemas.ts
@@ -135,7 +135,7 @@ export const chatAttachmentSchema = z.object({
 export const chatRequestSchema = z.object({
   projectId: z.string().min(1, "Project ID is required"),
   message: z.string().min(1, "Message is required").max(50_000),
-  clientId: z.string().min(1, "Client ID is required"),
+  clientId: z.string().min(1, "Client ID is required").optional(),
   conversationId: z.string().optional(),
   sessionId: z.string().optional(),
   explore: z.boolean().default(false),

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -405,7 +405,7 @@ export interface ChatAttachment {
 export interface ChatRequest {
   projectId: string;
   message: string;
-  clientId: string;
+  clientId?: string;
   conversationId?: string;
   sessionId?: string;
   explore?: boolean;

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useEffect, useMemo } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Header } from "./components/layout/Header";
 import { Board } from "./components/kanban/Board";
-import { TaskDetail } from "./components/task/TaskDetail";
+import { TaskDetail } from "@/components/task";
 import { CommandPalette } from "./components/layout/CommandPalette";
 import { useWebSocket } from "./hooks/useWebSocket";
 import { useProjects } from "./hooks/useProjects";
@@ -213,8 +213,10 @@ function AppContent() {
       {project && (
         <>
           <ChatPanel
+            key={project.id}
             isOpen={chatOpen}
             projectId={project.id}
+            projectName={project.name}
             taskId={selectedTaskId}
             onClose={() => setChatOpen(false)}
             onOpenTask={(id) => {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useEffect, useMemo } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Header } from "./components/layout/Header";
 import { Board } from "./components/kanban/Board";
-import { TaskDetail } from "@/components/task";
+import { TaskDetail } from "./components/task/TaskDetail";
 import { CommandPalette } from "./components/layout/CommandPalette";
 import { useWebSocket } from "./hooks/useWebSocket";
 import { useProjects } from "./hooks/useProjects";

--- a/packages/web/src/__tests__/ChatPanel.test.tsx
+++ b/packages/web/src/__tests__/ChatPanel.test.tsx
@@ -71,6 +71,26 @@ const { ChatPanel } = await import("@/components/chat/ChatPanel");
 
 const mockOnClose = vi.fn();
 
+function renderPanel(
+  overrides: Partial<{
+    isOpen: boolean;
+    projectId: string | null;
+    projectName: string | null;
+    taskId: string | null;
+  }> = {},
+) {
+  return render(
+    <ChatPanel
+      isOpen={true}
+      projectId="p-1"
+      projectName="Project One"
+      taskId={null}
+      onClose={mockOnClose}
+      {...overrides}
+    />,
+  );
+}
+
 describe("ChatPanel", () => {
   beforeEach(() => {
     mockMessages = [];
@@ -101,7 +121,7 @@ describe("ChatPanel", () => {
       },
     };
 
-    render(<ChatPanel isOpen={true} projectId="p-1" taskId={null} onClose={mockOnClose} />);
+    renderPanel();
 
     expect(screen.getByText("Profile:")).toBeDefined();
     expect(screen.getByText("GLM Claude")).toBeDefined();
@@ -111,9 +131,15 @@ describe("ChatPanel", () => {
     expect(screen.getByText("glm-5")).toBeDefined();
   });
 
+  it("shows the current project scope in the header", () => {
+    renderPanel();
+    expect(screen.getByText("Project:")).toBeDefined();
+    expect(screen.getByText("Project One")).toBeDefined();
+  });
+
   it("shows empty state when no messages", () => {
-    render(<ChatPanel isOpen={true} projectId="p-1" taskId={null} onClose={mockOnClose} />);
-    expect(screen.getByText("Ask anything about this project")).toBeDefined();
+    renderPanel();
+    expect(screen.getByText('Ask anything about "Project One"')).toBeDefined();
   });
 
   it("renders user and assistant messages", () => {
@@ -121,13 +147,13 @@ describe("ChatPanel", () => {
       { role: "user", content: "Hello" },
       { role: "assistant", content: "Hi there!" },
     ];
-    render(<ChatPanel isOpen={true} projectId="p-1" taskId={null} onClose={mockOnClose} />);
+    renderPanel();
     expect(screen.getByText("Hello")).toBeDefined();
     expect(screen.getByText("Hi there!")).toBeDefined();
   });
 
   it("sends message on Enter key", () => {
-    render(<ChatPanel isOpen={true} projectId="p-1" taskId={null} onClose={mockOnClose} />);
+    renderPanel();
     const textarea = screen.getByPlaceholderText("Ask a question...");
     fireEvent.change(textarea, { target: { value: "test message" } });
     fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
@@ -135,7 +161,7 @@ describe("ChatPanel", () => {
   });
 
   it("does not send message on Shift+Enter", () => {
-    render(<ChatPanel isOpen={true} projectId="p-1" taskId={null} onClose={mockOnClose} />);
+    renderPanel();
     const textarea = screen.getByPlaceholderText("Ask a question...");
     fireEvent.change(textarea, { target: { value: "test" } });
     fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true });
@@ -143,7 +169,7 @@ describe("ChatPanel", () => {
   });
 
   it("sends message on send button click", () => {
-    render(<ChatPanel isOpen={true} projectId="p-1" taskId={null} onClose={mockOnClose} />);
+    renderPanel();
     const textarea = screen.getByPlaceholderText("Ask a question...");
     fireEvent.change(textarea, { target: { value: "hello" } });
     const sendButton = screen.getByLabelText("Send message");
@@ -152,7 +178,7 @@ describe("ChatPanel", () => {
   });
 
   it("shows Explore checkbox toggle", () => {
-    render(<ChatPanel isOpen={true} projectId="p-1" taskId={null} onClose={mockOnClose} />);
+    renderPanel();
     expect(screen.getByText("Explore")).toBeDefined();
     const checkbox = screen.getByRole("checkbox");
     fireEvent.click(checkbox);
@@ -162,7 +188,7 @@ describe("ChatPanel", () => {
   it("shows typing indicator when streaming and no assistant message yet", () => {
     mockIsStreaming = true;
     mockMessages = [{ role: "user", content: "Hello" }];
-    render(<ChatPanel isOpen={true} projectId="p-1" taskId={null} onClose={mockOnClose} />);
+    renderPanel();
     expect(screen.getByText("Working...")).toBeDefined();
   });
 
@@ -172,12 +198,12 @@ describe("ChatPanel", () => {
       { role: "user", content: "Hello" },
       { role: "assistant", content: "Partial..." },
     ];
-    render(<ChatPanel isOpen={true} projectId="p-1" taskId={null} onClose={mockOnClose} />);
+    renderPanel();
     expect(screen.getByText("Working...")).toBeDefined();
   });
 
   it("clears messages on clear button click", () => {
-    render(<ChatPanel isOpen={true} projectId="p-1" taskId={null} onClose={mockOnClose} />);
+    renderPanel();
     const clearButton = screen.getByLabelText("Clear messages");
     fireEvent.click(clearButton);
     expect(mockClearMessages).toHaveBeenCalledOnce();
@@ -185,7 +211,7 @@ describe("ChatPanel", () => {
 
   it("shows usage limit banner when chat error code is CHAT_USAGE_LIMIT", () => {
     mockChatErrorCode = "CHAT_USAGE_LIMIT";
-    render(<ChatPanel isOpen={true} projectId="p-1" taskId={null} onClose={mockOnClose} />);
+    renderPanel();
     expect(screen.getByText("Usage Limit Reached")).toBeDefined();
     expect(
       screen.getByText(
@@ -195,32 +221,32 @@ describe("ChatPanel", () => {
   });
 
   it("calls onClose when close button is clicked", () => {
-    render(<ChatPanel isOpen={true} projectId="p-1" taskId={null} onClose={mockOnClose} />);
+    renderPanel();
     const closeButton = screen.getByLabelText("Close chat");
     fireEvent.click(closeButton);
     expect(mockOnClose).toHaveBeenCalledOnce();
   });
 
   it("calls onClose when Escape is pressed", () => {
-    render(<ChatPanel isOpen={true} projectId="p-1" taskId={null} onClose={mockOnClose} />);
+    renderPanel();
     fireEvent.keyDown(document, { key: "Escape" });
     expect(mockOnClose).toHaveBeenCalledOnce();
   });
 
   it("calls onClose on outside click", () => {
-    render(<ChatPanel isOpen={true} projectId="p-1" taskId={null} onClose={mockOnClose} />);
+    renderPanel();
     fireEvent.pointerDown(document.body);
     expect(mockOnClose).toHaveBeenCalledOnce();
   });
 
   it("does not call onClose on inside click", () => {
-    render(<ChatPanel isOpen={true} projectId="p-1" taskId={null} onClose={mockOnClose} />);
+    renderPanel();
     fireEvent.pointerDown(screen.getByText("AI Chat"));
     expect(mockOnClose).not.toHaveBeenCalled();
   });
 
   it("is hidden when isOpen is false", () => {
-    render(<ChatPanel isOpen={false} projectId="p-1" taskId={null} onClose={mockOnClose} />);
+    renderPanel({ isOpen: false });
     // Portal renders to document.body
     const panel = document.body.querySelector("[class*='-translate-x-full']");
     expect(panel).not.toBeNull();
@@ -234,7 +260,7 @@ describe("ChatPanel", () => {
         attachments: [{ name: "report.csv", mimeType: "text/csv", size: 1234 }],
       },
     ];
-    render(<ChatPanel isOpen={true} projectId="p-1" taskId={null} onClose={mockOnClose} />);
+    renderPanel();
     expect(screen.getByText("report.csv")).toBeDefined();
   });
 
@@ -250,7 +276,7 @@ describe("ChatPanel", () => {
         ],
       },
     ];
-    render(<ChatPanel isOpen={true} projectId="p-1" taskId={null} onClose={mockOnClose} />);
+    renderPanel();
     expect(screen.getByText("photo1.jpg")).toBeDefined();
     expect(screen.getByText("photo2.png")).toBeDefined();
     expect(screen.getByText("data.json")).toBeDefined();
@@ -272,7 +298,7 @@ describe("ChatPanel", () => {
         ],
       },
     ];
-    render(<ChatPanel isOpen={true} projectId="p-1" taskId={null} onClose={mockOnClose} />);
+    renderPanel();
     const link = screen.getByText("doc.pdf").closest("a");
     expect(link).toBeDefined();
     expect(link!.getAttribute("href")).toBe("/chat/sessions/session-123/attachments/doc.pdf");
@@ -287,7 +313,7 @@ describe("ChatPanel", () => {
         attachments: [{ name: "new-file.txt", mimeType: "text/plain", size: 100 }],
       },
     ];
-    render(<ChatPanel isOpen={true} projectId="p-1" taskId={null} onClose={mockOnClose} />);
+    renderPanel();
     const el = screen.getByText("new-file.txt");
     expect(el.closest("a")).toBeNull();
     expect(el.closest("span")).toBeDefined();
@@ -309,14 +335,14 @@ describe("ChatPanel", () => {
         ],
       },
     ];
-    render(<ChatPanel isOpen={true} projectId="p-1" taskId={null} onClose={mockOnClose} />);
+    renderPanel();
     const el = screen.getByText("file.txt");
     expect(el.closest("a")).toBeNull();
   });
 
   it("does not render attachment section when message has no attachments", () => {
     mockMessages = [{ role: "user", content: "Plain message" }];
-    render(<ChatPanel isOpen={true} projectId="p-1" taskId={null} onClose={mockOnClose} />);
+    renderPanel();
     // Portal renders to document.body — query there
     const messageBubbles = document.body.querySelectorAll(".bg-blue-600\\/15");
     expect(messageBubbles.length).toBe(1);

--- a/packages/web/src/__tests__/useChat.test.ts
+++ b/packages/web/src/__tests__/useChat.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook, act } from "@testing-library/react";
+import { renderHook, act, waitFor } from "@testing-library/react";
 
 const mockSendChatMessage = vi.fn();
 const mockGetChatSessionMessages = vi.fn();
+const mockGetWsClientId = vi.fn();
 
 vi.mock("@/lib/api", () => ({
   api: {
@@ -12,7 +13,7 @@ vi.mock("@/lib/api", () => ({
 }));
 
 vi.mock("@/hooks/useWebSocket", () => ({
-  getWsClientId: () => "test-client-id",
+  getWsClientId: () => mockGetWsClientId(),
 }));
 
 const { useChat } = await import("@/hooks/useChat");
@@ -21,6 +22,8 @@ describe("useChat", () => {
   beforeEach(() => {
     mockSendChatMessage.mockReset();
     mockGetChatSessionMessages.mockReset();
+    mockGetWsClientId.mockReset();
+    mockGetWsClientId.mockReturnValue("test-client-id");
     mockSendChatMessage.mockResolvedValue({ conversationId: "conv-1", sessionId: "sess-1" });
     mockGetChatSessionMessages.mockResolvedValue([]);
   });
@@ -232,6 +235,51 @@ describe("useChat", () => {
     expect(result.current.isStreaming).toBe(false);
   });
 
+  it("falls back to HTTP response when websocket clientId is unavailable", async () => {
+    mockGetWsClientId.mockReturnValue(null);
+    mockSendChatMessage.mockResolvedValueOnce({
+      conversationId: "conv-http-1",
+      sessionId: "sess-http-1",
+      assistantMessage: "HTTP fallback reply",
+    });
+
+    const { result } = renderHook(() => useChat("p-1"));
+
+    await act(async () => {
+      await result.current.sendMessage("Hello");
+      await new Promise<void>((resolve) => setTimeout(resolve, 150));
+    });
+
+    expect(mockSendChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "p-1",
+        message: "Hello",
+      }),
+    );
+    expect(mockSendChatMessage.mock.calls[0][0].clientId).toBeUndefined();
+    expect(result.current.messages).toEqual([
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "HTTP fallback reply" },
+    ]);
+    expect(result.current.isStreaming).toBe(false);
+  });
+
+  it("promotes the resolved session id after the first send", async () => {
+    const handleSessionResolved = vi.fn();
+    mockSendChatMessage.mockResolvedValueOnce({
+      conversationId: "conv-2",
+      sessionId: "sess-2",
+    });
+
+    const { result } = renderHook(() => useChat("p-1", null, null, handleSessionResolved));
+
+    await act(async () => {
+      await result.current.sendMessage("Hello");
+    });
+
+    expect(handleSessionResolved).toHaveBeenCalledWith("sess-2");
+  });
+
   it("does not duplicate error message when ws chat:error and http failure happen together", async () => {
     let rejectSend: ((reason?: unknown) => void) | null = null;
     mockSendChatMessage.mockImplementationOnce(
@@ -246,6 +294,7 @@ describe("useChat", () => {
     const sendPromise = act(async () => {
       await result.current.sendMessage("Hello");
     });
+    await waitFor(() => expect(mockSendChatMessage).toHaveBeenCalledTimes(1));
 
     const conversationId = mockSendChatMessage.mock.calls[0][0].conversationId as string;
 

--- a/packages/web/src/__tests__/useChat.test.ts
+++ b/packages/web/src/__tests__/useChat.test.ts
@@ -4,6 +4,7 @@ import { renderHook, act, waitFor } from "@testing-library/react";
 const mockSendChatMessage = vi.fn();
 const mockGetChatSessionMessages = vi.fn();
 const mockGetWsClientId = vi.fn();
+const WS_CLIENT_ID_WAIT_TIMEOUT_MS = 500;
 
 vi.mock("@/lib/api", () => ({
   api: {
@@ -236,6 +237,7 @@ describe("useChat", () => {
   });
 
   it("falls back to HTTP response when websocket clientId is unavailable", async () => {
+    vi.useFakeTimers();
     mockGetWsClientId.mockReturnValue(null);
     mockSendChatMessage.mockResolvedValueOnce({
       conversationId: "conv-http-1",
@@ -245,23 +247,29 @@ describe("useChat", () => {
 
     const { result } = renderHook(() => useChat("p-1"));
 
-    await act(async () => {
-      await result.current.sendMessage("Hello");
-      await new Promise<void>((resolve) => setTimeout(resolve, 150));
-    });
+    try {
+      await act(async () => {
+        const sendPromise = result.current.sendMessage("Hello");
+        await vi.advanceTimersByTimeAsync(WS_CLIENT_ID_WAIT_TIMEOUT_MS);
+        await sendPromise;
+        await vi.advanceTimersByTimeAsync(150);
+      });
 
-    expect(mockSendChatMessage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        projectId: "p-1",
-        message: "Hello",
-      }),
-    );
-    expect(mockSendChatMessage.mock.calls[0][0].clientId).toBeUndefined();
-    expect(result.current.messages).toEqual([
-      { role: "user", content: "Hello" },
-      { role: "assistant", content: "HTTP fallback reply" },
-    ]);
-    expect(result.current.isStreaming).toBe(false);
+      expect(mockSendChatMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: "p-1",
+          message: "Hello",
+        }),
+      );
+      expect(mockSendChatMessage.mock.calls[0][0].clientId).toBeUndefined();
+      expect(result.current.messages).toEqual([
+        { role: "user", content: "Hello" },
+        { role: "assistant", content: "HTTP fallback reply" },
+      ]);
+      expect(result.current.isStreaming).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("promotes the resolved session id after the first send", async () => {
@@ -313,6 +321,58 @@ describe("useChat", () => {
       (m) => m.role === "assistant" && m.content === "Chat request failed",
     );
     expect(assistantErrors).toHaveLength(1);
+  });
+
+  it("keeps the websocket stream active after the first token arrives", async () => {
+    vi.useFakeTimers();
+    mockSendChatMessage.mockResolvedValueOnce({
+      conversationId: "conv-stream-1",
+      sessionId: "sess-stream-1",
+      assistantMessage: "HTTP fallback reply",
+    });
+
+    const { result } = renderHook(() => useChat("p-1"));
+
+    try {
+      await act(async () => {
+        await result.current.sendMessage("Hello");
+      });
+
+      const conversationId = mockSendChatMessage.mock.calls[0][0].conversationId as string;
+
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent("chat:token", {
+            detail: { conversationId, token: "Hello " },
+          }),
+        );
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(600);
+      });
+
+      expect(result.current.isStreaming).toBe(true);
+      expect(result.current.messages[result.current.messages.length - 1]).toEqual({
+        role: "assistant",
+        content: "Hello ",
+      });
+
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent("chat:token", {
+            detail: { conversationId, token: "world!" },
+          }),
+        );
+      });
+
+      expect(result.current.messages[result.current.messages.length - 1]).toEqual({
+        role: "assistant",
+        content: "Hello world!",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("toggles explore mode", () => {

--- a/packages/web/src/__tests__/useChatSessions.test.ts
+++ b/packages/web/src/__tests__/useChatSessions.test.ts
@@ -135,4 +135,35 @@ describe("useChatSessions", () => {
     expect(mockListChatSessions).not.toHaveBeenCalled();
     expect(result.current.sessions).toEqual([]);
   });
+
+  it("clears the active session when the current project changes", async () => {
+    mockListChatSessions.mockImplementation((projectId: string) =>
+      Promise.resolve(
+        projectId === "proj-1"
+          ? [{ id: "s1", projectId: "proj-1", title: "Chat 1", updatedAt: "2026-01-01" }]
+          : [{ id: "s2", projectId: "proj-2", title: "Chat 2", updatedAt: "2026-01-02" }],
+      ),
+    );
+
+    const { result, rerender } = renderHook(({ projectId }) => useChatSessions(projectId), {
+      initialProps: { projectId: "proj-1" as string | null },
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.sessions[0]?.id).toBe("s1");
+    });
+
+    act(() => {
+      result.current.setActiveSessionId("s1");
+    });
+    expect(result.current.activeSessionId).toBe("s1");
+
+    rerender({ projectId: "proj-2" });
+
+    await waitFor(() => {
+      expect(result.current.sessions[0]?.id).toBe("s2");
+    });
+    expect(result.current.activeSessionId).toBe("s2");
+  });
 });

--- a/packages/web/src/components/chat/ChatPanel.tsx
+++ b/packages/web/src/components/chat/ChatPanel.tsx
@@ -37,12 +37,20 @@ import type { ChatAttachment } from "@aif/shared/browser";
 interface ChatPanelProps {
   isOpen: boolean;
   projectId: string | null;
+  projectName: string | null;
   taskId: string | null;
   onClose: () => void;
   onOpenTask?: (taskId: string) => void;
 }
 
-export function ChatPanel({ isOpen, projectId, taskId, onClose, onOpenTask }: ChatPanelProps) {
+export function ChatPanel({
+  isOpen,
+  projectId,
+  projectName,
+  taskId,
+  onClose,
+  onOpenTask,
+}: ChatPanelProps) {
   const [showSessions, setShowSessions] = useState(false);
 
   const {
@@ -64,7 +72,7 @@ export function ChatPanel({ isOpen, projectId, taskId, onClose, onOpenTask }: Ch
     sendMessage,
     clearMessages,
     newSession,
-  } = useChat(projectId, activeSessionId, taskId);
+  } = useChat(projectId, activeSessionId, taskId, setActiveSessionId);
 
   const { data: currentTask } = useTask(taskId);
   const { data: effectiveChatRuntime } = useEffectiveChatRuntime(projectId);
@@ -242,6 +250,10 @@ export function ChatPanel({ isOpen, projectId, taskId, onClose, onOpenTask }: Ch
           </div>
         )}
         <div className="mt-1.5 flex flex-wrap items-center gap-1.5 text-[11px] text-muted-foreground">
+          <span>Project:</span>
+          <Badge variant="outline" className="h-5 px-1.5 py-0 text-[10px] font-medium">
+            {projectName ?? "No project"}
+          </Badge>
           <span>Profile:</span>
           <Badge variant="outline" className="h-5 px-1.5 py-0 text-[10px] font-medium">
             {activeRuntimeProfileName}
@@ -265,6 +277,7 @@ export function ChatPanel({ isOpen, projectId, taskId, onClose, onOpenTask }: Ch
             <SessionList
               sessions={sessions}
               activeSessionId={activeSessionId}
+              projectName={projectName}
               onSelect={handleSessionSelect}
               onCreate={handleNewChat}
               onDelete={handleDeleteSession}
@@ -293,7 +306,9 @@ export function ChatPanel({ isOpen, projectId, taskId, onClose, onOpenTask }: Ch
           {messages.length === 0 && (
             <div className="flex h-full flex-col items-center justify-center gap-2 text-muted-foreground">
               <Bot className="h-8 w-8 opacity-30" />
-              <p className="text-xs">Ask anything about this project</p>
+              <p className="text-xs">
+                Ask anything about {projectName ? `"${projectName}"` : "this project"}
+              </p>
             </div>
           )}
           {messages.map((msg, i) => (

--- a/packages/web/src/components/chat/SessionList.tsx
+++ b/packages/web/src/components/chat/SessionList.tsx
@@ -9,6 +9,7 @@ import type { ChatSession } from "@aif/shared/browser";
 interface SessionListProps {
   sessions: ChatSession[];
   activeSessionId: string | null;
+  projectName: string | null;
   onSelect: (id: string) => void;
   onCreate: () => void;
   onDelete: (id: string) => void;
@@ -18,6 +19,7 @@ interface SessionListProps {
 export function SessionList({
   sessions,
   activeSessionId,
+  projectName,
   onSelect,
   onCreate,
   onDelete,
@@ -64,6 +66,9 @@ export function SessionList({
           <Plus className="h-3.5 w-3.5" />
           New Chat
         </Button>
+        <p className="mt-2 text-3xs uppercase tracking-[0.12em] text-muted-foreground">
+          {projectName ? `Current Project: ${projectName}` : "Current Project"}
+        </p>
       </div>
       <div className="flex-1 overflow-y-auto overscroll-contain py-1">
         {sessions.length === 0 && (

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -17,10 +17,25 @@ interface SessionStreamState {
   errorHandled: boolean;
 }
 
+async function waitForWsClientId(timeoutMs = 1500, pollIntervalMs = 50): Promise<string | null> {
+  const existing = getWsClientId();
+  if (existing) return existing;
+
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+    const clientId = getWsClientId();
+    if (clientId) return clientId;
+  }
+
+  return getWsClientId();
+}
+
 export function useChat(
   projectId: string | null,
   sessionId: string | null = null,
   taskId: string | null = null,
+  onSessionResolved?: (sessionId: string) => void,
 ) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [isStreaming, setIsStreaming] = useState(false);
@@ -28,16 +43,15 @@ export function useChat(
   const [chatErrorCode, setChatErrorCode] = useState<string | null>(null);
   const currentSessionIdRef = useRef<string | null>(null);
 
-  // Per-session streaming state: conversationId → streamKey (sessionId or conversationId)
+  // Per-session streaming state: conversationId -> streamKey (sessionId or conversationId)
   const activeStreamsRef = useRef<Map<string, string>>(new Map());
-  // Per-session stream data: streamKey → state
+  // Per-session stream data: streamKey -> state
   const sessionStreamsRef = useRef<Map<string, SessionStreamState>>(new Map());
   // Track conversationId used when no session exists (for matching events)
   const conversationIdForNoSession = useRef<string | null>(null);
   // Deduplicate WS and HTTP error handling for the same conversation.
   const handledErrorConversationsRef = useRef<Set<string>>(new Set());
 
-  // Check if a specific session is currently streaming
   const isSessionStreaming = useCallback((sid: string | null) => {
     if (!sid) return false;
     for (const [, streamSid] of activeStreamsRef.current) {
@@ -46,7 +60,6 @@ export function useChat(
     return false;
   }, []);
 
-  // Load messages when sessionId changes
   const prevSessionIdRef = useRef<string | null>(null);
   useEffect(() => {
     const prevSessionId = prevSessionIdRef.current;
@@ -69,7 +82,6 @@ export function useChat(
 
     currentSessionIdRef.current = sessionId;
 
-    // If this session is actively streaming, restore its in-flight messages
     const streamState = sessionStreamsRef.current.get(sessionId);
     if (streamState) {
       console.debug("[useChat] Restoring streaming session %s", sessionId);
@@ -79,7 +91,6 @@ export function useChat(
       return;
     }
 
-    // Otherwise load from server
     queueMicrotask(() => setIsStreaming(false));
     console.debug("[useChat] Loading session messages sessionId=%s", sessionId);
 
@@ -88,7 +99,7 @@ export function useChat(
       .then((msgs) => {
         if (currentSessionIdRef.current !== sessionId) return;
         if (isSessionStreaming(sessionId)) {
-          console.debug("[useChat] Skipping session load — streaming in progress");
+          console.debug("[useChat] Skipping session load - streaming in progress");
           return;
         }
         console.debug("[useChat] Session changed, loaded %d messages", msgs.length);
@@ -106,9 +117,7 @@ export function useChat(
       });
   }, [sessionId, isSessionStreaming]);
 
-  // Listen for chat stream events dispatched by useWebSocket
   useEffect(() => {
-    // Check if a stream belongs to the currently viewed session
     const isCurrentStream = (streamKey: string) =>
       currentSessionIdRef.current === streamKey ||
       (!currentSessionIdRef.current && streamKey === conversationIdForNoSession.current);
@@ -191,15 +200,13 @@ export function useChat(
     async (text: string, attachments?: ChatAttachment[]) => {
       if (!projectId || !text.trim() || isStreaming) return;
 
-      const clientId = getWsClientId();
+      const clientId = await waitForWsClientId();
       if (!clientId) {
-        console.debug("[useChat] No clientId available, WebSocket not connected");
-        return;
+        console.debug("[useChat] No clientId available, proceeding with HTTP fallback");
       }
 
       const newConversationId = crypto.randomUUID();
       const effectiveSessionId = sessionId ?? currentSessionIdRef.current;
-      // Use sessionId or conversationId as stream key (for sessions not yet created)
       const streamKey = effectiveSessionId ?? newConversationId;
 
       const messageAttachments: ChatMessageAttachment[] | undefined = attachments?.map((a) => ({
@@ -214,7 +221,6 @@ export function useChat(
       };
       const newMessages = [...messages, userMessage];
 
-      // Register active stream
       if (!effectiveSessionId) {
         conversationIdForNoSession.current = newConversationId;
       }
@@ -242,17 +248,17 @@ export function useChat(
         const result = await api.sendChatMessage({
           projectId,
           message: text.trim(),
-          clientId,
           conversationId: newConversationId,
           sessionId: effectiveSessionId ?? undefined,
           explore,
+          ...(clientId ? { clientId } : {}),
           ...(taskId ? { taskId } : {}),
           ...(attachments?.length ? { attachments } : {}),
         });
 
-        if (result.sessionId && !currentSessionIdRef.current) {
+        if (result.sessionId) {
           currentSessionIdRef.current = result.sessionId;
-          // Migrate stream tracking from temp key (conversationId) to real sessionId
+
           if (streamKey !== result.sessionId) {
             const state = sessionStreamsRef.current.get(streamKey);
             if (state) {
@@ -261,14 +267,19 @@ export function useChat(
             }
             activeStreamsRef.current.set(newConversationId, result.sessionId);
           }
+
+          if (result.sessionId !== effectiveSessionId) {
+            onSessionResolved?.(result.sessionId);
+          }
+          window.dispatchEvent(
+            new CustomEvent("chat:session_created", { detail: { id: result.sessionId } }),
+          );
         }
 
-        // Update user message attachments with server-resolved paths (for download links)
         if (result.attachments?.length) {
           setMessages((prev) =>
             prev.map((m) => (m === userMessage ? { ...m, attachments: result.attachments } : m)),
           );
-          // Also update in-flight stream state
           const activeStreamKey = activeStreamsRef.current.get(newConversationId) ?? streamKey;
           const state = sessionStreamsRef.current.get(activeStreamKey);
           if (state) {
@@ -283,21 +294,44 @@ export function useChat(
           }
         }
 
-        // Safety net: HTTP response arrives after server sends chat:done.
-        // Give WS events a moment to arrive, then force stop if still active.
-        setTimeout(() => {
-          if (activeStreamsRef.current.has(newConversationId)) {
-            console.debug("[useChat] Stream still active after HTTP — forcing stop");
+        if (result.assistantMessage?.trim()) {
+          setTimeout(() => {
+            const activeStreamKey = activeStreamsRef.current.get(newConversationId);
+            if (!activeStreamKey) return;
+
+            const state = sessionStreamsRef.current.get(activeStreamKey);
+            if (!state || state.accumulator.trim().length > 0) return;
+
+            console.debug(
+              "[useChat] Applying HTTP assistant fallback for conversation %s",
+              newConversationId,
+            );
+            state.messages = [
+              ...state.messages,
+              { role: "assistant", content: result.assistantMessage as string },
+            ];
+            setMessages(state.messages);
             activeStreamsRef.current.delete(newConversationId);
-            sessionStreamsRef.current.delete(streamKey);
+            sessionStreamsRef.current.delete(activeStreamKey);
             setIsStreaming(false);
-          }
+          }, 100);
+        }
+
+        setTimeout(() => {
+          const activeStreamKey = activeStreamsRef.current.get(newConversationId);
+          if (!activeStreamKey) return;
+
+          console.debug("[useChat] Stream still active after HTTP - forcing stop");
+          activeStreamsRef.current.delete(newConversationId);
+          sessionStreamsRef.current.delete(activeStreamKey);
+          setIsStreaming(false);
         }, 500);
       } catch (err) {
         console.error("[useChat] Failed to send message:", err);
+        const activeStreamKey = activeStreamsRef.current.get(newConversationId) ?? streamKey;
         activeStreamsRef.current.delete(newConversationId);
-        const errorHandled = sessionStreamsRef.current.get(streamKey)?.errorHandled ?? false;
-        sessionStreamsRef.current.delete(streamKey);
+        const errorHandled = sessionStreamsRef.current.get(activeStreamKey)?.errorHandled ?? false;
+        sessionStreamsRef.current.delete(activeStreamKey);
         setIsStreaming(false);
         const wsHandled = handledErrorConversationsRef.current.has(newConversationId);
         if (!errorHandled && !wsHandled) {
@@ -309,7 +343,7 @@ export function useChat(
         handledErrorConversationsRef.current.delete(newConversationId);
       }
     },
-    [projectId, sessionId, messages, isStreaming, explore, taskId],
+    [projectId, sessionId, messages, isStreaming, explore, taskId, onSessionResolved],
   );
 
   const clearMessages = useCallback(() => {

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -342,7 +342,8 @@ export function useChat(
           }
         }
 
-        if (result.assistantMessage?.trim()) {
+        const assistantMessage = result.assistantMessage;
+        if (assistantMessage?.trim()) {
           const fallbackTimer = window.setTimeout(() => {
             const activeStreamKey = activeStreamsRef.current.get(newConversationId);
             if (!activeStreamKey) {
@@ -366,10 +367,7 @@ export function useChat(
               newConversationId,
             );
             clearConversationTimers(newConversationId);
-            state.messages = [
-              ...state.messages,
-              { role: "assistant", content: result.assistantMessage },
-            ];
+            state.messages = [...state.messages, { role: "assistant", content: assistantMessage }];
             setMessages(state.messages);
             activeStreamsRef.current.delete(newConversationId);
             sessionStreamsRef.current.delete(activeStreamKey);

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -17,7 +17,13 @@ interface SessionStreamState {
   errorHandled: boolean;
 }
 
-async function waitForWsClientId(timeoutMs = 1500, pollIntervalMs = 50): Promise<string | null> {
+const WS_CLIENT_ID_WAIT_TIMEOUT_MS = 500;
+const WS_CLIENT_ID_POLL_INTERVAL_MS = 50;
+
+async function waitForWsClientId(
+  timeoutMs = WS_CLIENT_ID_WAIT_TIMEOUT_MS,
+  pollIntervalMs = WS_CLIENT_ID_POLL_INTERVAL_MS,
+): Promise<string | null> {
   const existing = getWsClientId();
   if (existing) return existing;
 
@@ -43,15 +49,43 @@ export function useChat(
   const [chatErrorCode, setChatErrorCode] = useState<string | null>(null);
   const currentSessionIdRef = useRef<string | null>(null);
 
-  // Per-session streaming state: conversationId -> streamKey (sessionId or conversationId)
+  // Per-session streaming state: conversationId → streamKey (sessionId or conversationId)
   const activeStreamsRef = useRef<Map<string, string>>(new Map());
-  // Per-session stream data: streamKey -> state
+  // Per-session stream data: streamKey → state
   const sessionStreamsRef = useRef<Map<string, SessionStreamState>>(new Map());
   // Track conversationId used when no session exists (for matching events)
   const conversationIdForNoSession = useRef<string | null>(null);
   // Deduplicate WS and HTTP error handling for the same conversation.
   const handledErrorConversationsRef = useRef<Set<string>>(new Set());
+  // Coordinate HTTP fallback and forced-stop timeouts per conversation.
+  const fallbackTimersRef = useRef<Map<string, number>>(new Map());
+  const forcedStopTimersRef = useRef<Map<string, number>>(new Map());
 
+  const clearConversationTimers = useCallback((conversationId: string) => {
+    const fallbackTimer = fallbackTimersRef.current.get(conversationId);
+    if (fallbackTimer !== undefined) {
+      window.clearTimeout(fallbackTimer);
+      fallbackTimersRef.current.delete(conversationId);
+    }
+
+    const forcedStopTimer = forcedStopTimersRef.current.get(conversationId);
+    if (forcedStopTimer !== undefined) {
+      window.clearTimeout(forcedStopTimer);
+      forcedStopTimersRef.current.delete(conversationId);
+    }
+  }, []);
+
+  const clearAllConversationTimers = useCallback(() => {
+    const conversationIds = new Set([
+      ...fallbackTimersRef.current.keys(),
+      ...forcedStopTimersRef.current.keys(),
+    ]);
+    for (const conversationId of conversationIds) {
+      clearConversationTimers(conversationId);
+    }
+  }, [clearConversationTimers]);
+
+  // Check if a specific session is currently streaming
   const isSessionStreaming = useCallback((sid: string | null) => {
     if (!sid) return false;
     for (const [, streamSid] of activeStreamsRef.current) {
@@ -61,6 +95,7 @@ export function useChat(
   }, []);
 
   const prevSessionIdRef = useRef<string | null>(null);
+  // Load messages when sessionId changes
   useEffect(() => {
     const prevSessionId = prevSessionIdRef.current;
     prevSessionIdRef.current = sessionId;
@@ -82,6 +117,7 @@ export function useChat(
 
     currentSessionIdRef.current = sessionId;
 
+    // If this session is actively streaming, restore its in-flight messages
     const streamState = sessionStreamsRef.current.get(sessionId);
     if (streamState) {
       console.debug("[useChat] Restoring streaming session %s", sessionId);
@@ -91,6 +127,7 @@ export function useChat(
       return;
     }
 
+    // Otherwise load from server
     queueMicrotask(() => setIsStreaming(false));
     console.debug("[useChat] Loading session messages sessionId=%s", sessionId);
 
@@ -99,7 +136,7 @@ export function useChat(
       .then((msgs) => {
         if (currentSessionIdRef.current !== sessionId) return;
         if (isSessionStreaming(sessionId)) {
-          console.debug("[useChat] Skipping session load - streaming in progress");
+          console.debug("[useChat] Skipping session load — streaming in progress");
           return;
         }
         console.debug("[useChat] Session changed, loaded %d messages", msgs.length);
@@ -117,7 +154,9 @@ export function useChat(
       });
   }, [sessionId, isSessionStreaming]);
 
+  // Listen for chat stream events dispatched by useWebSocket
   useEffect(() => {
+    // Check if a stream belongs to the currently viewed session
     const isCurrentStream = (streamKey: string) =>
       currentSessionIdRef.current === streamKey ||
       (!currentSessionIdRef.current && streamKey === conversationIdForNoSession.current);
@@ -126,6 +165,8 @@ export function useChat(
       const { conversationId, token } = (e as CustomEvent<ChatStreamTokenPayload>).detail;
       const streamKey = activeStreamsRef.current.get(conversationId);
       if (!streamKey) return;
+
+      clearConversationTimers(conversationId);
 
       const state = sessionStreamsRef.current.get(streamKey);
       if (!state) return;
@@ -154,6 +195,7 @@ export function useChat(
       if (!streamKey) return;
 
       console.debug("[useChat] Stream done for %s conversation %s", streamKey, conversationId);
+      clearConversationTimers(conversationId);
       activeStreamsRef.current.delete(conversationId);
       sessionStreamsRef.current.delete(streamKey);
 
@@ -173,6 +215,7 @@ export function useChat(
       handledErrorConversationsRef.current.add(conversationId);
 
       console.debug("[useChat] Stream error for %s", streamKey);
+      clearConversationTimers(conversationId);
       activeStreamsRef.current.delete(conversationId);
       sessionStreamsRef.current.delete(streamKey);
 
@@ -193,8 +236,9 @@ export function useChat(
       window.removeEventListener("chat:token", handleToken);
       window.removeEventListener("chat:done", handleDone);
       window.removeEventListener("chat:error", handleError);
+      clearAllConversationTimers();
     };
-  }, []);
+  }, [clearAllConversationTimers, clearConversationTimers]);
 
   const sendMessage = useCallback(
     async (text: string, attachments?: ChatAttachment[]) => {
@@ -207,6 +251,7 @@ export function useChat(
 
       const newConversationId = crypto.randomUUID();
       const effectiveSessionId = sessionId ?? currentSessionIdRef.current;
+      // Use sessionId or conversationId as stream key (for sessions not yet created)
       const streamKey = effectiveSessionId ?? newConversationId;
 
       const messageAttachments: ChatMessageAttachment[] | undefined = attachments?.map((a) => ({
@@ -221,6 +266,7 @@ export function useChat(
       };
       const newMessages = [...messages, userMessage];
 
+      // Register active stream
       if (!effectiveSessionId) {
         conversationIdForNoSession.current = newConversationId;
       }
@@ -276,6 +322,7 @@ export function useChat(
           );
         }
 
+        // Update user message attachments with server-resolved paths (for download links)
         if (result.attachments?.length) {
           setMessages((prev) =>
             prev.map((m) => (m === userMessage ? { ...m, attachments: result.attachments } : m)),
@@ -283,6 +330,7 @@ export function useChat(
           const activeStreamKey = activeStreamsRef.current.get(newConversationId) ?? streamKey;
           const state = sessionStreamsRef.current.get(activeStreamKey);
           if (state) {
+            // Also update in-flight stream state
             state.messages = state.messages.map((m) =>
               m.role === "user" &&
               m.content === userMessage.content &&
@@ -295,39 +343,64 @@ export function useChat(
         }
 
         if (result.assistantMessage?.trim()) {
-          setTimeout(() => {
+          const fallbackTimer = window.setTimeout(() => {
             const activeStreamKey = activeStreamsRef.current.get(newConversationId);
-            if (!activeStreamKey) return;
+            if (!activeStreamKey) {
+              clearConversationTimers(newConversationId);
+              return;
+            }
 
             const state = sessionStreamsRef.current.get(activeStreamKey);
-            if (!state || state.accumulator.trim().length > 0) return;
+            if (!state) {
+              clearConversationTimers(newConversationId);
+              return;
+            }
+
+            if (state.accumulator.length > 0) {
+              clearConversationTimers(newConversationId);
+              return;
+            }
 
             console.debug(
               "[useChat] Applying HTTP assistant fallback for conversation %s",
               newConversationId,
             );
+            clearConversationTimers(newConversationId);
             state.messages = [
               ...state.messages,
-              { role: "assistant", content: result.assistantMessage as string },
+              { role: "assistant", content: result.assistantMessage },
             ];
             setMessages(state.messages);
             activeStreamsRef.current.delete(newConversationId);
             sessionStreamsRef.current.delete(activeStreamKey);
             setIsStreaming(false);
           }, 100);
+          fallbackTimersRef.current.set(newConversationId, fallbackTimer);
         }
 
-        setTimeout(() => {
+        const forcedStopTimer = window.setTimeout(() => {
           const activeStreamKey = activeStreamsRef.current.get(newConversationId);
-          if (!activeStreamKey) return;
+          if (!activeStreamKey) {
+            clearConversationTimers(newConversationId);
+            return;
+          }
 
-          console.debug("[useChat] Stream still active after HTTP - forcing stop");
+          const state = sessionStreamsRef.current.get(activeStreamKey);
+          if (state?.accumulator.length) {
+            clearConversationTimers(newConversationId);
+            return;
+          }
+
+          console.debug("[useChat] Stream still active after HTTP — forcing stop");
+          clearConversationTimers(newConversationId);
           activeStreamsRef.current.delete(newConversationId);
           sessionStreamsRef.current.delete(activeStreamKey);
           setIsStreaming(false);
         }, 500);
+        forcedStopTimersRef.current.set(newConversationId, forcedStopTimer);
       } catch (err) {
         console.error("[useChat] Failed to send message:", err);
+        clearConversationTimers(newConversationId);
         const activeStreamKey = activeStreamsRef.current.get(newConversationId) ?? streamKey;
         activeStreamsRef.current.delete(newConversationId);
         const errorHandled = sessionStreamsRef.current.get(activeStreamKey)?.errorHandled ?? false;
@@ -343,7 +416,16 @@ export function useChat(
         handledErrorConversationsRef.current.delete(newConversationId);
       }
     },
-    [projectId, sessionId, messages, isStreaming, explore, taskId, onSessionResolved],
+    [
+      projectId,
+      sessionId,
+      messages,
+      isStreaming,
+      explore,
+      taskId,
+      onSessionResolved,
+      clearConversationTimers,
+    ],
   );
 
   const clearMessages = useCallback(() => {

--- a/packages/web/src/hooks/useChatSessions.ts
+++ b/packages/web/src/hooks/useChatSessions.ts
@@ -1,13 +1,19 @@
 import { useState, useCallback, useEffect } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import type { ChatSession, ChatSessionMessage } from "@aif/shared/browser";
-import { api } from "../lib/api.js";
+import { api } from "@/lib/api";
 
 export function useChatSessions(projectId: string | null) {
   const queryClient = useQueryClient();
-  const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
-  // When true, user explicitly started a new chat — don't auto-select
-  const [newChatMode, setNewChatMode] = useState(false);
+  const [activeSessionScope, setActiveSessionScope] = useState<{
+    projectId: string | null;
+    sessionId: string | null;
+  }>({
+    projectId: null,
+    sessionId: null,
+  });
+  // When true, user explicitly started a new chat - don't auto-select
+  const [newChatScopeProjectId, setNewChatScopeProjectId] = useState<string | null>(null);
 
   const sessionsQuery = useQuery<ChatSession[]>({
     queryKey: ["chatSessions", projectId],
@@ -16,6 +22,10 @@ export function useChatSessions(projectId: string | null) {
     staleTime: 2_000,
   });
 
+  const activeSessionId =
+    activeSessionScope.projectId === projectId ? activeSessionScope.sessionId : null;
+  const newChatMode = newChatScopeProjectId === projectId;
+
   // Auto-select the most recent session when sessions load and none is active
   const resolvedSessionId =
     activeSessionId ?? (newChatMode ? null : (sessionsQuery.data?.[0]?.id ?? null));
@@ -23,9 +33,9 @@ export function useChatSessions(projectId: string | null) {
   // Pin the auto-selected session so it doesn't shift when the sessions list refetches
   const pinActiveSession = useCallback(() => {
     if (!activeSessionId && resolvedSessionId) {
-      setActiveSessionId(resolvedSessionId);
+      setActiveSessionScope({ projectId, sessionId: resolvedSessionId });
     }
-  }, [activeSessionId, resolvedSessionId]);
+  }, [activeSessionId, projectId, resolvedSessionId]);
 
   // Listen for WS events to invalidate sessions
   useEffect(() => {
@@ -47,7 +57,8 @@ export function useChatSessions(projectId: string | null) {
     onSuccess: (session) => {
       console.debug("[useChatSessions] Created session %s", session.id);
       queryClient.invalidateQueries({ queryKey: ["chatSessions", projectId] });
-      setActiveSessionId(session.id);
+      setNewChatScopeProjectId(null);
+      setActiveSessionScope({ projectId, sessionId: session.id });
     },
   });
 
@@ -58,7 +69,7 @@ export function useChatSessions(projectId: string | null) {
       queryClient.invalidateQueries({ queryKey: ["chatSessions", projectId] });
       if (activeSessionId === deletedId) {
         const remaining = sessionsQuery.data?.filter((s) => s.id !== deletedId) ?? [];
-        setActiveSessionId(remaining[0]?.id ?? null);
+        setActiveSessionScope({ projectId, sessionId: remaining[0]?.id ?? null });
       }
     },
   });
@@ -94,15 +105,18 @@ export function useChatSessions(projectId: string | null) {
     [],
   );
 
-  const selectSession = useCallback((id: string) => {
-    setNewChatMode(false);
-    setActiveSessionId(id);
-  }, []);
+  const selectSession = useCallback(
+    (id: string) => {
+      setNewChatScopeProjectId(null);
+      setActiveSessionScope({ projectId, sessionId: id });
+    },
+    [projectId],
+  );
 
   const clearActiveSession = useCallback(() => {
-    setNewChatMode(true);
-    setActiveSessionId(null);
-  }, []);
+    setNewChatScopeProjectId(projectId);
+    setActiveSessionScope({ projectId, sessionId: null });
+  }, [projectId]);
 
   return {
     sessions: sessionsQuery.data ?? [],

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -357,6 +357,7 @@ export const api = {
   sendChatMessage(input: ChatRequest): Promise<{
     conversationId: string;
     sessionId: string | null;
+    assistantMessage?: string | null;
     attachments?: ChatMessageAttachment[];
   }> {
     console.debug("[api] POST /chat", {
@@ -367,6 +368,7 @@ export const api = {
     return request<{
       conversationId: string;
       sessionId: string | null;
+      assistantMessage?: string | null;
       attachments?: ChatMessageAttachment[];
     }>(
       "/chat",


### PR DESCRIPTION
## What changed

- Made `clientId` optional for chat requests so `/chat` can still work before the WebSocket handshake completes.
- Added HTTP fallback for assistant replies: the API now returns `assistantMessage`, and the client uses it when WS tokens are unavailable.
- Updated the chat client to wait briefly for `clientId`, sync the resolved `sessionId` after the first send, and keep the UI responsive even if stream events are delayed or missing.
- Scoped chat sessions to the current project in the UI and made the project context explicit in the chat header and session sidebar.

## Why

Chat could silently fail from the user's perspective when the frontend depended on WebSocket-only delivery.
This change makes chat resilient when WS is unavailable or late, and removes ambiguity about which project the current chat belongs to.

## Validation

- `npm run lint`
- `npm test`
