### PR TITLE
Enable HTTP MCP in local dev when MCP_PORT is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ npm run init
 npm run dev
 ```
 
+Set `MCP_PORT` in your shell or root `.env` before `npm run dev` if you also want the MCP HTTP server in local development.
+
 ### With Docker
 
 ```bash
@@ -53,13 +55,14 @@ cd aif-handoff
 docker compose up --build
 ```
 
-Both options start three services:
+Development starts three services by default. If `MCP_PORT` is set, it starts a fourth service for MCP over HTTP. Docker starts all four services.
 
-| Service   | URL                     | Description                                  |
-| --------- | ----------------------- | -------------------------------------------- |
-| **API**   | `http://localhost:3009` | Hono REST + WebSocket server                 |
-| **Web**   | `http://localhost:5180` | React Kanban UI                              |
-| **Agent** | _(background)_          | Event-driven + polling, dispatches subagents |
+| Service   | URL                               | Description                                  |
+| --------- | --------------------------------- | -------------------------------------------- |
+| **API**   | `http://localhost:3009`           | Hono REST + WebSocket server                 |
+| **Web**   | `http://localhost:5180`           | React Kanban UI                              |
+| **Agent** | _(background)_                    | Event-driven + polling, dispatches subagents |
+| **MCP**   | `http://localhost:<MCP_PORT>/mcp` | Optional local MCP HTTP endpoint             |
 
 The agent coordinator reacts to task events via WebSocket in near real-time and falls back to 30-second polling. Activity logging can be switched to batch mode (`ACTIVITY_LOG_MODE=batch`) to reduce DB write amplification. See [Configuration](docs/configuration.md) for all tuning options.
 
@@ -161,7 +164,7 @@ The project includes full Docker support (Angie reverse proxy + Node services).
 docker compose up --build
 ```
 
-Web UI at `localhost:5180`, API at `localhost:3009`.
+Web UI at `localhost:5180`, API at `localhost:3009`, MCP at `localhost:${MCP_PORT:-3100}`.
 
 ### Production
 
@@ -178,6 +181,7 @@ Only ports 80/443 are exposed. API is bound to localhost only. Includes security
 | `ANTHROPIC_API_KEY` | —            | API key (or use `claude login`)        |
 | `DOMAIN`            | `localhost`  | Domain for SSL certificate (ACME)      |
 | `PORT`              | `3009`       | Host port for API                      |
+| `MCP_PORT`          | `3100`       | Host port for MCP HTTP server          |
 | `WEB_PORT`          | `5180`       | Host port for Web UI (dev)             |
 | `WEB_HOST`          | `localhost`  | Web UI dev server host (Vite)          |
 | `HTTP_PORT`         | `80`         | Host port for Web UI (production)      |

--- a/docs/api.md
+++ b/docs/api.md
@@ -588,6 +588,8 @@ The WebSocket endpoint is a simple broadcast channel — no authentication, no s
 
 The Handoff MCP server (`packages/mcp`) provides bidirectional sync between AIF tooling and Handoff via the Model Context Protocol. When MCP tools modify tasks, they broadcast `sync:*` events over the WebSocket system so the Kanban UI reflects changes in real time.
 
+The web settings route `POST /settings/mcp/install` installs the MCP server into supported runtimes. When `MCP_PORT` is set in the server environment, it writes a streamable HTTP entry pointing to `http://localhost:<MCP_PORT>/mcp`; otherwise it writes the local `stdio` launcher entry.
+
 See [MCP Sync Server](mcp-sync.md) for full documentation.
 
 ## See Also

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,7 +17,7 @@ cd aif-handoff
 docker compose up --build
 ```
 
-This builds and starts API (port 3009), Web UI (port 5180), and Agent in one command. Uses Angie as a reverse proxy — Web UI at `localhost:5180` proxies all API and WebSocket requests automatically.
+This builds and starts API (port 3009), Web UI (port 5180), Agent, and MCP (port 3100) in one command. Uses Angie as a reverse proxy — Web UI at `localhost:5180` proxies all API and WebSocket requests automatically.
 
 Data is persisted in Docker volumes (SQLite database, project files, and Claude auth).
 
@@ -91,12 +91,13 @@ Copy the example environment file:
 cp .env.example .env
 ```
 
-`api` and `agent` automatically read env from root `.env` (`.env.local` overrides when present), so no extra export step is required.
+`npm run dev`, `api`, and `agent` automatically read env from root `.env` (`.env.local` overrides when present), so no extra export step is required.
 
 | Variable                          | Default             | Description                                                                                   |
 | --------------------------------- | ------------------- | --------------------------------------------------------------------------------------------- |
 | `ANTHROPIC_API_KEY`               | _(optional)_        | API key. Agent SDK uses `~/.claude/` auth by default                                          |
 | `PORT`                            | `3009`              | API server port                                                                               |
