### PR TITLE
Fix chat timeout handling and agent polling interval

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2994,13 +2994,6 @@
         "undici-types": "~7.18.0"
       }
     },
-    "node_modules/@types/node-cron": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@types/node-cron/-/node-cron-3.0.11.tgz",
-      "integrity": "sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -8198,15 +8191,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/node-cron": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
-      "integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
@@ -11138,11 +11122,9 @@
       "dependencies": {
         "@aif/data": "*",
         "@aif/runtime": "*",
-        "@aif/shared": "*",
-        "node-cron": "^4.2.1"
+        "@aif/shared": "*"
       },
       "devDependencies": {
-        "@types/node-cron": "^3.0.11",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "vitest": "^4.1.2"

--- a/packages/agent/CHECKLIST.md
+++ b/packages/agent/CHECKLIST.md
@@ -11,6 +11,7 @@ Run through this list whenever you touch anything under `packages/agent/`.
 - [ ] If you added a new subagent, add tests that verify it resolves the correct agent definition and handles the runtime capability fallback.
 - [ ] If you touched the coordinator polling logic, verify the state machine transitions in `@aif/shared/stateMachine.ts` still line up.
 - [ ] Polling intervals are configured in milliseconds. Do not convert values above 59 seconds into a cron step expression.
+- [ ] If you touched the poll scheduler, verify periodic ticks do not overlap while a previous poll callback is still running.
 - [ ] If you touched first-activity watchdog logic, verify streamed runtime events (not only tool/subagent hooks) count as activity for tool-less workflows.
 - [ ] `npm run lint`
 - [ ] `npm test`

--- a/packages/agent/CHECKLIST.md
+++ b/packages/agent/CHECKLIST.md
@@ -11,5 +11,6 @@ Run through this list whenever you touch anything under `packages/agent/`.
 - [ ] If you added a new subagent, add tests that verify it resolves the correct agent definition and handles the runtime capability fallback.
 - [ ] If you touched the coordinator polling logic, verify the state machine transitions in `@aif/shared/stateMachine.ts` still line up.
 - [ ] Polling intervals are configured in milliseconds. Do not convert values above 59 seconds into a cron step expression.
+- [ ] If you touched first-activity watchdog logic, verify streamed runtime events (not only tool/subagent hooks) count as activity for tool-less workflows.
 - [ ] `npm run lint`
 - [ ] `npm test`

--- a/packages/agent/CHECKLIST.md
+++ b/packages/agent/CHECKLIST.md
@@ -10,5 +10,6 @@ Run through this list whenever you touch anything under `packages/agent/`.
 - [ ] All DB access goes through `@aif/data`. No direct drizzle/SQL imports here.
 - [ ] If you added a new subagent, add tests that verify it resolves the correct agent definition and handles the runtime capability fallback.
 - [ ] If you touched the coordinator polling logic, verify the state machine transitions in `@aif/shared/stateMachine.ts` still line up.
+- [ ] Polling intervals are configured in milliseconds. Do not convert values above 59 seconds into a cron step expression.
 - [ ] `npm run lint`
 - [ ] `npm test`

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -17,11 +17,9 @@
   "dependencies": {
     "@aif/data": "*",
     "@aif/runtime": "*",
-    "@aif/shared": "*",
-    "node-cron": "^4.2.1"
+    "@aif/shared": "*"
   },
   "devDependencies": {
-    "@types/node-cron": "^3.0.11",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vitest": "^4.1.2"

--- a/packages/agent/src/__tests__/pollScheduler.test.ts
+++ b/packages/agent/src/__tests__/pollScheduler.test.ts
@@ -36,4 +36,34 @@ describe("pollScheduler", () => {
     await vi.advanceTimersByTimeAsync(600_000);
     expect(callback).toHaveBeenCalledTimes(1);
   });
+
+  it("skips interval ticks while the previous callback is still running", async () => {
+    let resolveCallback: (() => void) | null = null;
+    const callback = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCallback = resolve;
+        }),
+    );
+    const scheduler = startPollScheduler(callback, 10_000);
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    const finishCallback: () => void =
+      resolveCallback ??
+      (() => {
+        throw new Error("Expected callback resolver to be captured");
+      });
+    finishCallback();
+    await Promise.resolve();
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(callback).toHaveBeenCalledTimes(2);
+
+    scheduler.stop();
+  });
 });

