### PR TITLE
Fix `handoff` MCP integration with Codex over `stdio`.

### DIFF
--- a/docs/mcp-sync.md
+++ b/docs/mcp-sync.md
@@ -26,9 +26,11 @@ Configured in `.mcp.json` at the project root (already included in the repositor
       "args": ["tsx", "packages/mcp/src/index.ts"],
       "cwd": "/absolute/path/to/aif-handoff",
       "env": {
+        "MCP_TRANSPORT": "stdio",
         "DATABASE_URL": "/absolute/path/to/aif-handoff/data/aif.sqlite",
         "PROJECTS_DIR": "/absolute/path/to/aif-handoff/.projects",
-        "LOG_LEVEL": "info"
+        "LOG_LEVEL": "info",
+        "LOG_DESTINATION": "stderr"
       }
     }
   }
@@ -36,6 +38,8 @@ Configured in `.mcp.json` at the project root (already included in the repositor
 ```
 
 > **Important:** Use absolute paths for `cwd`, `DATABASE_URL`, and `PROJECTS_DIR`. Relative paths won't resolve correctly because the MCP process cwd is not guaranteed to be the project root.
+>
+> **Important for Codex stdio:** set `LOG_DESTINATION=stderr`. MCP over stdio reserves `stdout` for protocol messages; regular app logs on `stdout` will break the handshake.
 
 Claude Code auto-discovers the Handoff MCP server from `.mcp.json` — no build step required.
 

--- a/docs/mcp-sync.md
+++ b/docs/mcp-sync.md
@@ -40,6 +40,8 @@ Configured in `.mcp.json` at the project root (already included in the repositor
 > **Important:** Use absolute paths for `cwd`, `DATABASE_URL`, and `PROJECTS_DIR`. Relative paths won't resolve correctly because the MCP process cwd is not guaranteed to be the project root.
 >
 > **Important for Codex stdio:** set `LOG_DESTINATION=stderr`. MCP over stdio reserves `stdout` for protocol messages; regular app logs on `stdout` will break the handshake.
+>
+> **Security note:** values placed in MCP `env` are stored in plain text in local client config files such as `~/.codex/config.toml`, so do not put long-lived secrets there unless you accept that on-disk exposure.
 
 Claude Code auto-discovers the Handoff MCP server from `.mcp.json` — no build step required.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9361,6 +9361,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/smol-toml": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
     "node_modules/sonic-boom": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
@@ -11231,7 +11243,8 @@
       "dependencies": {
         "@aif/shared": "*",
         "@anthropic-ai/claude-agent-sdk": "0.2.90",
-        "@openai/codex-sdk": "^0.118.0"
+        "@openai/codex-sdk": "^0.118.0",
+        "smol-toml": "^1.6.1"
       },
       "devDependencies": {
         "typescript": "^5.9.3",

--- a/packages/api/src/routes/settings.ts
+++ b/packages/api/src/routes/settings.ts
@@ -19,9 +19,11 @@ function buildMcpServerEntry() {
     args: ["tsx", join(MONOREPO_ROOT, "packages/mcp/src/index.ts")],
     cwd: MONOREPO_ROOT,
     env: {
+      MCP_TRANSPORT: "stdio",
       DATABASE_URL: join(MONOREPO_ROOT, env.DATABASE_URL),
       PROJECTS_DIR: join(MONOREPO_ROOT, process.env.PROJECTS_DIR || ".projects"),
       LOG_LEVEL: "info",
+      LOG_DESTINATION: "stderr",
     },
   };
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -20,7 +20,8 @@
   "dependencies": {
     "@aif/shared": "*",
     "@anthropic-ai/claude-agent-sdk": "0.2.90",
-    "@openai/codex-sdk": "^0.118.0"
+    "@openai/codex-sdk": "^0.118.0",
+    "smol-toml": "^1.6.1"
   },
   "devDependencies": {
     "typescript": "^5.9.3",

--- a/packages/runtime/src/__tests__/codexMcp.test.ts
+++ b/packages/runtime/src/__tests__/codexMcp.test.ts
@@ -20,7 +20,8 @@ vi.mock("node:os", () => ({
   homedir: () => homedirMock(),
 }));
 
-const { getCodexMcpStatus, installCodexMcpServer } = await import("../adapters/codex/mcp.js");
+const { getCodexMcpStatus, installCodexMcpServer, uninstallCodexMcpServer } =
+  await import("../adapters/codex/mcp.js");
 
 describe("Codex MCP config", () => {
   beforeEach(() => {
@@ -42,6 +43,11 @@ describe("Codex MCP config", () => {
         "tsx",
         "E:\\Users\\Daniil\\PhpstormProjects\\aif-handoff\\packages\\mcp\\src\\index.ts",
       ],
+      cwd: "E:\\Users\\Daniil\\PhpstormProjects\\aif-handoff",
+      env: {
+        DATABASE_URL: "E:\\Users\\Daniil\\PhpstormProjects\\aif-handoff\\data\\aif.sqlite",
+        LOG_DESTINATION: "stderr",
+      },
     });
 
     expect(writeFileMock).toHaveBeenCalledTimes(1);
@@ -49,12 +55,23 @@ describe("Codex MCP config", () => {
     expect(content).toContain(
       'args = [ "tsx", "E:\\\\Users\\\\Daniil\\\\PhpstormProjects\\\\aif-handoff\\\\packages\\\\mcp\\\\src\\\\index.ts" ]',
     );
+    expect(content).toContain('cwd = "E:\\\\Users\\\\Daniil\\\\PhpstormProjects\\\\aif-handoff"');
+    expect(content).toContain("[mcp_servers.handoff.env]");
+    expect(content).toContain(
+      'DATABASE_URL = "E:\\\\Users\\\\Daniil\\\\PhpstormProjects\\\\aif-handoff\\\\data\\\\aif.sqlite"',
+    );
+    expect(content).toContain('LOG_DESTINATION = "stderr"');
   });
 
   it("reads escaped Windows paths back from TOML", async () => {
     readFileMock.mockResolvedValue(`[mcp_servers.handoff]
 command = "npx"
 args = [ "tsx", "E:\\\\Users\\\\Daniil\\\\PhpstormProjects\\\\aif-handoff\\\\packages\\\\mcp\\\\src\\\\index.ts" ]
+cwd = "E:\\\\Users\\\\Daniil\\\\PhpstormProjects\\\\aif-handoff"
+
+[mcp_servers.handoff.env]
+DATABASE_URL = "E:\\\\Users\\\\Daniil\\\\PhpstormProjects\\\\aif-handoff\\\\data\\\\aif.sqlite"
+LOG_DESTINATION = "stderr"
 `);
 
     const status = await getCodexMcpStatus({ serverName: "handoff" });
@@ -66,6 +83,41 @@ args = [ "tsx", "E:\\\\Users\\\\Daniil\\\\PhpstormProjects\\\\aif-handoff\\\\pac
         "tsx",
         "E:\\Users\\Daniil\\PhpstormProjects\\aif-handoff\\packages\\mcp\\src\\index.ts",
       ],
+      cwd: "E:\\Users\\Daniil\\PhpstormProjects\\aif-handoff",
+      env: {
+        DATABASE_URL: "E:\\Users\\Daniil\\PhpstormProjects\\aif-handoff\\data\\aif.sqlite",
+        LOG_DESTINATION: "stderr",
+      },
     });
+  });
+
+  it("removes the full server block without leaving args array fragments", async () => {
+    readFileMock.mockResolvedValue(`[mcp_servers.yougile]
+command = "node"
+args = [ "C:\\\\projects\\\\yougile-mcp\\\\yougile.cjs" ]
+
+[mcp_servers.handoff]
+command = "npx"
+args = [ "tsx", "C:\\\\projects\\\\aifhub\\\\aif-handoff\\\\packages\\\\mcp\\\\src\\\\index.ts" ]
+cwd = "C:\\\\projects\\\\aifhub\\\\aif-handoff"
+
+[mcp_servers.handoff.env]
+DATABASE_URL = "C:\\\\projects\\\\aifhub\\\\aif-handoff\\\\data\\\\aif.sqlite"
+LOG_DESTINATION = "stderr"
+
+[plugins."github@openai-curated"]
+enabled = true
+`);
+
+    await uninstallCodexMcpServer({ serverName: "handoff" });
+
+    expect(writeFileMock).toHaveBeenCalledTimes(1);
+    const [, content] = writeFileMock.mock.calls[0] as [string, string];
+    expect(content).toContain("[mcp_servers.yougile]");
+    expect(content).toContain('[plugins."github@openai-curated"]');
+    expect(content).not.toContain("[mcp_servers.handoff]");
+    expect(content).not.toContain("[mcp_servers.handoff.env]");
+    expect(content).not.toContain('args = [ "tsx"');
+    expect(content).not.toContain('cwd = "C:\\\\projects\\\\aifhub\\\\aif-handoff"');
   });
 });

--- a/packages/runtime/src/__tests__/codexMcp.test.ts
+++ b/packages/runtime/src/__tests__/codexMcp.test.ts
@@ -46,6 +46,7 @@ describe("Codex MCP config", () => {
       cwd: "E:\\Users\\Daniil\\PhpstormProjects\\aif-handoff",
       env: {
         DATABASE_URL: "E:\\Users\\Daniil\\PhpstormProjects\\aif-handoff\\data\\aif.sqlite",
+        GREETING: "Привет 👋",
         LOG_DESTINATION: "stderr",
       },
     });
@@ -60,6 +61,7 @@ describe("Codex MCP config", () => {
     expect(content).toContain(
       'DATABASE_URL = "E:\\\\Users\\\\Daniil\\\\PhpstormProjects\\\\aif-handoff\\\\data\\\\aif.sqlite"',
     );
+    expect(content).toContain('GREETING = "Привет 👋"');
     expect(content).toContain('LOG_DESTINATION = "stderr"');
   });
 
@@ -71,6 +73,7 @@ cwd = "E:\\\\Users\\\\Daniil\\\\PhpstormProjects\\\\aif-handoff"
 
 [mcp_servers.handoff.env]
 DATABASE_URL = "E:\\\\Users\\\\Daniil\\\\PhpstormProjects\\\\aif-handoff\\\\data\\\\aif.sqlite"
+GREETING = "Привет 👋"
 LOG_DESTINATION = "stderr"
 `);
 