+| `MCP_PORT`                        | _(optional)_        | When set, `npm run dev` also starts the MCP HTTP server on this port                          |
 | `WEB_PORT`                        | `5180`              | Web UI dev server port                                                                        |
 | `WEB_HOST`                        | `localhost`         | Web UI dev server host                                                                        |
 | `POLL_INTERVAL_MS`                | `30000`             | Agent coordinator polling interval (ms)                                                       |
@@ -124,13 +125,14 @@ Start all services with hot reload:
 npm run dev
 ```
 
-This runs three processes in parallel via Turborepo:
+This runs three processes in parallel via Turborepo by default. If `MCP_PORT` is set, it starts a fourth process for MCP over HTTP.
 
-| Service   | URL                     | Description                                               |
-| --------- | ----------------------- | --------------------------------------------------------- |
-| **API**   | `http://localhost:3009` | REST + WebSocket server                                   |
-| **Web**   | `http://localhost:5180` | Kanban board UI                                           |
-| **Agent** | _(background)_          | Polls every 30s + event-driven wake, dispatches subagents |
+| Service   | URL                         | Description                                               |
+| --------- | --------------------------- | --------------------------------------------------------- |
+| **API**   | `http://localhost:3009`     | REST + WebSocket server                                   |
+| **Web**   | `http://localhost:5180`     | Kanban board UI                                           |
+| **Agent** | _(background)_              | Polls every 30s + event-driven wake, dispatches subagents |
+| **MCP**   | `http://localhost:3100/mcp` | Optional MCP HTTP endpoint                                |
 
 ## Verify It Works
 

--- a/docs/mcp-sync.md
+++ b/docs/mcp-sync.md
@@ -47,7 +47,7 @@ Claude Code auto-discovers the Handoff MCP server from `.mcp.json` — no build 
 
 #### HTTP — Docker / remote
 