--- a/packages/agent/src/__tests__/pollScheduler.test.ts
+++ b/packages/agent/src/__tests__/pollScheduler.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { normalizePollIntervalMs, startPollScheduler } from "../pollScheduler.js";
+
+describe("pollScheduler", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps millisecond intervals above the minimum unchanged", () => {
+    expect(normalizePollIntervalMs(600_000)).toBe(600_000);
+  });
+
+  it("clamps invalid or too-small intervals to the minimum", () => {
+    expect(normalizePollIntervalMs(0)).toBe(10_000);
+    expect(normalizePollIntervalMs(-1)).toBe(10_000);
+    expect(normalizePollIntervalMs(9_999)).toBe(10_000);
+  });
+
+  it("schedules callbacks using the normalized millisecond interval", async () => {
+    const callback = vi.fn();
+    const scheduler = startPollScheduler(callback, 600_000);
+
+    expect(scheduler.intervalMs).toBe(600_000);
+
+    await vi.advanceTimersByTimeAsync(599_999);
+    expect(callback).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    scheduler.stop();
+    await vi.advanceTimersByTimeAsync(600_000);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/agent/src/__tests__/subagentQuery.test.ts
+++ b/packages/agent/src/__tests__/subagentQuery.test.ts
@@ -538,4 +538,44 @@ describe("executeSubagentQuery first-activity watchdog", () => {
     delete mockEnvOverrides.AGENT_FIRST_ACTIVITY_TIMEOUT_MS;
     delete mockEnvOverrides.AGENT_QUERY_START_TIMEOUT_MS;
   }, 10_000);
+
+  it("treats streamed runtime events as activity for tool-less workflows", async () => {
+    mockEnvOverrides.AGENT_FIRST_ACTIVITY_TIMEOUT_MS = 100;
+    mockEnvOverrides.AGENT_QUERY_START_TIMEOUT_MS = 0;
+
+    queryMock.mockImplementation(async function* () {
+      yield {
+        type: "system",
+        subtype: "init",
+        session_id: "session-tool-less",
+      };
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      yield {
+        type: "result",
+        subtype: "success",
+        result: "done-without-tools",
+        usage: {},
+        total_cost_usd: 0,
+      };
+    });
+
+    await expect(
+      executeSubagentQuery({
+        taskId: "task-tool-less",
+        projectRoot: "/tmp/project",
+        agentName: "implement-checklist-sync",
+        prompt: "run",
+        workflowKind: "implementer_checklist_sync",
+      }),
+    ).resolves.toEqual({ resultText: "done-without-tools" });
+
+    expect(queryMock).toHaveBeenCalledTimes(1);
+    const stallLogs = logActivityMock.mock.calls.filter(
+      (call: string[]) => call[1] === "Agent" && call[2]?.includes("stalled"),
+    );
+    expect(stallLogs.length).toBe(0);
+
+    delete mockEnvOverrides.AGENT_FIRST_ACTIVITY_TIMEOUT_MS;
+    delete mockEnvOverrides.AGENT_QUERY_START_TIMEOUT_MS;
+  });
 });

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,4 +1,3 @@
-import cron from "node-cron";
 import { listProjects } from "@aif/data";
 import { getEnv, logger } from "@aif/shared";
 import { bootstrapRuntimeRegistry } from "@aif/runtime";
@@ -6,6 +5,7 @@ import { pollAndProcess, setRuntimeRegistry } from "./coordinator.js";
 import { flushAllActivityQueues } from "./hooks.js";
 import { connectWakeChannel, closeWakeChannel, waitForApiReady } from "./wakeChannel.js";
 import { abortAllActiveStages } from "./stageAbort.js";
+import { startPollScheduler } from "./pollScheduler.js";
 
 const log = logger("agent");
 
@@ -15,11 +15,13 @@ const env = getEnv();
 // Ensure DB is ready
 listProjects();
 
