### PR TITLE
fix(api): assign unique plan path per task on ROADMAP import

### DIFF
--- a/packages/api/src/__tests__/roadmapGeneration.test.ts
+++ b/packages/api/src/__tests__/roadmapGeneration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { projects } from "@aif/shared";
+import { generatePlanPath, projects } from "@aif/shared";
 import { createTestDb } from "@aif/shared/server";
 import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
@@ -383,6 +383,75 @@ describe("roadmapGeneration", () => {
 
       expect(result.byPhase[1]).toEqual({ created: 1, skipped: 0 });
       expect(result.byPhase[2]).toEqual({ created: 2, skipped: 0 });
+    });
+
+    // Regression: lee-to/aif-handoff#55 — roadmap import used to assign every
+    // task the shared default plan path `.ai-factory/PLAN.md` because
+    // importGeneratedTasks didn't compute a per-task planPath, so successive
+    // tasks would overwrite each other's plan file on disk. The fix derives a
+    // unique slug-based planPath per task while leaving plannerMode untouched.
+    it("should assign a unique per-task planPath on roadmap import (#55)", () => {
+      const { projectId } = createProjectWithRoadmap("# Roadmap");
+
+      const tasks = [
+        {
+          title: "Implement auth flow",
+          description: "JWT + refresh",
+          phase: 1,
+          phaseName: "Backend",
+          sequence: 1,
+        },
+        {
+          title: "Add product search",
+          description: "Postgres FTS",
+          phase: 1,
+          phaseName: "Backend",
+          sequence: 2,
+        },
+        {
+          title: "Build dashboard page",
+          description: "React + Tailwind",
+          phase: 2,
+          phaseName: "Frontend",
+          sequence: 1,
+        },
+      ];
+
+      const result = importGeneratedTasks(projectId, {
+        alias: "v1",
+        tasks,
+      });
+
+      expect(result.created, "all three tasks should be created").toBe(3);
+      expect(result.skipped).toBe(0);
+
+      const stored = findTasksByRoadmapAlias(projectId, "v1");
+      expect(stored).toHaveLength(3);
+
+      const planPaths = stored.map((t) => t.planPath);
+      const uniquePlanPaths = new Set(planPaths);
+      expect(uniquePlanPaths.size, "each imported task must have a distinct planPath").toBe(3);
+
+      for (const path of planPaths) {
+        expect(
+          path,
+          "no imported task should inherit the shared default `.ai-factory/PLAN.md`",
+        ).not.toBe(".ai-factory/PLAN.md");
+        expect(path.startsWith(".ai-factory/plans/")).toBe(true);
+        expect(path.endsWith(".md")).toBe(true);
+      }
+
+      // Each planPath must match the slug computed from the title via the
+      // shared helper — keeps the contract with `generatePlanPath` explicit.
+      for (const task of tasks) {
+        const expectedPath = generatePlanPath(task.title, "full", {
+          plansDir: ".ai-factory/plans/",
+          defaultPlanPath: ".ai-factory/PLAN.md",
+        });
+        const matched = stored.find((t) => t.title === task.title);
+        expect(matched, `task ${task.title} should exist`).toBeDefined();
+        expect(matched?.planPath).toBe(expectedPath);
+      }
     });
   });
 });