-When running in Docker, the MCP server uses Streamable HTTP transport. Set `MCP_TRANSPORT=http` and the server listens on `MCP_PORT` (default `3100`):
+When running in Docker, or in local development with `MCP_PORT` set, the MCP server uses Streamable HTTP transport and listens on `MCP_PORT` (default `3100`):
 
 ```json
 {
@@ -60,6 +60,8 @@ When running in Docker, the MCP server uses Streamable HTTP transport. Set `MCP_
 ```
 
 The HTTP mode also exposes a `/health` endpoint for Docker healthchecks.
+
+When the web settings UI calls `POST /settings/mcp/install`, the API installs this HTTP URL form automatically whenever `MCP_PORT` is set. If `MCP_PORT` is not set, it falls back to the local `stdio`/`npx tsx packages/mcp/src/index.ts` entry.
 
 ### Environment Variables
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "scripts": {
     "init": "npm run db:setup",
-    "dev": "turbo dev",
+    "dev": "node ./scripts/dev.mjs",
     "build": "turbo build",
     "lint": "turbo lint",
     "test": "turbo test",

--- a/packages/api/src/__tests__/settings.test.ts
+++ b/packages/api/src/__tests__/settings.test.ts
@@ -180,6 +180,26 @@ describe("settings API — config routes", () => {
       const checkRes = await app.request("/settings/mcp");
       const checkBody = await checkRes.json();
       expect(checkBody.installed).toBe(true);
+
+      const claudeConfig = JSON.parse(readFileSync(claudeConfigPath, "utf-8"));
+      expect(claudeConfig.mcpServers.handoff).toEqual({
+        type: "stdio",
+        command: "npx",
+        args: ["tsx", join(tempRoot, "packages/mcp/src/index.ts")],
+        cwd: tempRoot,
+        env: {
+          DATABASE_URL: join(tempRoot, "data", "aif.sqlite"),
+          LOG_DESTINATION: "stderr",
+          LOG_LEVEL: "info",
+          MCP_TRANSPORT: "stdio",
+          PROJECTS_DIR: join(tempRoot, ".projects"),
+        },
+      });
+
+      const codexToml = readFileSync(codexConfigPath, "utf-8");
+      expect(codexToml).toContain("[mcp_servers.handoff]");
+      expect(codexToml).toContain('command = "npx"');
+      expect(codexToml).not.toContain('url = "http://localhost:3100/mcp"');
     });
 
     it("POST /settings/mcp/install adds handoff HTTP server when MCP_PORT is set", async () => {
@@ -197,6 +217,7 @@ describe("settings API — config routes", () => {
 
       const claudeConfig = JSON.parse(readFileSync(claudeConfigPath, "utf-8"));
       expect(claudeConfig.mcpServers.handoff).toEqual({
+        type: "http",
         url: "http://localhost:3100/mcp",
       });
 

--- a/packages/api/src/__tests__/settings.test.ts
+++ b/packages/api/src/__tests__/settings.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
-import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -142,10 +142,17 @@ describe("settings API — config routes", () => {
 
   describe("MCP routes", () => {
     const claudeConfigPath = join(fakeHome, ".claude.json");
+    const codexConfigPath = join(fakeHome, ".codex", "config.toml");
 
     beforeEach(() => {
+      delete process.env.MCP_PORT;
       try {
         rmSync(claudeConfigPath);
+      } catch {
+        /* ok */
+      }
+      try {
+        rmSync(join(fakeHome, ".codex"), { recursive: true, force: true });
       } catch {
         /* ok */
       }
@@ -175,11 +182,52 @@ describe("settings API — config routes", () => {
       expect(checkBody.installed).toBe(true);
     });
 
+    it("POST /settings/mcp/install adds handoff HTTP server when MCP_PORT is set", async () => {
+      process.env.MCP_PORT = "3100";
+      writeFileSync(claudeConfigPath, "{}");
+
+      const res = await app.request("/settings/mcp/install", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+
+      const claudeConfig = JSON.parse(readFileSync(claudeConfigPath, "utf-8"));
+      expect(claudeConfig.mcpServers.handoff).toEqual({
+        url: "http://localhost:3100/mcp",
+      });
+
+      const codexToml = readFileSync(codexConfigPath, "utf-8");
+      expect(codexToml).toContain("[mcp_servers.handoff]");
+      expect(codexToml).toContain('url = "http://localhost:3100/mcp"');
+      expect(codexToml).not.toContain('command = "npx"');
+    });
+
     it("DELETE /settings/mcp removes handoff server", async () => {
       writeFileSync(
         claudeConfigPath,
         JSON.stringify({ mcpServers: { handoff: { command: "test" } } }),
       );
+      const res = await app.request("/settings/mcp", { method: "DELETE" });
+      expect(res.status).toBe(200);
+
+      const checkRes = await app.request("/settings/mcp");
+      const checkBody = await checkRes.json();
+      expect(checkBody.installed).toBe(false);
+    });
+
+    it("DELETE /settings/mcp removes handoff HTTP server", async () => {
+      process.env.MCP_PORT = "3100";
+      writeFileSync(
+        claudeConfigPath,
+        JSON.stringify({ mcpServers: { handoff: { url: "http://localhost:3100/mcp" } } }),
+      );
+      mkdirSync(join(fakeHome, ".codex"), { recursive: true });
+      writeFileSync(codexConfigPath, '[mcp_servers.handoff]\nurl = "http://localhost:3100/mcp"\n');
+
       const res = await app.request("/settings/mcp", { method: "DELETE" });
       expect(res.status).toBe(200);
 

--- a/packages/api/src/routes/settings.ts
+++ b/packages/api/src/routes/settings.ts
@@ -13,9 +13,19 @@ const log = logger("api:settings");
 const MCP_SERVER_NAME = "handoff";
 const MONOREPO_ROOT = findMonorepoRoot(import.meta.dirname);
 
+function resolveMcpPort(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const port = Number(trimmed);
+  return Number.isInteger(port) && port > 0 ? String(port) : null;
+}
+
 function buildMcpServerEntry(): RuntimeMcpInstallInput {
   const env = getEnv();
-  const mcpPort = process.env.MCP_PORT?.trim();
+  const mcpPort = resolveMcpPort(process.env.MCP_PORT);
 
   if (mcpPort) {
     return {

--- a/packages/api/src/routes/settings.ts
+++ b/packages/api/src/routes/settings.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import YAML from "yaml";
 import { findProjectById } from "@aif/data";
 import { logger, findMonorepoRoot, getEnv, clearProjectConfigCache } from "@aif/shared";
+import type { RuntimeMcpInstallInput } from "@aif/runtime";
 import { getApiRuntimeRegistry } from "../services/runtime.js";
 
 const log = logger("api:settings");
@@ -12,9 +13,21 @@ const log = logger("api:settings");
 const MCP_SERVER_NAME = "handoff";
 const MONOREPO_ROOT = findMonorepoRoot(import.meta.dirname);
 
-function buildMcpServerEntry() {
+function buildMcpServerEntry(): RuntimeMcpInstallInput {
   const env = getEnv();
+  const mcpPort = process.env.MCP_PORT?.trim();
+
+  if (mcpPort) {
+    return {
+      serverName: MCP_SERVER_NAME,
+      transport: "streamable_http",
+      url: `http://localhost:${mcpPort}/mcp`,
+    };
+  }
+
   return {
+    serverName: MCP_SERVER_NAME,
+    transport: "stdio",
     command: "npx",
     args: ["tsx", join(MONOREPO_ROOT, "packages/mcp/src/index.ts")],
     cwd: MONOREPO_ROOT,
@@ -78,14 +91,11 @@ settingsRoutes.post("/mcp/install", async (c) => {
     const adapter = registry.tryResolveRuntime(descriptor.id);
     if (!adapter?.installMcpServer) continue;
     try {
-      await adapter.installMcpServer({
-        serverName: MCP_SERVER_NAME,
-        command: entry.command,
-        args: entry.args,
-        cwd: entry.cwd,
-        env: entry.env,
-      });
-      log.info({ runtimeId: descriptor.id }, "MCP server installed");
+      await adapter.installMcpServer(entry);
+      log.info(
+        { runtimeId: descriptor.id, transport: entry.transport ?? "stdio" },
+        "MCP server installed",
+      );
       results.push({ runtimeId: descriptor.id, success: true });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -8,6 +8,7 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {
+    "dev": "node ./scripts/dev-http.mjs",
     "build": "tsc",
     "test": "vitest run --passWithNoTests",
     "coverage": "vitest run --coverage --passWithNoTests",

--- a/packages/mcp/scripts/dev-http.mjs
+++ b/packages/mcp/scripts/dev-http.mjs
@@ -1,0 +1,47 @@
+import { spawn } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const port = process.env.MCP_PORT || "3100";
+console.log(`[mcp] Starting HTTP transport on port ${port}`);
+
+const child =
+  process.platform === "win32"
+    ? spawn("cmd.exe", ["/d", "/s", "/c", "npx", "tsx", "watch", "src/index.ts"], {
+        cwd: packageRoot,
+        stdio: "inherit",
+        env: {
+          ...process.env,
+          MCP_TRANSPORT: "http",
+          MCP_PORT: port,
+        },
+      })
+    : spawn("npx", ["tsx", "watch", "src/index.ts"], {
+        cwd: packageRoot,
+        stdio: "inherit",
+        env: {
+          ...process.env,
+          MCP_TRANSPORT: "http",
+          MCP_PORT: port,
+        },
+      });
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.on(signal, () => {
+    if (!child.killed) child.kill(signal);
+  });
+}
+
+child.on("error", (error) => {
+  console.error("[mcp] Failed to start dev server", error);
+  process.exit(1);
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 0);
+});

--- a/packages/runtime/src/__tests__/claudeMcp.test.ts
+++ b/packages/runtime/src/__tests__/claudeMcp.test.ts
@@ -27,6 +27,7 @@ describe("Claude MCP config", () => {
   it("writes stdio MCP servers to .claude.json", async () => {
     await installClaudeMcpServer({
       serverName: "handoff",
+      transport: "stdio",
       command: "npx",
       args: ["tsx", "packages/mcp/src/index.ts"],
       cwd: "C:\\projects\\aifhub\\aif-handoff",
@@ -64,6 +65,7 @@ describe("Claude MCP config", () => {
     expect(JSON.parse(content)).toEqual({
       mcpServers: {
         handoff: {
+          type: "http",
           url: "http://localhost:3100/mcp",
         },
       },
@@ -75,6 +77,7 @@ describe("Claude MCP config", () => {
       JSON.stringify({
         mcpServers: {
           handoff: {
+            type: "http",
             url: "http://localhost:3100/mcp",
           },
         },
@@ -85,6 +88,7 @@ describe("Claude MCP config", () => {
 
     expect(status.installed).toBe(true);
     expect(status.config).toEqual({
+      type: "http",
       url: "http://localhost:3100/mcp",
     });
   });
@@ -94,6 +98,7 @@ describe("Claude MCP config", () => {
       JSON.stringify({
         mcpServers: {
           handoff: {
+            type: "http",
             url: "http://localhost:3100/mcp",
           },
           other: {
@@ -111,6 +116,26 @@ describe("Claude MCP config", () => {
       mcpServers: {
         other: {
           command: "npx",
+        },
+      },
+    });
+  });
+
+  it("does not write unsupported bearer token env vars for Claude HTTP MCP servers", async () => {
+    await installClaudeMcpServer({
+      serverName: "handoff",
+      transport: "streamable_http",
+      url: "http://localhost:3100/mcp",
+      bearerTokenEnvVar: "AIF_MCP_TOKEN",
+    });
+
+    expect(writeFileMock).toHaveBeenCalledTimes(1);
+    const [, content] = writeFileMock.mock.calls[0] as [string, string];
+    expect(JSON.parse(content)).toEqual({
+      mcpServers: {
+        handoff: {
+          type: "http",
+          url: "http://localhost:3100/mcp",
         },
       },
     });

--- a/packages/runtime/src/__tests__/claudeMcp.test.ts
+++ b/packages/runtime/src/__tests__/claudeMcp.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const readFileMock = vi.fn();
+const writeFileMock = vi.fn();
+const homedirMock = vi.fn(() => "C:\\Users\\Daniil");
+
+vi.mock("node:fs/promises", () => ({
+  readFile: (...args: unknown[]) => readFileMock(...args),
+  writeFile: (...args: unknown[]) => writeFileMock(...args),
+}));
+
+vi.mock("node:os", () => ({
+  homedir: () => homedirMock(),
+}));
+
+const { getClaudeMcpStatus, installClaudeMcpServer, uninstallClaudeMcpServer } =
+  await import("../adapters/claude/mcp.js");
+
+describe("Claude MCP config", () => {
+  beforeEach(() => {
+    readFileMock.mockReset();
+    writeFileMock.mockReset();
+    readFileMock.mockRejectedValue(new Error("missing"));
+    writeFileMock.mockResolvedValue(undefined);
+  });
+
+  it("writes stdio MCP servers to .claude.json", async () => {
+    await installClaudeMcpServer({
+      serverName: "handoff",
+      command: "npx",
+      args: ["tsx", "packages/mcp/src/index.ts"],
+      cwd: "C:\\projects\\aifhub\\aif-handoff",
+      env: {
+        DATABASE_URL: "C:\\projects\\aifhub\\aif-handoff\\data\\aif.sqlite",
+      },
+    });
+
+    expect(writeFileMock).toHaveBeenCalledTimes(1);
+    const [, content] = writeFileMock.mock.calls[0] as [string, string];
+    expect(JSON.parse(content)).toEqual({
+      mcpServers: {
+        handoff: {
+          type: "stdio",
+          command: "npx",
+          args: ["tsx", "packages/mcp/src/index.ts"],
+          cwd: "C:\\projects\\aifhub\\aif-handoff",
+          env: {
+            DATABASE_URL: "C:\\projects\\aifhub\\aif-handoff\\data\\aif.sqlite",
+          },
+        },
+      },
+    });
+  });
+
+  it("writes HTTP MCP servers to .claude.json when url is provided", async () => {
+    await installClaudeMcpServer({
+      serverName: "handoff",
+      transport: "streamable_http",
+      url: "http://localhost:3100/mcp",
+    });
+
+    expect(writeFileMock).toHaveBeenCalledTimes(1);
+    const [, content] = writeFileMock.mock.calls[0] as [string, string];
+    expect(JSON.parse(content)).toEqual({
+      mcpServers: {
+        handoff: {
+          url: "http://localhost:3100/mcp",
+        },
+      },
+    });
+  });
+
+  it("reads HTTP MCP server entries back from .claude.json", async () => {
+    readFileMock.mockResolvedValue(
+      JSON.stringify({
+        mcpServers: {
+          handoff: {
+            url: "http://localhost:3100/mcp",
+          },
+        },
+      }),
+    );
+
+    const status = await getClaudeMcpStatus({ serverName: "handoff" });
+
+    expect(status.installed).toBe(true);
+    expect(status.config).toEqual({
+      url: "http://localhost:3100/mcp",
+    });
+  });
+
+  it("removes MCP servers from .claude.json", async () => {
+    readFileMock.mockResolvedValue(
+      JSON.stringify({
+        mcpServers: {
+          handoff: {
+            url: "http://localhost:3100/mcp",
+          },
+          other: {
+            command: "npx",
+          },
+        },
+      }),
+    );
+
+    await uninstallClaudeMcpServer({ serverName: "handoff" });
+
+    expect(writeFileMock).toHaveBeenCalledTimes(1);
+    const [, content] = writeFileMock.mock.calls[0] as [string, string];
+    expect(JSON.parse(content)).toEqual({
+      mcpServers: {
+        other: {
+          command: "npx",
+        },
+      },
+    });
+  });
+});

--- a/packages/runtime/src/__tests__/codexMcp.test.ts
+++ b/packages/runtime/src/__tests__/codexMcp.test.ts
@@ -65,6 +65,20 @@ describe("Codex MCP config", () => {
     expect(content).toContain('LOG_DESTINATION = "stderr"');
   });
 
+  it("writes streamable HTTP MCP servers as URL entries", async () => {
+    await installCodexMcpServer({
+      serverName: "handoff",
+      transport: "streamable_http",
+      url: "http://localhost:3100/mcp",
+    });
+
+    expect(writeFileMock).toHaveBeenCalledTimes(1);
+    const [, content] = writeFileMock.mock.calls[0] as [string, string];
+    expect(content).toContain("[mcp_servers.handoff]");
+    expect(content).toContain('url = "http://localhost:3100/mcp"');
+    expect(content).not.toContain('command = "npx"');
+  });
+
   it("reads escaped Windows paths back from TOML", async () => {
     readFileMock.mockResolvedValue(`[mcp_servers.handoff]
 command = "npx"
@@ -112,6 +126,21 @@ cwd = "C:\\\\projects\\\\aifhub\\\\aif-handoff"
       command: "npx",
       args: ["tsx", "C:\\projects\\aifhub\\aif-handoff\\packages\\mcp\\src\\index.ts"],
       cwd: "C:\\projects\\aifhub\\aif-handoff",
+    });
+  });
+
+  it("reads streamable HTTP MCP servers back from TOML", async () => {
+    readFileMock.mockResolvedValue(`[mcp_servers.handoff]
+url = "http://localhost:3100/mcp"
+bearer_token_env_var = "AIF_MCP_TOKEN"
+`);
+
+    const status = await getCodexMcpStatus({ serverName: "handoff" });
+
+    expect(status.installed).toBe(true);
+    expect(status.config).toEqual({
+      url: "http://localhost:3100/mcp",
+      bearer_token_env_var: "AIF_MCP_TOKEN",
     });
   });
 

--- a/packages/runtime/src/adapters/claude/mcp.ts
+++ b/packages/runtime/src/adapters/claude/mcp.ts
@@ -37,12 +37,13 @@ export async function getClaudeMcpStatus(input: RuntimeMcpInput): Promise<Runtim
 export async function installClaudeMcpServer(input: RuntimeMcpInstallInput): Promise<void> {
   const config = await readConfig();
   if (!config.mcpServers) config.mcpServers = {};
-  if (input.url) {
+
+  if (input.transport === "streamable_http") {
     config.mcpServers[input.serverName] = {
+      type: "http",
       url: input.url,
-      ...(input.bearerTokenEnvVar ? { bearerTokenEnvVar: input.bearerTokenEnvVar } : {}),
     };
-  } else if (input.command) {
+  } else {
     config.mcpServers[input.serverName] = {
       type: "stdio",
       command: input.command,
@@ -50,8 +51,6 @@ export async function installClaudeMcpServer(input: RuntimeMcpInstallInput): Pro
       ...(input.cwd ? { cwd: input.cwd } : {}),
       ...(input.env ? { env: input.env } : {}),
     };
-  } else {
-    throw new Error("Claude MCP install requires either url or command");
   }
   await writeConfig(config);
 }

--- a/packages/runtime/src/adapters/claude/mcp.ts
+++ b/packages/runtime/src/adapters/claude/mcp.ts
@@ -37,13 +37,22 @@ export async function getClaudeMcpStatus(input: RuntimeMcpInput): Promise<Runtim
 export async function installClaudeMcpServer(input: RuntimeMcpInstallInput): Promise<void> {
   const config = await readConfig();
   if (!config.mcpServers) config.mcpServers = {};
-  config.mcpServers[input.serverName] = {
-    type: "stdio",
-    command: input.command,
-    args: input.args ?? [],
-    ...(input.cwd ? { cwd: input.cwd } : {}),
-    ...(input.env ? { env: input.env } : {}),
-  };
+  if (input.url) {
+    config.mcpServers[input.serverName] = {
+      url: input.url,
+      ...(input.bearerTokenEnvVar ? { bearerTokenEnvVar: input.bearerTokenEnvVar } : {}),
+    };
+  } else if (input.command) {
+    config.mcpServers[input.serverName] = {
+      type: "stdio",
+      command: input.command,
+      args: input.args ?? [],
+      ...(input.cwd ? { cwd: input.cwd } : {}),
+      ...(input.env ? { env: input.env } : {}),
+    };
+  } else {
+    throw new Error("Claude MCP install requires either url or command");
+  }
   await writeConfig(config);
 }
 

--- a/packages/runtime/src/adapters/codex/mcp.ts
+++ b/packages/runtime/src/adapters/codex/mcp.ts
@@ -140,7 +140,7 @@ function serializeMcpSection(name: string, entry: CodexMcpServerEntry): string {
 function removeServerSections(toml: string, serverName: string): string {
   const mainSectionHeader = `[mcp_servers.${serverName}]`;
   const envSectionHeader = `[mcp_servers.${serverName}.env]`;
-  const sectionHeaderRegex = /^\[[^\]]+\]\s*$/;
+  const sectionHeaderRegex = /^\[[^\]]+]\s*$/;
   const keptLines: string[] = [];
   let skipping = false;
 
@@ -198,24 +198,20 @@ export async function installCodexMcpServer(input: RuntimeMcpInstallInput): Prom
   let toml = await readToml();
   toml = removeServerSections(toml, input.serverName);
 
-  const section = serializeMcpSection(
-    input.serverName,
-    input.url
+  const entry: CodexMcpServerEntry =
+    input.transport === "streamable_http"
       ? {
           url: input.url,
           bearer_token_env_var: input.bearerTokenEnvVar,
         }
-      : input.command
-        ? {
-            command: input.command,
-            args: input.args ?? [],
-            cwd: input.cwd,
-            env: input.env,
-          }
-        : (() => {
-            throw new Error("Codex MCP install requires either url or command");
-          })(),
-  );
+      : {
+          command: input.command,
+          args: input.args ?? [],
+          cwd: input.cwd,
+          env: input.env,
+        };
+
+  const section = serializeMcpSection(input.serverName, entry);
 
   toml = toml ? `${toml}\n\n${section}\n` : `${section}\n`;
   await writeToml(toml);

--- a/packages/runtime/src/adapters/codex/mcp.ts
+++ b/packages/runtime/src/adapters/codex/mcp.ts
@@ -8,10 +8,12 @@ import type { RuntimeMcpInput, RuntimeMcpInstallInput, RuntimeMcpStatus } from "
 const CODEX_CONFIG_PATH = join(homedir(), ".codex", "config.toml");
 
 interface CodexMcpServerEntry extends Record<string, unknown> {
-  command: string;
-  args: string[];
+  command?: string;
+  args?: string[];
   cwd?: string;
   env?: Record<string, string>;
+  url?: string;
+  bearer_token_env_var?: string;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -45,14 +47,24 @@ function normalizeEnv(value: unknown): Record<string, string> | undefined {
 }
 
 function normalizeServerEntry(value: unknown): CodexMcpServerEntry | null {
-  if (!isRecord(value) || typeof value.command !== "string") {
+  if (!isRecord(value)) {
     return null;
   }
 
-  const entry: CodexMcpServerEntry = {
-    command: value.command,
-    args: normalizeStringArray(value.args),
-  };
+  const entry: CodexMcpServerEntry = {};
+
+  if (typeof value.url === "string") {
+    entry.url = value.url;
+  }
+
+  if (typeof value.command === "string") {
+    entry.command = value.command;
+    entry.args = normalizeStringArray(value.args);
+  }
+
+  if (!entry.url && !entry.command) {
+    return null;
+  }
 
   if (typeof value.cwd === "string") {
     entry.cwd = value.cwd;
@@ -61,6 +73,10 @@ function normalizeServerEntry(value: unknown): CodexMcpServerEntry | null {
   const env = normalizeEnv(value.env);
   if (env) {
     entry.env = env;
+  }
+
+  if (typeof value.bearer_token_env_var === "string") {
+    entry.bearer_token_env_var = value.bearer_token_env_var;
   }
 
   return entry;
@@ -92,8 +108,14 @@ function parseMcpServers(toml: string): Record<string, CodexMcpServerEntry> {
 }
 
 function serializeMcpSection(name: string, entry: CodexMcpServerEntry): string {
-  const serverConfig: Record<string, unknown> = { command: entry.command };
-  if (entry.args.length > 0) {
+  const serverConfig: Record<string, unknown> = {};
+  if (entry.url) {
+    serverConfig.url = entry.url;
+  }
+  if (entry.command) {
+    serverConfig.command = entry.command;
+  }
+  if (entry.args && entry.args.length > 0) {
     serverConfig.args = entry.args;
   }
   if (entry.cwd) {
@@ -103,6 +125,9 @@ function serializeMcpSection(name: string, entry: CodexMcpServerEntry): string {
     serverConfig.env = Object.fromEntries(
       Object.entries(entry.env).sort(([a], [b]) => a.localeCompare(b)),
     );
+  }
+  if (entry.bearer_token_env_var) {
+    serverConfig.bearer_token_env_var = entry.bearer_token_env_var;
   }
 
   return stringifyToml({
@@ -173,12 +198,24 @@ export async function installCodexMcpServer(input: RuntimeMcpInstallInput): Prom
   let toml = await readToml();
   toml = removeServerSections(toml, input.serverName);
 
-  const section = serializeMcpSection(input.serverName, {
-    command: input.command,
-    args: input.args ?? [],
-    cwd: input.cwd,
-    env: input.env,
-  });
+  const section = serializeMcpSection(
+    input.serverName,
+    input.url
+      ? {
+          url: input.url,
+          bearer_token_env_var: input.bearerTokenEnvVar,
+        }
+      : input.command
+        ? {
+            command: input.command,
+            args: input.args ?? [],
+            cwd: input.cwd,
+            env: input.env,
+          }
+        : (() => {
+            throw new Error("Codex MCP install requires either url or command");
+          })(),
+  );
 
   toml = toml ? `${toml}\n\n${section}\n` : `${section}\n`;
   await writeToml(toml);

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -259,15 +259,25 @@ export interface RuntimeMcpInput {
   serverName: string;
 }
 
-export interface RuntimeMcpInstallInput extends RuntimeMcpInput {
-  transport?: "stdio" | "streamable_http";
-  command?: string;
-  args?: string[];
-  cwd?: string;
-  env?: Record<string, string>;
-  url?: string;
-  bearerTokenEnvVar?: string;
-}
+export type RuntimeMcpInstallInput =
+  | (RuntimeMcpInput & {
+      transport?: "stdio";
+      command: string;
+      args?: string[];
+      cwd?: string;
+      env?: Record<string, string>;
+      url?: never;
+      bearerTokenEnvVar?: never;
+    })
+  | (RuntimeMcpInput & {
+      transport: "streamable_http";
+      url: string;
+      bearerTokenEnvVar?: string;
+      command?: never;
+      args?: never;
+      cwd?: never;
+      env?: never;
+    });
 
 export interface RuntimeMcpStatus {
   installed: boolean;

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -260,10 +260,13 @@ export interface RuntimeMcpInput {
 }
 
 export interface RuntimeMcpInstallInput extends RuntimeMcpInput {
-  command: string;
+  transport?: "stdio" | "streamable_http";
+  command?: string;
   args?: string[];
   cwd?: string;
   env?: Record<string, string>;
+  url?: string;
+  bearerTokenEnvVar?: string;
 }
 
 export interface RuntimeMcpStatus {

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
+// Minimal root .env loader for local dev scripts. Supports single-line KEY=VALUE pairs only.
 function parseEnvFile(path) {
   const entries = {};
   const lines = readFileSync(path, "utf8").split(/\r?\n/u);
@@ -47,13 +48,25 @@ function loadRootEnv() {
   }
 }
 
+function resolveMcpPort(value) {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const port = Number(trimmed);
+  return Number.isInteger(port) && port > 0 ? String(port) : null;
+}
+
 loadRootEnv();
 
 const filters = ["@aif/api", "@aif/web", "@aif/agent"];
+const mcpPort = resolveMcpPort(process.env.MCP_PORT);
 
-if (process.env.MCP_PORT) {
+if (mcpPort) {
+  process.env.MCP_PORT = mcpPort;
   filters.push("@aif/mcp");
-  console.log(`[dev] MCP enabled on port ${process.env.MCP_PORT}`);
+  console.log(`[dev] MCP enabled on port ${mcpPort}`);
 }
 
 const args = [

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,0 +1,95 @@
+import { spawn } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+function parseEnvFile(path) {
+  const entries = {};
+  const lines = readFileSync(path, "utf8").split(/\r?\n/u);
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+
+    const normalized = trimmed.startsWith("export ") ? trimmed.slice(7) : trimmed;
+    const separatorIndex = normalized.indexOf("=");
+    if (separatorIndex < 0) continue;
+
+    const key = normalized.slice(0, separatorIndex).trim();
+    if (!key) continue;
+
+    let value = normalized.slice(separatorIndex + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    entries[key] = value;
+  }
+
+  return entries;
+}
+
+function loadRootEnv() {
+  const resolvedEnv = {};
+
+  for (const filename of [".env", ".env.local"]) {
+    const path = resolve(process.cwd(), filename);
+    if (!existsSync(path)) continue;
+    Object.assign(resolvedEnv, parseEnvFile(path));
+  }
+
+  for (const [key, value] of Object.entries(resolvedEnv)) {
+    if (process.env[key] === undefined) {
+      process.env[key] = value;
+    }
+  }
+}
+
+loadRootEnv();
+
+const filters = ["@aif/api", "@aif/web", "@aif/agent"];
+
+if (process.env.MCP_PORT) {
+  filters.push("@aif/mcp");
+  console.log(`[dev] MCP enabled on port ${process.env.MCP_PORT}`);
+}
+
+const args = [
+  "turbo",
+  "run",
+  "dev",
+  ...filters.flatMap((filter) => ["--filter", filter]),
+  ...process.argv.slice(2),
+];
+
+const child =
+  process.platform === "win32"
+    ? spawn("cmd.exe", ["/d", "/s", "/c", "npx", ...args], {
+        stdio: "inherit",
+        env: process.env,
+      })
+    : spawn("npx", args, {
+        stdio: "inherit",
+        env: process.env,
+      });
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.on(signal, () => {
+    if (!child.killed) child.kill(signal);
+  });
+}
+
+child.on("error", (error) => {
+  console.error("[dev] Failed to start turbo dev", error);
+  process.exit(1);
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 0);
+});


### PR DESCRIPTION
## Summary

- Start `@aif/mcp` automatically during `npm run dev` when `MCP_PORT` is configured
- Install and remove the MCP server from the web settings UI using a localhost HTTP entry instead of `npx` when `MCP_PORT` is set
- Keep the existing `stdio` / `npx` fallback for environments where `MCP_PORT` is not configured

## Changes

Updated the local dev flow so the monorepo starts the MCP server only when `MCP_PORT` is present, including support for loading the value from the root `.env`. Added an HTTP-specific dev runner for the MCP package and documented the new behavior.

Updated MCP installation through the settings API and runtime adapters so Claude and Codex can persist either `stdio` or streamable HTTP MCP entries. When `MCP_PORT` is set, the web UI now installs `http://localhost:<MCP_PORT>/mcp` and removes that same entry during uninstall instead of writing an `npx tsx ...` launcher config.

Added route and adapter tests to cover the HTTP install/remove path and the new config serialization behavior.

## AI Model

Which AI model was used to generate or assist with this code?

- [ ] Claude Opus 4.6
- [ ] Claude Sonnet 4.6
- [ ] Claude Haiku 4.5
- [x] Other: OpenAI Codex (GPT-5)
- [ ] No AI used

## Test Plan

- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Documentation updated (if applicable)
- [x] Manually verified the change works as expected