@@ -86,9 +89,41 @@ LOG_DESTINATION = "stderr"
       cwd: "E:\\Users\\Daniil\\PhpstormProjects\\aif-handoff",
       env: {
         DATABASE_URL: "E:\\Users\\Daniil\\PhpstormProjects\\aif-handoff\\data\\aif.sqlite",
+        GREETING: "Привет 👋",
         LOG_DESTINATION: "stderr",
       },
     });
+  });
+
+  it("reads multiline args arrays back from TOML", async () => {
+    readFileMock.mockResolvedValue(`[mcp_servers.handoff]
+command = "npx"
+args = [
+  "tsx",
+  "C:\\\\projects\\\\aifhub\\\\aif-handoff\\\\packages\\\\mcp\\\\src\\\\index.ts",
+]
+cwd = "C:\\\\projects\\\\aifhub\\\\aif-handoff"
+`);
+
+    const status = await getCodexMcpStatus({ serverName: "handoff" });
+
+    expect(status.installed).toBe(true);
+    expect(status.config).toEqual({
+      command: "npx",
+      args: ["tsx", "C:\\projects\\aifhub\\aif-handoff\\packages\\mcp\\src\\index.ts"],
+      cwd: "C:\\projects\\aifhub\\aif-handoff",
+    });
+  });
+
+  it("ignores env subsections whose server names do not match the main section syntax", async () => {
+    readFileMock.mockResolvedValue(`[mcp_servers.foo.bar.env]
+TOKEN = "secret"
+`);
+
+    const status = await getCodexMcpStatus({ serverName: "foo.bar" });
+
+    expect(status.installed).toBe(false);
+    expect(status.config).toBeNull();
   });
 
   it("removes the full server block without leaving args array fragments", async () => {
@@ -119,5 +154,6 @@ enabled = true
     expect(content).not.toContain("[mcp_servers.handoff.env]");
     expect(content).not.toContain('args = [ "tsx"');
     expect(content).not.toContain('cwd = "C:\\\\projects\\\\aifhub\\\\aif-handoff"');
+    expect(content).not.toContain("\n\n\n");
   });
 });

