### PR TITLE
fix(web): allowed hosts example for dev behind a reverse proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@
 PORT=3009
 # WEB_PORT=5180
 # WEB_HOST=localhost
+#
+# Change this if you're running handoff in DEV mode behind a reverse proxy.
+# __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS=handoff.example.com
 DATABASE_URL=./data/aif.sqlite
 
 # ----------------------------------------------------------


### PR DESCRIPTION
## Summary

- Document the allowed hosts env var for DEV reverse proxy setups

## Changes

Added a commented example for `__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS` to the env configuration with a short note explaining when it should be used.

This makes the DEV reverse proxy setup easier to discover and helps avoid Vite host blocking issues when handoff is accessed through an external domain.

## AI Model

Which AI model was used to generate or assist with this code?

- [ ] Claude Opus 4.6
- [ ] Claude Sonnet 4.6
- [ ] Claude Haiku 4.5
- [x] Other: GPT-5.4 Thinking
- [ ] No AI used

## Test Plan

- [ ] Tests pass (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable)
- [x] Manually verified the change works as expected