-const intervalMs = env.POLL_INTERVAL_MS;
-const intervalSeconds = Math.max(Math.floor(intervalMs / 1000), 10);
-
-// Convert to cron expression (every N seconds)
-const cronExpr = `*/${intervalSeconds} * * * * *`;
+const pollScheduler = startPollScheduler(async () => {
+  try {
+    await pollAndProcess();
+  } catch (err) {
+    log.error({ err }, "Unexpected error in poll cycle");
+  }
+}, env.POLL_INTERVAL_MS);
 
 // Pre-load runtime registry so project init includes all adapters
 bootstrapRuntimeRegistry({ runtimeModules: env.AIF_RUNTIME_MODULES })
@@ -29,15 +31,13 @@ bootstrapRuntimeRegistry({ runtimeModules: env.AIF_RUNTIME_MODULES })
   })
   .catch((err) => log.warn({ err }, "Failed to pre-load runtime registry"));
 
-log.info({ intervalMs, intervalSeconds, cronExpr }, "Agent coordinator starting");
-
-cron.schedule(cronExpr, async () => {
-  try {
-    await pollAndProcess();
-  } catch (err) {
-    log.error({ err }, "Unexpected error in poll cycle");
-  }
-});
+log.info(
+  {
+    configuredIntervalMs: env.POLL_INTERVAL_MS,
+    intervalMs: pollScheduler.intervalMs,
+  },
+  "Agent coordinator starting",
+);
 
 // ---------------------------------------------------------------------------
 // Event-driven wake: subscribe to API WS for immediate coordinator triggers