--- a/packages/api/src/services/roadmapGeneration.ts
+++ b/packages/api/src/services/roadmapGeneration.ts
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { z } from "zod";
-import { logger, getEnv, getProjectConfig } from "@aif/shared";
+import { logger, getEnv, getProjectConfig, generatePlanPath } from "@aif/shared";
 import {
   createTask,
   findProjectById,
@@ -394,6 +394,18 @@ export function importGeneratedTasks(
 
   log.info({ projectId, alias, totalTasks: generatedTasks.length }, "Starting task import");
 
+  // Resolve project config so every imported task gets a unique slug-based
+  // planPath. Without this each task would fall back to the shared default
+  // `cfg.paths.plan` and overwrite the previous task's plan on disk
+  // (see lee-to/aif-handoff#55). planPath is decoupled from plannerMode here:
+  // the task keeps whatever planner mode the project defaults to, we only
+  // ensure the plan file path itself is unique for bulk imports.
+  const project = findProjectById(projectId);
+  if (!project) {
+    throw new RoadmapGenerationError("PROJECT_NOT_FOUND", `Project ${projectId} not found`);
+  }
+  const cfg = getProjectConfig(project.rootPath);
+
   // Load existing tasks for this alias for dedupe
   const existing = findTasksByRoadmapAlias(projectId, alias);
   const existingTitles = new Set(existing.map((t) => normalizeTitle(t.title)));
@@ -419,12 +431,22 @@ export function importGeneratedTasks(
     }
 
     const tags = buildTaskTags(alias, genTask);
+    // Compute a unique plan path per task using the shared slug helper.
+    // "full" here is just the path-shape selector (`<plansDir>/<slug>.md`),
+    // NOT a planner-mode override — plannerMode is left untouched so the
+    // project/task defaults still apply (fast for regular projects,
+    // parallelEnabled projects already force full via POST /tasks).
+    const planPath = generatePlanPath(genTask.title, "full", {
+      plansDir: cfg.paths.plans,
+      defaultPlanPath: cfg.paths.plan,
+    });
     const created = createTask({
       projectId,
       title: genTask.title,
       description: genTask.description,
       roadmapAlias: alias,
       tags,
+      planPath,
       useSubagents: getEnv().AGENT_USE_SUBAGENTS,
     });
 
@@ -433,12 +455,28 @@ export function importGeneratedTasks(
       phaseStats.created++;
       result.created++;
       existingTitles.add(normalized);
+      log.debug(
+        {
+          id: created.id,
+          title: created.title,
+          planPath: created.planPath,
+          phase: genTask.phase,
+          sequence: genTask.sequence,
+          alias,
+        },
+        "Roadmap task created with unique plan path",
+      );
     }
   }
 
   log.info(
-    { projectId, alias, created: result.created, skipped: result.skipped },
-    "Task import complete",
+    {
+      projectId,
+      alias,
+      created: result.created,
+      skipped: result.skipped,
+    },
+    "Task import complete with distinct plan paths",
   );
 
   return result;


### PR DESCRIPTION
## Summary

Fixes #55 — when importing tasks from `ROADMAP.md` every created task was assigned the same `planPath` (`.ai-factory/PLAN.md`), so successive tasks would overwrite each other's plan file on disk.

`importGeneratedTasks()` in `packages/api/src/services/roadmapGeneration.ts` used to call `createTask()` without a `planPath`, so the SQLite column default from `packages/shared/src/schema.ts` kicked in for every row.

This PR resolves the project config once before the loop and derives a unique slug-based `planPath` per task via the shared `generatePlanPath` helper from `@aif/shared`:

```ts
const planPath = generatePlanPath(genTask.title, "full", {
  plansDir: cfg.paths.plans,
  defaultPlanPath: cfg.paths.plan,
});
```

`plannerMode` is intentionally left untouched — roadmap import is decoupled from planner-mode selection, which is still driven by project defaults and the `parallelEnabled` branch in `packages/api/src/routes/tasks.ts`. Here `"full"` is just the path-shape selector (`<plansDir>/<slug>.md`) for the helper, not a planner-mode override.

## Test plan

- [x] New regression test `should assign a unique per-task planPath on roadmap import (#55)` in `packages/api/src/__tests__/roadmapGeneration.test.ts`:
  - Imports 3 roadmap tasks across multiple phases
  - Asserts every `planPath` is distinct
  - Asserts no task inherits the shared default `.ai-factory/PLAN.md`
  - Asserts every `planPath` starts with `.ai-factory/plans/` and ends with `.md`
  - Asserts every `planPath` matches the reference slug from `generatePlanPath(title, "full", { plansDir, defaultPlanPath })`
- [x] `npm test` — all packages green (`@aif/api`: 196 tests)
- [x] `npm run lint` — zero errors
- [x] `npm run format:check` — clean
- [x] Manual DB verification: no new files are written to `.ai-factory/plans/` by the import itself (`createTask` only stores the path string; the markdown file is created lazily by the planner subagent)

## Non-goals

- DB migration for existing broken rows — forward-only
- Changing the schema default for `plan_path` (still correct for manual fast-flow task creation via `POST /tasks`)
- Touching `plannerMode` during roadmap import — this bug is about the path, not the mode
- Slug collision handling between different titles that `slugify()` to the same string — rare edge case, separate PR if it ever surfaces

Closes #55