--- a/packages/runtime/src/adapters/codex/mcp.ts
+++ b/packages/runtime/src/adapters/codex/mcp.ts
@@ -6,6 +6,13 @@ import type { RuntimeMcpInput, RuntimeMcpInstallInput, RuntimeMcpStatus } from "
 
 const CODEX_CONFIG_PATH = join(homedir(), ".codex", "config.toml");
 
+interface CodexMcpServerEntry extends Record<string, unknown> {
+  command: string;
+  args: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+}
+
 /**
  * Minimal TOML parser/writer for Codex MCP config.
  * Only handles the [mcp_servers.<name>] section format.
@@ -24,53 +31,110 @@ function serializeTomlString(value: string): string {
   return JSON.stringify(value);
 }
 
-function parseMcpServers(toml: string): Record<string, { command: string; args: string[] }> {
-  const servers: Record<string, { command: string; args: string[] }> = {};
-  const sectionRegex = /^\[mcp_servers\.([^\]]+)\]\s*$/;
+function parseMcpServers(toml: string): Record<string, CodexMcpServerEntry> {
+  const servers: Record<string, CodexMcpServerEntry> = {};
+  const envSectionRegex = /^\[mcp_servers\.([^\]]+)\.env\]\s*$/;
+  const sectionRegex = /^\[mcp_servers\.([^. \]]+)\]\s*$/;
   let currentName: string | null = null;
-  let currentCommand = "";
-  let currentArgs: string[] = [];
+  let currentSection: "main" | "env" | null = null;
 
   for (const line of toml.split("\n")) {
     const trimmed = line.trim();
-    const sectionMatch = sectionRegex.exec(trimmed);
-    if (sectionMatch) {
-      if (currentName) {
-        servers[currentName] = { command: currentCommand, args: currentArgs };
-      }
-      currentName = sectionMatch[1];
-      currentCommand = "";
-      currentArgs = [];
+    const envSectionMatch = envSectionRegex.exec(trimmed);
+    if (envSectionMatch) {
+      currentName = envSectionMatch[1];
+      currentSection = "env";
+      servers[currentName] ??= { command: "", args: [], env: {} };
       continue;
     }
+
+    const sectionMatch = sectionRegex.exec(trimmed);
+    if (sectionMatch) {
+      currentName = sectionMatch[1];
+      currentSection = "main";
+      servers[currentName] ??= { command: "", args: [], env: {} };
+      continue;
+    }
+
+    if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+      currentName = null;
+      currentSection = null;
+      continue;
+    }
+
     if (!currentName) continue;
     const kvMatch = trimmed.match(/^(\w+)\s*=\s*(.+)$/);
     if (!kvMatch) continue;
     const [, key, rawValue] = kvMatch;
+
+    if (currentSection === "env") {
+      (servers[currentName].env ??= {})[key] = parseTomlString(rawValue);
+      continue;
+    }
+
     if (key === "command") {
-      currentCommand = parseTomlString(rawValue);
+      servers[currentName].command = parseTomlString(rawValue);
+    } else if (key === "cwd") {
+      servers[currentName].cwd = parseTomlString(rawValue);
     } else if (key === "args") {
       try {
-        currentArgs = JSON.parse(rawValue.replace(/'/g, '"'));
+        servers[currentName].args = JSON.parse(rawValue.replace(/'/g, '"'));
       } catch {
-        currentArgs = [];
+        servers[currentName].args = [];
       }
     }
   }
-  if (currentName) {
-    servers[currentName] = { command: currentCommand, args: currentArgs };
-  }
+
   return servers;
 }
 
-function serializeMcpSection(name: string, entry: { command: string; args?: string[] }): string {
+function serializeMcpSection(name: string, entry: CodexMcpServerEntry): string {
   const lines = [`[mcp_servers.${name}]`];
   lines.push(`command = ${serializeTomlString(entry.command)}`);
   if (entry.args && entry.args.length > 0) {
     const argsStr = entry.args.map((a) => serializeTomlString(a)).join(", ");
     lines.push(`args = [ ${argsStr} ]`);
   }
+  if (entry.cwd) {
+    lines.push(`cwd = ${serializeTomlString(entry.cwd)}`);
+  }
+  if (entry.env && Object.keys(entry.env).length > 0) {
+    lines.push("");
+    lines.push(`[mcp_servers.${name}.env]`);
+    for (const [envKey, envValue] of Object.entries(entry.env).sort(([a], [b]) =>
+      a.localeCompare(b),
+    )) {
+      lines.push(`${envKey} = ${serializeTomlString(envValue)}`);
+    }
+  }
   return lines.join("\n");
+}
+
+function removeServerSections(toml: string, serverName: string): string {
+  const mainSectionHeader = `[mcp_servers.${serverName}]`;
+  const envSectionHeader = `[mcp_servers.${serverName}.env]`;
+  const sectionHeaderRegex = /^\[[^\]]+\]\s*$/;
+  const keptLines: string[] = [];
+  let skipping = false;
+
+  for (const line of toml.split("\n")) {
+    const trimmed = line.trim();
+
+    if (trimmed === mainSectionHeader || trimmed === envSectionHeader) {
+      skipping = true;
+      continue;
+    }
+
+    if (skipping && sectionHeaderRegex.test(trimmed)) {
+      skipping = false;
+    }
+
+    if (!skipping) {
+      keptLines.push(line);
+    }
+  }
+
+  return keptLines.join("\n").trim();
 }
 
 async function readToml(): Promise<string> {
@@ -102,17 +166,13 @@ export async function getCodexMcpStatus(input: RuntimeMcpInput): Promise<Runtime
 
 export async function installCodexMcpServer(input: RuntimeMcpInstallInput): Promise<void> {
   let toml = await readToml();
-  const servers = parseMcpServers(toml);
-
-  // Remove existing section if present
-  if (input.serverName in servers) {
-    const sectionRegex = new RegExp(`\\[mcp_servers\\.${input.serverName}\\][^\\[]*`, "g");
-    toml = toml.replace(sectionRegex, "").trim();
-  }
+  toml = removeServerSections(toml, input.serverName);
 
   const section = serializeMcpSection(input.serverName, {
     command: input.command,
-    args: input.args,
+    args: input.args ?? [],
+    cwd: input.cwd,
+    env: input.env,
   });
 
   toml = toml ? `${toml}\n\n${section}\n` : `${section}\n`;
@@ -120,8 +180,6 @@ export async function installCodexMcpServer(input: RuntimeMcpInstallInput): Prom
 }
 
 export async function uninstallCodexMcpServer(input: RuntimeMcpInput): Promise<void> {
-  let toml = await readToml();
-  const sectionRegex = new RegExp(`\\[mcp_servers\\.${input.serverName}\\][^\\[]*`, "g");
-  toml = toml.replace(sectionRegex, "").trim();
+  const toml = removeServerSections(await readToml(), input.serverName);
   await writeToml(toml ? `${toml}\n` : "");
 }

--- a/packages/runtime/src/adapters/codex/mcp.ts
+++ b/packages/runtime/src/adapters/codex/mcp.ts
@@ -2,6 +2,7 @@ import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, dirname } from "node:path";
+import { parse as parseToml, stringify as stringifyToml } from "smol-toml";
 import type { RuntimeMcpInput, RuntimeMcpInstallInput, RuntimeMcpStatus } from "../../types.js";
 
 const CODEX_CONFIG_PATH = join(homedir(), ".codex", "config.toml");
@@ -13,101 +14,102 @@ interface CodexMcpServerEntry extends Record<string, unknown> {
   env?: Record<string, string>;
 }
 
-/**
- * Minimal TOML parser/writer for Codex MCP config.
- * Only handles the [mcp_servers.<name>] section format.
- * Does not depend on a full TOML library.
- */
-
-function parseTomlString(rawValue: string): string {
-  try {
-    return JSON.parse(rawValue);
-  } catch {
-    return rawValue.replace(/^"(.*)"$/, "$1");
-  }
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function serializeTomlString(value: string): string {
-  return JSON.stringify(value);
+function normalizeStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function normalizeEnv(value: unknown): Record<string, string> | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const entries = Object.entries(value).filter(
+    (entry): entry is [string, string] => typeof entry[1] === "string",
+  );
+  if (entries.length === 0) {
+    return undefined;
+  }
+
+  return Object.fromEntries(entries.sort(([a], [b]) => a.localeCompare(b))) as Record<
+    string,
+    string
+  >;
+}
+
+function normalizeServerEntry(value: unknown): CodexMcpServerEntry | null {
+  if (!isRecord(value) || typeof value.command !== "string") {
+    return null;
+  }
+
+  const entry: CodexMcpServerEntry = {
+    command: value.command,
+    args: normalizeStringArray(value.args),
+  };
+
+  if (typeof value.cwd === "string") {
+    entry.cwd = value.cwd;
+  }
+
+  const env = normalizeEnv(value.env);
+  if (env) {
+    entry.env = env;
+  }
+
+  return entry;
 }
 
 function parseMcpServers(toml: string): Record<string, CodexMcpServerEntry> {
-  const servers: Record<string, CodexMcpServerEntry> = {};
-  const envSectionRegex = /^\[mcp_servers\.([^\]]+)\.env\]\s*$/;
-  const sectionRegex = /^\[mcp_servers\.([^. \]]+)\]\s*$/;
-  let currentName: string | null = null;
-  let currentSection: "main" | "env" | null = null;
-
-  for (const line of toml.split("\n")) {
-    const trimmed = line.trim();
-    const envSectionMatch = envSectionRegex.exec(trimmed);
-    if (envSectionMatch) {
-      currentName = envSectionMatch[1];
-      currentSection = "env";
-      servers[currentName] ??= { command: "", args: [], env: {} };
-      continue;
-    }
-
-    const sectionMatch = sectionRegex.exec(trimmed);
-    if (sectionMatch) {
-      currentName = sectionMatch[1];
-      currentSection = "main";
-      servers[currentName] ??= { command: "", args: [], env: {} };
-      continue;
-    }
-
-    if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
-      currentName = null;
-      currentSection = null;
-      continue;
-    }
-
-    if (!currentName) continue;
-    const kvMatch = trimmed.match(/^(\w+)\s*=\s*(.+)$/);
-    if (!kvMatch) continue;
-    const [, key, rawValue] = kvMatch;
-
-    if (currentSection === "env") {
-      (servers[currentName].env ??= {})[key] = parseTomlString(rawValue);
-      continue;
-    }
-
-    if (key === "command") {
-      servers[currentName].command = parseTomlString(rawValue);
-    } else if (key === "cwd") {
-      servers[currentName].cwd = parseTomlString(rawValue);
-    } else if (key === "args") {
-      try {
-        servers[currentName].args = JSON.parse(rawValue.replace(/'/g, '"'));
-      } catch {
-        servers[currentName].args = [];
-      }
-    }
+  if (!toml.trim()) {
+    return {};
   }
 
-  return servers;
+  try {
+    const parsed = parseToml(toml) as { mcp_servers?: unknown };
+    if (!isRecord(parsed.mcp_servers)) {
+      return {};
+    }
+
+    const servers: Record<string, CodexMcpServerEntry> = {};
+    for (const [name, value] of Object.entries(parsed.mcp_servers)) {
+      const entry = normalizeServerEntry(value);
+      if (entry) {
+        servers[name] = entry;
+      }
+    }
+
+    return servers;
+  } catch {
+    return {};
+  }
 }
 
 function serializeMcpSection(name: string, entry: CodexMcpServerEntry): string {
-  const lines = [`[mcp_servers.${name}]`];
-  lines.push(`command = ${serializeTomlString(entry.command)}`);
-  if (entry.args && entry.args.length > 0) {
-    const argsStr = entry.args.map((a) => serializeTomlString(a)).join(", ");
-    lines.push(`args = [ ${argsStr} ]`);
+  const serverConfig: Record<string, unknown> = { command: entry.command };
+  if (entry.args.length > 0) {
+    serverConfig.args = entry.args;
   }
   if (entry.cwd) {
-    lines.push(`cwd = ${serializeTomlString(entry.cwd)}`);
+    serverConfig.cwd = entry.cwd;
   }
   if (entry.env && Object.keys(entry.env).length > 0) {
-    lines.push("");
-    lines.push(`[mcp_servers.${name}.env]`);
-    for (const [envKey, envValue] of Object.entries(entry.env).sort(([a], [b]) =>
-      a.localeCompare(b),
-    )) {
-      lines.push(`${envKey} = ${serializeTomlString(envValue)}`);
-    }
+    serverConfig.env = Object.fromEntries(
+      Object.entries(entry.env).sort(([a], [b]) => a.localeCompare(b)),
+    );
   }
-  return lines.join("\n");
+
+  return stringifyToml({
+    mcp_servers: {
+      [name]: serverConfig,
+    },
+  }).trim();
 }
 
 function removeServerSections(toml: string, serverName: string): string {
@@ -134,7 +136,10 @@ function removeServerSections(toml: string, serverName: string): string {
     }
   }
 
-  return keptLines.join("\n").trim();
+  return keptLines
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
 }
 
 async function readToml(): Promise<string> {

--- a/packages/shared/src/__tests__/loadEnv.test.ts
+++ b/packages/shared/src/__tests__/loadEnv.test.ts
@@ -1,15 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const existsSyncMock = vi.fn<(path: string) => boolean>();
-const dotenvConfigMock = vi.fn<(options: { path: string; override?: boolean }) => void>();
-const findMonorepoRootFromUrlMock = vi.fn<(url: string) => string>();
+const existsSyncMock = vi.fn();
+const readFileSyncMock = vi.fn();
+const dotenvParseMock = vi.fn();
+const findMonorepoRootFromUrlMock = vi.fn();
 
 vi.mock("node:fs", () => ({
   existsSync: existsSyncMock,
+  readFileSync: readFileSyncMock,
 }));
 
 vi.mock("dotenv", () => ({
-  config: dotenvConfigMock,
+  parse: dotenvParseMock,
 }));
 
 vi.mock("../monorepoRoot.js", () => ({
@@ -19,24 +21,75 @@ vi.mock("../monorepoRoot.js", () => ({
 describe("loadEnv", () => {
   beforeEach(() => {
     vi.resetModules();
+    vi.unstubAllEnvs();
     existsSyncMock.mockReset();
-    dotenvConfigMock.mockReset();
+    readFileSyncMock.mockReset();
+    dotenvParseMock.mockReset();
     findMonorepoRootFromUrlMock.mockReset();
     findMonorepoRootFromUrlMock.mockReturnValue("/repo-root");
+    delete process.env.NODE_ENV;
+    delete process.env.LOG_LEVEL;
+    delete process.env.DATABASE_URL;
+    delete process.env.API_BASE_URL;
   });
 
   it("skips dotenv loading in test environment (VITEST is set)", async () => {
-    // VITEST env var is always set by vitest runner, so loadEnv skips loading
     existsSyncMock.mockReturnValue(true);
     await import("../loadEnv.js");
 
-    expect(dotenvConfigMock).not.toHaveBeenCalled();
+    expect(dotenvParseMock).not.toHaveBeenCalled();
   });
 
   it("skips dotenv loading when root env files are missing", async () => {
+    process.env.VITEST = "";
+    process.env.NODE_ENV = "development";
     existsSyncMock.mockReturnValue(false);
     await import("../loadEnv.js");
 
-    expect(dotenvConfigMock).not.toHaveBeenCalled();
+    expect(dotenvParseMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves explicit process env values over .env files", async () => {
+    process.env.VITEST = "";
+    process.env.NODE_ENV = "development";
+    process.env.DATABASE_URL = "C:/explicit/db.sqlite";
+
+    existsSyncMock.mockImplementation((path: string) => String(path).endsWith(".env"));
+    readFileSyncMock.mockReturnValue("DATABASE_URL=/repo-root/data/aif.sqlite\nLOG_LEVEL=debug\n");
+    dotenvParseMock.mockReturnValue({
+      DATABASE_URL: "/repo-root/data/aif.sqlite",
+      LOG_LEVEL: "debug",
+    });
+
+    await import("../loadEnv.js");
+
+    expect(process.env.DATABASE_URL).toBe("C:/explicit/db.sqlite");
+    expect(process.env.LOG_LEVEL).toBe("debug");
+    expect(readFileSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it(".env.local overrides .env values, but not explicit process env", async () => {
+    process.env.VITEST = "";
+    process.env.NODE_ENV = "development";
+    process.env.API_BASE_URL = "http://explicit-host:3009";
+
+    existsSyncMock.mockReturnValue(true);
+    readFileSyncMock
+      .mockReturnValueOnce("LOG_LEVEL=info\nAPI_BASE_URL=http://from-env:3009\n")
+      .mockReturnValueOnce("LOG_LEVEL=trace\nAPI_BASE_URL=http://from-env-local:3009\n");
+    dotenvParseMock
+      .mockReturnValueOnce({
+        LOG_LEVEL: "info",
+        API_BASE_URL: "http://from-env:3009",
+      })
+      .mockReturnValueOnce({
+        LOG_LEVEL: "trace",
+        API_BASE_URL: "http://from-env-local:3009",
+      });
+
+    await import("../loadEnv.js");
+
+    expect(process.env.LOG_LEVEL).toBe("trace");
+    expect(process.env.API_BASE_URL).toBe("http://explicit-host:3009");
   });
 });

--- a/packages/shared/src/__tests__/loadEnv.test.ts
+++ b/packages/shared/src/__tests__/loadEnv.test.ts
@@ -41,7 +41,7 @@ describe("loadEnv", () => {
   });
 
   it("skips dotenv loading when root env files are missing", async () => {
-    process.env.VITEST = "";
+    delete process.env.VITEST;
     process.env.NODE_ENV = "development";
     existsSyncMock.mockReturnValue(false);
     await import("../loadEnv.js");
@@ -50,7 +50,7 @@ describe("loadEnv", () => {
   });
 
   it("preserves explicit process env values over .env files", async () => {
-    process.env.VITEST = "";
+    delete process.env.VITEST;
     process.env.NODE_ENV = "development";
     process.env.DATABASE_URL = "C:/explicit/db.sqlite";
 
@@ -69,7 +69,7 @@ describe("loadEnv", () => {
   });
 
   it(".env.local overrides .env values, but not explicit process env", async () => {
-    process.env.VITEST = "";
+    delete process.env.VITEST;
     process.env.NODE_ENV = "development";
     process.env.API_BASE_URL = "http://explicit-host:3009";
 

--- a/packages/shared/src/__tests__/logger.test.ts
+++ b/packages/shared/src/__tests__/logger.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { resolveLogDestination } from "../logger.js";
+
+describe("logger", () => {
+  it("defaults to stdout when LOG_DESTINATION is not set", () => {
+    expect(resolveLogDestination({})).toBe(1);
+  });
+
+  it("routes logs to stderr when LOG_DESTINATION=stderr", () => {
+    expect(resolveLogDestination({ LOG_DESTINATION: "stderr" })).toBe(2);
+  });
+
+  it("accepts numeric stderr destination values", () => {
+    expect(resolveLogDestination({ LOG_DESTINATION: "2" })).toBe(2);
+  });
+});

--- a/packages/shared/src/__tests__/logger.test.ts
+++ b/packages/shared/src/__tests__/logger.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveLogDestination } from "../logger.js";
+import { resolveLogDestination, resolveLogDestinationConfig } from "../logger.js";
 
 describe("logger", () => {
   it("defaults to stdout when LOG_DESTINATION is not set", () => {
@@ -12,5 +12,21 @@ describe("logger", () => {
 
   it("accepts numeric stderr destination values", () => {
     expect(resolveLogDestination({ LOG_DESTINATION: "2" })).toBe(2);
+  });
+
+  it("uses sync destination outside production", () => {
+    expect(resolveLogDestinationConfig({ NODE_ENV: "development" })).toEqual({
+      dest: 1,
+      sync: true,
+    });
+  });
+
+  it("uses async destination in production", () => {
+    expect(
+      resolveLogDestinationConfig({ NODE_ENV: "production", LOG_DESTINATION: "stderr" }),
+    ).toEqual({
+      dest: 2,
+      sync: false,
+    });
   });
 });

--- a/packages/shared/src/loadEnv.ts
+++ b/packages/shared/src/loadEnv.ts
@@ -1,6 +1,6 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { config as dotenvConfig } from "dotenv";
+import { parse as parseDotenv } from "dotenv";
 import { findMonorepoRootFromUrl } from "./monorepoRoot.js";
 
 const MONOREPO_ROOT = findMonorepoRootFromUrl(import.meta.url);
@@ -12,21 +12,30 @@ let envLoaded = false;
 /**
  * Load root-level .env files once for all Node packages.
  * .env is loaded first, then .env.local overrides it when present.
+ * Explicit process env wins over both files.
  */
 export function ensureRootEnvLoaded(): void {
   if (envLoaded) return;
 
-  // Skip loading .env files during test runs — tests control env via vi.stubEnv / process.env
+  // Skip loading .env files during test runs - tests control env via vi.stubEnv / process.env
   if (process.env.VITEST || process.env.NODE_ENV === "test") {
     envLoaded = true;
     return;
   }
 
+  const resolvedEnv: Record<string, string> = {};
+
   if (existsSync(ROOT_ENV_PATH)) {
-    dotenvConfig({ path: ROOT_ENV_PATH, override: true });
+    Object.assign(resolvedEnv, parseDotenv(readFileSync(ROOT_ENV_PATH)));
   }
   if (existsSync(ROOT_ENV_LOCAL_PATH)) {
-    dotenvConfig({ path: ROOT_ENV_LOCAL_PATH, override: true });
+    Object.assign(resolvedEnv, parseDotenv(readFileSync(ROOT_ENV_LOCAL_PATH)));
+  }
+
+  for (const [key, value] of Object.entries(resolvedEnv)) {
+    if (process.env[key] === undefined) {
+      process.env[key] = value;
+    }
   }
 
   envLoaded = true;

--- a/packages/shared/src/logger.ts
+++ b/packages/shared/src/logger.ts
@@ -3,13 +3,12 @@ import "./loadEnv.js";
 
 const level = process.env.LOG_LEVEL ?? "debug";
 
-const rootLogger = pino({
-  level,
-  transport:
-    process.env.NODE_ENV !== "production"
-      ? { target: "pino/file", options: { destination: 1 } }
-      : undefined,
-});
+export function resolveLogDestination(env: NodeJS.ProcessEnv = process.env): 1 | 2 {
+  const destination = env.LOG_DESTINATION?.trim().toLowerCase();
+  return destination === "stderr" || destination === "2" ? 2 : 1;
+}
+
+const rootLogger = pino({ level }, pino.destination(resolveLogDestination()));
 
 /** Create a child logger with a component name */
 export function logger(component: string): pino.Logger {

--- a/packages/shared/src/logger.ts
+++ b/packages/shared/src/logger.ts
@@ -8,7 +8,17 @@ export function resolveLogDestination(env: NodeJS.ProcessEnv = process.env): 1 |
   return destination === "stderr" || destination === "2" ? 2 : 1;
 }
 
-const rootLogger = pino({ level }, pino.destination(resolveLogDestination()));
+export function resolveLogDestinationConfig(env: NodeJS.ProcessEnv = process.env): {
+  dest: 1 | 2;
+  sync: boolean;
+} {
+  return {
+    dest: resolveLogDestination(env),
+    sync: env.NODE_ENV !== "production",
+  };
+}
+
+const rootLogger = pino({ level }, pino.destination(resolveLogDestinationConfig()));
 
 /** Create a child logger with a component name */
 export function logger(component: string): pino.Logger {


### PR DESCRIPTION
What changed:
- added full MCP config persistence for Codex: it now saves not only `command/args`, but also `cwd/env`
- fixed removal of the `handoff` section from `~/.codex/config.toml` so uninstall no longer leaves behind stray `args`/`cwd` entries
- switched the logger to a managed destination via `LOG_DESTINATION`, so with `stdio` regular logs go to `stderr` instead of breaking the MCP handshake through `stdout`
- changed `.env` loading so explicit environment variables from the MCP config are not overwritten by values from `.env/.env.local`
- updated MCP settings generation and documentation for the current `stdio` schema

Why:
- `handoff` could fail to connect in Codex because `stdout` was polluted
- server env from the MCP config could be lost due to `dotenv override`
- removing MCP via the web UI could leave a broken section in `config.toml`

Verification:
- `npm run test --workspace=@aif/runtime -- codexMcp.test.ts`
- `npm run test --workspace=@aif/runtime`
- manual `handoff` MCP smoke test over `stdio`: `initialize`, `tools/list`, `handoff_list_projects`