@@ -76,6 +76,7 @@ function onShutdown(signal: string): void {
     "Shutdown signal received — aborting stages, closing wake channel, flushing activity queues",
   );
   try {
+    pollScheduler.stop();
     abortAllActiveStages();
     closeWakeChannel();
     flushAllActivityQueues();

--- a/packages/agent/src/pollScheduler.ts
+++ b/packages/agent/src/pollScheduler.ts
@@ -18,8 +18,20 @@ export function startPollScheduler(
   intervalMs: number,
 ): PollScheduler {
   const normalizedIntervalMs = normalizePollIntervalMs(intervalMs);
+  let isRunning = false;
+
+  async function runTick(): Promise<void> {
+    if (isRunning) return;
+    isRunning = true;
+    try {
+      await callback();
+    } finally {
+      isRunning = false;
+    }
+  }
+
   const handle = setInterval(() => {
-    void callback();
+    void runTick();
   }, normalizedIntervalMs);
 
   return {

--- a/packages/agent/src/pollScheduler.ts
+++ b/packages/agent/src/pollScheduler.ts
@@ -1,0 +1,31 @@
+const MIN_POLL_INTERVAL_MS = 10_000;
+
+export interface PollScheduler {
+  intervalMs: number;
+  stop(): void;
+}
+
+export function normalizePollIntervalMs(intervalMs: number): number {
+  if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+    return MIN_POLL_INTERVAL_MS;
+  }
+
+  return Math.max(Math.floor(intervalMs), MIN_POLL_INTERVAL_MS);
+}
+
+export function startPollScheduler(
+  callback: () => void | Promise<void>,
+  intervalMs: number,
+): PollScheduler {
+  const normalizedIntervalMs = normalizePollIntervalMs(intervalMs);
+  const handle = setInterval(() => {
+    void callback();
+  }, normalizedIntervalMs);
+
+  return {
+    intervalMs: normalizedIntervalMs,
+    stop() {
+      clearInterval(handle);
+    },
+  };
+}

--- a/packages/agent/src/subagentQuery.ts
+++ b/packages/agent/src/subagentQuery.ts
@@ -43,7 +43,7 @@ const FIRST_ACTIVITY_TIMEOUT_ERROR = "first_activity_timeout";
 const FIRST_ACTIVITY_MAX_RETRIES = 2;
 
 /**
- * First-activity watchdog: aborts the agent if no tool call or subagent spawn
+ * First-activity watchdog: aborts the agent if no runtime activity
  * arrives within AGENT_FIRST_ACTIVITY_TIMEOUT_MS after "started".
  * Detects hung agents early (~60s) instead of waiting for the 90-min stale timeout.
  */
@@ -455,15 +455,13 @@ export async function executeSubagentQuery(
     // runtime activity in real time. SDK / CLI adapters emit RuntimeEvent
     // callbacks for streamed text, reasoning, and tool summaries, so any such
     // event proves the runtime is alive even if the workflow performs no tool
-    // calls. API transport is
-    // pure HTTP — no intermediate events — and must stay disabled.
+    // calls. API transport is pure HTTP — no intermediate events — and must
+    // stay disabled.
     //
     // CLI gets a 2x buffer over SDK because it carries extra cold-start cost
-    // the SDK path doesn't have: binary spawn (~1-3s), system/init message
-    // with the full tool/MCP catalogue, and — for Codex — model preambles
-    // that stream as agent_message text rather than tool_use events (so they
-    // don't reset the watchdog). Without the buffer, slow first-tool turns
-    // on CLI can false-positive the watchdog.
+    // the SDK path doesn't have: binary spawn (~1-3s) and the initial
+    // system/init exchange with the full tool/MCP catalogue. Without the
+    // buffer, slow first-turn startup on CLI can false-positive the watchdog.
     const baseFirstActivityTimeoutMs = getEnv().AGENT_FIRST_ACTIVITY_TIMEOUT_MS;
     const firstActivityTimeoutMs =
       context.transport === "api"
@@ -473,7 +471,7 @@ export async function executeSubagentQuery(
           : baseFirstActivityTimeoutMs;
     let result: Awaited<ReturnType<RuntimeAdapter["run"]>> | undefined;
 
-    // Retry loop: if agent stalls (no tool activity after start), kill and restart
+    // Retry loop: if agent stalls (no runtime activity after start), kill and restart
     for (let attempt = 0; attempt <= FIRST_ACTIVITY_MAX_RETRIES; attempt++) {
       // Fresh AbortController per attempt — AbortController is single-use
       const attemptAbort = new AbortController();
@@ -512,7 +510,7 @@ export async function executeSubagentQuery(
         logActivity(
           taskId,
           "Agent",
-          `${agentName} stalled — no tool activity within ${timeoutSec}s after start (attempt ${attempt + 1}/${FIRST_ACTIVITY_MAX_RETRIES + 1}), restarting`,
+          `${agentName} stalled — no runtime activity within ${timeoutSec}s after start (attempt ${attempt + 1}/${FIRST_ACTIVITY_MAX_RETRIES + 1}), restarting`,
         );
         log.warn(
           { taskId, agentName, firstActivityTimeoutMs, attempt: attempt + 1 },
@@ -520,14 +518,16 @@ export async function executeSubagentQuery(
         );
       });
 
-      // Wrap callbacks to clear watchdog on first activity
+      // Install an onEvent bridge even when the caller did not request
+      // streamed events directly: the watchdog needs a callback to observe
+      // runtime activity for tool-less workflows such as checklist sync.
       const wd = watchdog!;
-      const originalOnEvent = executionIntent.onEvent;
+      const originalOnEvent = executionIntent.onEvent ?? (() => undefined);
       const originalOnToolUse = executionIntent.onToolUse;
       const originalOnSubagentStart = executionIntent.onSubagentStart;
       executionIntent.onEvent = (event) => {
         wd.markActivity();
-        originalOnEvent?.(event);
+        originalOnEvent(event);
       };
       if (originalOnToolUse) {
         executionIntent.onToolUse = (toolName, detail) => {

--- a/packages/agent/src/subagentQuery.ts
+++ b/packages/agent/src/subagentQuery.ts
@@ -451,10 +451,11 @@ export async function executeSubagentQuery(
     const registry = await getRuntimeRegistry();
     adapter = registry.resolveRuntime(context.runtimeId);
 
-    // First-activity watchdog requires a transport that surfaces tool_use
-    // events in real time. SDK (in-process query stream) and CLI (stream-json
-    // for Claude / JSONL for Codex) both fire execution.onToolUse during the
-    // run, so the watchdog can observe activity on both. API transport is
+    // First-activity watchdog requires a transport that surfaces incremental
+    // runtime activity in real time. SDK / CLI adapters emit RuntimeEvent
+    // callbacks for streamed text, reasoning, and tool summaries, so any such
+    // event proves the runtime is alive even if the workflow performs no tool
+    // calls. API transport is
     // pure HTTP — no intermediate events — and must stay disabled.
     //
     // CLI gets a 2x buffer over SDK because it carries extra cold-start cost
@@ -520,17 +521,21 @@ export async function executeSubagentQuery(
       });
 
       // Wrap callbacks to clear watchdog on first activity
+      const wd = watchdog!;
+      const originalOnEvent = executionIntent.onEvent;
       const originalOnToolUse = executionIntent.onToolUse;
       const originalOnSubagentStart = executionIntent.onSubagentStart;
+      executionIntent.onEvent = (event) => {
+        wd.markActivity();
+        originalOnEvent?.(event);
+      };
       if (originalOnToolUse) {
-        const wd = watchdog;
         executionIntent.onToolUse = (toolName, detail) => {
           wd.markActivity();
           originalOnToolUse(toolName, detail);
         };
       }
       if (originalOnSubagentStart) {
-        const wd = watchdog;
         executionIntent.onSubagentStart = (name, id) => {
           wd.markActivity();
           originalOnSubagentStart(name, id);

--- a/packages/api/src/__tests__/chat.test.ts
+++ b/packages/api/src/__tests__/chat.test.ts
@@ -91,6 +91,9 @@ vi.mock("@aif/shared", async (importOriginal) => {
     ...actual,
     getEnv: () => ({
       AGENT_BYPASS_PERMISSIONS: false,
+      API_RUNTIME_START_TIMEOUT_MS: 600_000,
+      API_RUNTIME_RUN_TIMEOUT_MS: 600_000,
+      AGENT_CHAT_MAX_TURNS: 50,
       AIF_DEFAULT_RUNTIME_ID: "claude",
       AIF_DEFAULT_PROVIDER_ID: "anthropic",
     }),
@@ -286,6 +289,27 @@ describe("chat API", () => {
         sessionId: "session-1",
         role: "assistant",
         content: "resumed output",
+      }),
+    );
+  });
+
+  it("passes chat execution timeouts from env", async () => {
+    const res = await app.request("/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        projectId: "project-1",
+        message: "plain prompt",
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const runInput = mockAdapterRun.mock.calls[0]?.[0] as RuntimeRunInput;
+    expect(runInput.execution).toEqual(
+      expect.objectContaining({
+        startTimeoutMs: 600_000,
+        runTimeoutMs: 600_000,
+        maxTurns: 50,
       }),
     );
   });

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -690,6 +690,7 @@ chatRouter.post("/", jsonValidator(chatRequestSchema), async (c) => {
   const body = c.req.valid("json") as ChatRequestPayload;
   const { projectId, message, clientId, conversationId, explore, taskId, attachments } = body;
   let { sessionId: inputSessionId } = body;
+  const env = getEnv();
 
   const project = findProjectById(projectId);
   if (!project) {
@@ -813,7 +814,7 @@ chatRouter.post("/", jsonValidator(chatRequestSchema), async (c) => {
       });
     }
 
-    const bypassPermissions = getEnv().AGENT_BYPASS_PERMISSIONS;
+    const bypassPermissions = env.AGENT_BYPASS_PERMISSIONS;
     let fullAssistantResponse = "";
     let hasStreamedTokens = false;
 
@@ -865,8 +866,10 @@ chatRouter.post("/", jsonValidator(chatRequestSchema), async (c) => {
           : {}),
       },
       execution: {
+        startTimeoutMs: env.API_RUNTIME_START_TIMEOUT_MS,
+        runTimeoutMs: env.API_RUNTIME_RUN_TIMEOUT_MS,
         includePartialMessages: true,
-        maxTurns: getEnv().AGENT_CHAT_MAX_TURNS,
+        maxTurns: env.AGENT_CHAT_MAX_TURNS,
         onEvent: onRuntimeEvent,
         systemPromptAppend: systemAppend,
         environment: {


### PR DESCRIPTION
## Changes

This PR fixes two timing issues that were causing confusing behavior in production. Chat requests now honor the timeout values from the environment instead of falling back to the Codex CLI default, and agent polling now respects `POLL_INTERVAL_MS` correctly. Regression tests were added for both cases.

## AI Model

Which AI model was used to generate or assist with this code?

- [ ] Claude Opus 4.6
- [ ] Claude Sonnet 4.6
- [ ] Claude Haiku 4.5
- [x] GPT-5.4
- [ ] No AI used

## Test Plan

- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable)
- [ ] Manually verified the change works as expected
