### PR TITLE
feat(runtime): universal LLM token usage tracking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,10 +157,11 @@ data/                    # SQLite database files (gitignored)
 ## Runtime Adapter Sync Rule
 
 - **Docs must stay in sync when adding or modifying runtime adapters.** When a new adapter is added to `packages/runtime/src/adapters/` or an existing adapter's capabilities change:
-  - `docs/providers.md` — update the "Supported Runtimes" table.
+  - `docs/providers.md` — update the "Supported Runtimes" table (including the `Usage Reporting` column).
   - `packages/runtime/src/adapters/TEMPLATE.ts` — verify the template still reflects current conventions.
   - `packages/runtime/src/bootstrap.ts` — register the new built-in adapter.
   - `.docker/Dockerfile` — add any new system-level dependencies.
+  - **Usage reporting contract** — declare `capabilities.usageReporting` (`FULL` / `PARTIAL` / `NONE`) and return `RuntimeRunResult.usage` as `RuntimeUsage` or explicit `null`. The discovery test in `bootstrap.test.ts` fails the build if the field is missing.
 
 ## Project Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,10 +185,11 @@ data/                    # SQLite database files (gitignored)
 ## Runtime Adapter Sync Rule
 
 - **Docs must stay in sync when adding or modifying runtime adapters.** When a new adapter is added to `packages/runtime/src/adapters/` or an existing adapter's capabilities change:
-  - `docs/providers.md` — update the "Supported Runtimes" table with the new adapter's capabilities, transports, and light model.
+  - `docs/providers.md` — update the "Supported Runtimes" table with the new adapter's capabilities (including the `Usage Reporting` column), transports, and light model.
   - `packages/runtime/src/adapters/TEMPLATE.ts` — verify the template still reflects current conventions.
   - `packages/runtime/src/bootstrap.ts` — register the new built-in adapter (or document `AIF_RUNTIME_MODULES` loading).
   - `.docker/Dockerfile` — add any new system-level dependencies the adapter needs.
+  - **Usage reporting contract** — every adapter must declare `capabilities.usageReporting` (`FULL` / `PARTIAL` / `NONE`) and return `RuntimeRunResult.usage` as a concrete value (including explicit `null`). The discovery test in `packages/runtime/src/__tests__/bootstrap.test.ts` fails the build if a new adapter ships without a valid `usageReporting` value. See `docs/providers.md` → "Usage reporting contract".
 
 ## Project Rules
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -50,15 +50,25 @@ The API exposes effective selection endpoints:
 
 ## Supported Runtimes
 
-| Runtime      | Provider     | Transports    | Resume         | Sessions       | Agent Defs    | Light Model         | Status                    |
-| ------------ | ------------ | ------------- | -------------- | -------------- | ------------- | ------------------- | ------------------------- |
-| `claude`     | `anthropic`  | SDK, CLI, API | Yes (SDK/CLI)  | Yes (SDK/CLI)  | Yes (SDK/CLI) | `claude-haiku-3-5`  | Built-in                  |
-| `codex`      | `openai`     | SDK, CLI, API | Yes (SDK only) | Yes (SDK only) | No            | default             | Built-in                  |
-| `opencode`   | `opencode`   | API           | Yes            | Yes            | No            | null (configurable) | Built-in                  |
-| `openrouter` | `openrouter` | API           | No             | No             | No            | null (configurable) | Built-in                  |
-| Custom       | Any          | Any           | Configurable   | Configurable   | Configurable  | Configurable        | Via `AIF_RUNTIME_MODULES` |
+| Runtime      | Provider     | Transports    | Resume         | Sessions       | Agent Defs    | Usage Reporting               | Light Model         | Status                    |
+| ------------ | ------------ | ------------- | -------------- | -------------- | ------------- | ----------------------------- | ------------------- | ------------------------- |
+| `claude`     | `anthropic`  | SDK, CLI, API | Yes (SDK/CLI)  | Yes (SDK/CLI)  | Yes (SDK/CLI) | `FULL` (all transports)       | `claude-haiku-3-5`  | Built-in                  |
+| `codex`      | `openai`     | SDK, CLI, API | Yes (SDK only) | Yes (SDK only) | No            | `FULL` SDK/API, `PARTIAL` CLI | default             | Built-in                  |
+| `opencode`   | `opencode`   | API           | Yes            | Yes            | No            | `NONE`                        | null (configurable) | Built-in                  |
+| `openrouter` | `openrouter` | API           | No             | No             | No            | `FULL`                        | null (configurable) | Built-in                  |
+| Custom       | Any          | Any           | Configurable   | Configurable   | Configurable  | Must declare                  | Configurable        | Via `AIF_RUNTIME_MODULES` |
 
 Capabilities are **transport-aware**: the same adapter may expose different capabilities depending on the selected transport. For example, the Codex adapter supports resume/sessions via SDK transport but not via CLI. Use `resolveAdapterCapabilities(adapter, transport)` to get the effective set.
+
+### Usage reporting contract
+
+Every adapter must declare a `usageReporting` value in its `RuntimeCapabilities`. The registry wrapper reads this field for every run and enforces the contract — a new adapter cannot silently skip token accounting:
+
+- **`FULL`** — adapter always populates `RuntimeRunResult.usage` on a successful run. If the wrapper observes a null `usage` while the capability says `FULL`, it logs an error (dev) or fires a metric (prod). The contract test in `bootstrap.test.ts` also fails the build if the field is missing.
+- **`PARTIAL`** — adapter returns usage when the provider gives it, but may return `null` on some transport/streaming paths (e.g. CLI early-termination). The wrapper accepts both and records only the non-null events.
+- **`NONE`** — transport fundamentally cannot report token counts (e.g. OpenCode message payload). The wrapper warns if usage unexpectedly appears, but this is an opt-out from the usage pipeline — dashboards will show zero traffic for runtimes in this tier.
+
+All successful runs that produce non-null usage flow through the registry's `usageSink`, which persists them to the `usage_events` table and rolls them up into per-task / per-project / per-chat-session aggregates. Sink wiring lives in `packages/api/src/services/runtime.ts` (API) and `packages/agent/src/index.ts` / `subagentQuery.ts` (agent) — both use `createDbUsageSink()` from `@aif/data`.
 
 ### Transport Types
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,4 +1,4 @@
-import { listProjects } from "@aif/data";
+import { createDbUsageSink, listProjects } from "@aif/data";
 import { getEnv, logger } from "@aif/shared";
 import { bootstrapRuntimeRegistry } from "@aif/runtime";
 import { pollAndProcess, setRuntimeRegistry } from "./coordinator.js";
@@ -24,7 +24,10 @@ const pollScheduler = startPollScheduler(async () => {
 }, env.POLL_INTERVAL_MS);
 
 // Pre-load runtime registry so project init includes all adapters
-bootstrapRuntimeRegistry({ runtimeModules: env.AIF_RUNTIME_MODULES })
+bootstrapRuntimeRegistry({
+  runtimeModules: env.AIF_RUNTIME_MODULES,
+  usageSink: createDbUsageSink(),
+})
   .then((registry) => {
     setRuntimeRegistry(registry);
     log.info("Runtime registry loaded for project initialization");

--- a/packages/agent/src/subagentQuery.ts
+++ b/packages/agent/src/subagentQuery.ts
@@ -1,7 +1,7 @@
 import {
+  createDbUsageSink,
   findTaskById,
   getTaskSessionId,
-  incrementTaskTokenUsage,
   renewTaskClaim,
   resolveEffectiveRuntimeProfile,
   saveTaskSessionId,
@@ -17,6 +17,7 @@ import {
   resolveRuntimeProfile,
   resolveRuntimePromptPolicy,
   RUNTIME_TRUST_TOKEN,
+  UsageSource,
   type RuntimeAdapter,
   type RuntimeCapabilities,
   type RuntimeCapabilityName,
@@ -163,6 +164,7 @@ async function getRuntimeRegistry(): Promise<RuntimeRegistry> {
   runtimeRegistryPromise = bootstrapRuntimeRegistry({
     logger: createRuntimeRegistryLogger(),
     runtimeModules: getEnv().AIF_RUNTIME_MODULES,
+    usageSink: createDbUsageSink(),
   }).catch((error) => {
     runtimeRegistryPromise = null;
     throw error;
@@ -542,6 +544,10 @@ export async function executeSubagentQuery(
         };
       }
 
+      // Look up project scope fresh per attempt so a retry that sees a
+      // re-parented task still records against the correct project.
+      const projectIdForUsage = findTaskById(taskId)?.projectId ?? null;
+
       const runInput = {
         runtimeId: context.runtimeId,
         providerId: context.providerId,
@@ -557,6 +563,11 @@ export async function executeSubagentQuery(
         headers: context.headers,
         options: context.options,
         execution: executionIntent,
+        usageContext: {
+          source: UsageSource.SUBAGENT,
+          projectId: projectIdForUsage,
+          taskId,
+        },
       } as const;
 
       try {
@@ -605,14 +616,9 @@ export async function executeSubagentQuery(
       );
     }
 
-    if (result.usage) {
-      incrementTaskTokenUsage(taskId, {
-        input_tokens: result.usage.inputTokens,
-        output_tokens: result.usage.outputTokens,
-        total_tokens: result.usage.totalTokens,
-        total_cost_usd: result.usage.costUsd,
-      });
-    }
+    // Usage is recorded automatically by the registry wrapper via the DB
+    // usage sink (see packages/data createDbUsageSink + packages/runtime
+    // registry.wrapAdapter). No manual increment needed here.
 
     const resultText = result.outputText ?? "";
 

--- a/packages/agent/src/subagentQuery.ts
+++ b/packages/agent/src/subagentQuery.ts
@@ -155,6 +155,9 @@ function createRuntimeRegistryLogger(): RuntimeRegistryLogger {
     warn(context, message) {
       log.warn({ ...context }, `WARN [runtime-module] ${message}`);
     },
+    error(context, message) {
+      log.error({ ...context }, `ERROR [runtime-registry] ${message}`);
+    },
   };
 }
 

--- a/packages/api/src/__tests__/chat.test.ts
+++ b/packages/api/src/__tests__/chat.test.ts
@@ -38,6 +38,7 @@ const runtimeAdapter: RuntimeAdapter = {
       supportsModelDiscovery: true,
       supportsApprovals: true,
       supportsCustomEndpoint: true,
+      usageReporting: "full",
     },
   },
   run: (input) => mockAdapterRun(input),
@@ -60,6 +61,7 @@ vi.mock("@aif/data", () => ({
   toChatMessageResponse: (row: unknown) => mockToChatMessageResponse(row),
   deleteChatSession: vi.fn(),
   findRuntimeProfileById: vi.fn(() => null),
+  createDbUsageSink: () => ({ record: vi.fn() }),
 }));
 
 vi.mock("../services/runtime.js", () => ({

--- a/packages/api/src/__tests__/chatSessions.test.ts
+++ b/packages/api/src/__tests__/chatSessions.test.ts
@@ -40,9 +40,10 @@ const runtimeAdapter: RuntimeAdapter = {
       supportsModelDiscovery: true,
       supportsApprovals: true,
       supportsCustomEndpoint: true,
+      usageReporting: "full",
     },
   },
-  run: vi.fn(async () => ({ outputText: "" })),
+  run: vi.fn(async () => ({ outputText: "", usage: null })),
   listSessions: (...args) => mockListSessions(...args),
   getSession: (...args) => mockGetSession(...args),
   listSessionEvents: (...args) => mockListSessionEvents(...args),
@@ -64,6 +65,7 @@ vi.mock("@aif/data", () => ({
   updateChatSessionTimestamp: vi.fn(),
   findRuntimeProfileById: (id: string) => mockFindRuntimeProfileById(id),
   toRuntimeProfileResponse: (row: Record<string, unknown>) => mockToRuntimeProfileResponse(row),
+  createDbUsageSink: () => ({ record: vi.fn() }),
 }));
 
 vi.mock("../services/runtime.js", () => ({

--- a/packages/api/src/__tests__/fastFix.test.ts
+++ b/packages/api/src/__tests__/fastFix.test.ts
@@ -48,7 +48,7 @@ describe("fastFix service", () => {
     });
   });
 
-  it("returns plan text on success and records usage", async () => {
+  it("returns plan text on success and passes fast-fix usageContext to runtime", async () => {
     mockRunApiRuntimeOneShot.mockResolvedValue(
       runtimeResult("## Plan\n- Updated", {
         inputTokens: 10,
@@ -75,10 +75,18 @@ describe("fastFix service", () => {
 
     expect(updated).toBe("## Plan\n- Updated");
     expect(mockRunApiRuntimeOneShot).toHaveBeenCalledTimes(1);
-    expect(incrementTaskTokenUsage).toHaveBeenCalledWith(
-      "task-1",
-      expect.objectContaining({ total_tokens: 30, total_cost_usd: 0.002 }),
+    // Usage is now persisted by the runtime registry wrapper via createDbUsageSink,
+    // so the only thing we verify at the service layer is that the call site
+    // tagged the run with the correct source — the sink test in the runtime
+    // package covers the recording path end-to-end.
+    expect(mockRunApiRuntimeOneShot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskId: "task-1",
+        workflowKind: "fast-fix",
+        usageContext: expect.objectContaining({ source: "fast-fix" }),
+      }),
     );
+    expect(incrementTaskTokenUsage).not.toHaveBeenCalled();
   });
 
   it("uses fallback prompt mode when file update is disabled", async () => {

--- a/packages/api/src/__tests__/runtimeService.test.ts
+++ b/packages/api/src/__tests__/runtimeService.test.ts
@@ -75,6 +75,7 @@ vi.mock("@aif/data", () => ({
   findTaskById: mockFindTaskById,
   resolveEffectiveRuntimeProfile: mockResolveEffectiveRuntimeProfile,
   toRuntimeProfileResponse: mockToRuntimeProfileResponse,
+  createDbUsageSink: () => ({ record: vi.fn() }),
 }));
 
 function createAdapter() {
@@ -370,6 +371,7 @@ describe("runtime service", () => {
       prompt: "summarize",
       includePartialMessages: true,
       maxTurns: 4,
+      usageContext: { source: "test" },
     });
 
     expect(result.result.outputText).toBe("ok");
@@ -426,6 +428,7 @@ describe("runtime service", () => {
       projectRoot: "/tmp/project",
       prompt: "generate roadmap",
       workflowKind: "roadmap-generate",
+      usageContext: { source: "test" },
     });
 
     expect(adapter.run).toHaveBeenCalledWith(
@@ -455,6 +458,7 @@ describe("runtime service", () => {
       prompt: "do work",
       workflowKind: "commit",
       systemPromptAppend: "extra",
+      usageContext: { source: "test" },
     });
 
     expect(adapter.run).toHaveBeenCalledWith(
@@ -486,6 +490,7 @@ describe("runtime service", () => {
       projectRoot: "/tmp/project",
       prompt: "do work",
       workflowKind: "commit",
+      usageContext: { source: "test" },
     });
 
     expect(adapter.run).toHaveBeenCalledWith(

--- a/packages/api/src/__tests__/settings.test.ts
+++ b/packages/api/src/__tests__/settings.test.ts
@@ -24,6 +24,7 @@ vi.mock("@aif/shared", async (importOriginal) => {
 vi.mock("@aif/data", () => ({
   findProjectById: (id: string) =>
     id === TEST_PROJECT_ID ? { id, rootPath: tempRoot } : undefined,
+  createDbUsageSink: () => ({ record: vi.fn() }),
 }));
 
 vi.mock("node:os", async (importOriginal) => {

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -8,6 +8,7 @@ import {
   RUNTIME_TRUST_TOKEN,
   resolveAdapterCapabilities,
   RuntimeTransport,
+  UsageSource,
   type RuntimeAdapter,
   type RuntimeEvent,
   type RuntimeRunInput,
@@ -853,6 +854,12 @@ chatRouter.post("/", jsonValidator(chatRequestSchema), async (c) => {
       projectRoot: project.rootPath,
       cwd: project.rootPath,
       headers: runtimeContext.resolvedProfile.headers,
+      usageContext: {
+        source: UsageSource.CHAT,
+        projectId: project.id,
+        chatSessionId: chatSessionId ?? null,
+        taskId: taskId ?? null,
+      },
       options: {
         ...runtimeContext.resolvedProfile.options,
         ...(runtimeContext.resolvedProfile.baseUrl
@@ -946,7 +953,14 @@ chatRouter.post("/", jsonValidator(chatRequestSchema), async (c) => {
 
     const doneEvent: WsEvent = {
       type: "chat:done",
-      payload: { conversationId: chatConversationId },
+      payload: {
+        conversationId: chatConversationId,
+        // Expose per-turn usage so the frontend can show token/cost spend
+        // without a round-trip to the usage_events table. Recording of the
+        // usage itself already happened inside the registry wrapper via the
+        // DB sink — this payload is purely for UI display.
+        usage: result.usage ?? null,
+      },
     };
     if (clientId) {
       sendToClient(clientId, doneEvent);
@@ -956,6 +970,7 @@ chatRouter.post("/", jsonValidator(chatRequestSchema), async (c) => {
       conversationId: chatConversationId,
       sessionId: chatSessionId,
       assistantMessage: fullAssistantResponse || null,
+      usage: result.usage ?? null,
       runtime: {
         runtimeId,
         profileId: runtimeProfileId,

--- a/packages/api/src/services/commitGeneration.ts
+++ b/packages/api/src/services/commitGeneration.ts
@@ -1,5 +1,6 @@
 import { logger } from "@aif/shared";
 import { findProjectById } from "@aif/data";
+import { UsageSource } from "@aif/runtime";
 import { runApiRuntimeOneShot } from "./runtime.js";
 
 const log = logger("commit-generation");
@@ -32,6 +33,7 @@ export async function runCommitQuery(projectId: string): Promise<void> {
       prompt: "/aif-commit",
       workflowKind: "commit",
       systemPromptAppend: PROJECT_SCOPE_APPEND,
+      usageContext: { source: UsageSource.COMMIT },
     });
     log.info({ projectId }, "/aif-commit completed successfully");
   } catch (err) {

--- a/packages/api/src/services/fastFix.ts
+++ b/packages/api/src/services/fastFix.ts
@@ -1,5 +1,6 @@
-import { findTaskById, incrementTaskTokenUsage } from "@aif/data";
+import { findTaskById } from "@aif/data";
 import { parseAttachments } from "@aif/shared";
+import { UsageSource } from "@aif/runtime";
 import { resolveApiLightModel, runApiRuntimeOneShot } from "./runtime.js";
 
 interface FastFixComment {
@@ -132,16 +133,12 @@ ${
     systemPromptAppend: includeFileUpdateStep
       ? undefined
       : "Do not use tools or subagents. Reply directly with markdown only.",
+    usageContext: { source: UsageSource.FAST_FIX },
   });
 
-  if (result.usage) {
-    incrementTaskTokenUsage(input.taskId, {
-      input_tokens: result.usage.inputTokens,
-      output_tokens: result.usage.outputTokens,
-      total_tokens: result.usage.totalTokens,
-      total_cost_usd: result.usage.costUsd,
-    });
-  }
+  // Usage recorded automatically by the runtime registry wrapper via the DB
+  // sink (see packages/api/services/runtime.ts bootstrap). No manual
+  // incrementTaskTokenUsage needed here.
 
   const resultText = (result.outputText ?? "").trim();
   if (!resultText) {

--- a/packages/api/src/services/roadmapGeneration.ts
+++ b/packages/api/src/services/roadmapGeneration.ts
@@ -2,13 +2,8 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { z } from "zod";
 import { logger, getEnv, getProjectConfig, generatePlanPath } from "@aif/shared";
-import {
-  createTask,
-  findProjectById,
-  findTasksByRoadmapAlias,
-  incrementTaskTokenUsage,
-  listTasks,
-} from "@aif/data";
+import { createTask, findProjectById, findTasksByRoadmapAlias, listTasks } from "@aif/data";
+import { UsageSource } from "@aif/runtime";
 import { resolveApiLightModel, runApiRuntimeOneShot } from "./runtime.js";
 
 const log = logger("roadmap-generation");
@@ -115,6 +110,7 @@ export async function generateRoadmapFile(
       workflowKind: "roadmap-generate",
       systemPromptAppend:
         "Do not spawn subagents. Reply directly with the ROADMAP.md content in markdown format. No JSON, no code fences around the entire output.",
+      usageContext: { source: UsageSource.ROADMAP_GENERATE },
     });
     rawResult = (result.outputText ?? "").trim();
   } catch (err) {
@@ -245,16 +241,11 @@ export async function generateRoadmapTasks(
       modelOverride: lightModel,
       systemPromptAppend:
         "Do not spawn subagents. Reply directly with JSON only. No markdown fences, no explanatory text.",
+      usageContext: { source: UsageSource.ROADMAP_EXTRACT },
     });
 
-    if (trackingTaskId && result.usage) {
-      incrementTaskTokenUsage(trackingTaskId, {
-        input_tokens: result.usage.inputTokens,
-        output_tokens: result.usage.outputTokens,
-        total_tokens: result.usage.totalTokens,
-        total_cost_usd: result.usage.costUsd,
-      });
-    }
+    // Usage recorded automatically by the runtime registry wrapper via the DB
+    // sink (runApiRuntimeOneShot stamps projectId + taskId into usageContext).
 
     rawResult = (result.outputText ?? "").trim();
   } catch (err) {

--- a/packages/api/src/services/runtime.ts
+++ b/packages/api/src/services/runtime.ts
@@ -43,6 +43,9 @@ export async function getApiRuntimeRegistry(): Promise<RuntimeRegistry> {
         warn(context, message) {
           log.warn({ ...context }, `WARN [runtime-module] ${message}`);
         },
+        error(context, message) {
+          log.error({ ...context }, `ERROR [runtime-registry] ${message}`);
+        },
       },
       runtimeModules: getEnv().AIF_RUNTIME_MODULES ?? [],
       // DB-backed sink persists every successful run through the registry

--- a/packages/api/src/services/runtime.ts
+++ b/packages/api/src/services/runtime.ts
@@ -14,10 +14,12 @@ import {
   type RuntimeAdapter,
   type RuntimeModelDiscoveryService,
   type RuntimeRegistry,
+  type RuntimeUsageContext,
   type RuntimeWorkflowSpec,
 } from "@aif/runtime";
 import { getEnv, logger } from "@aif/shared";
 import {
+  createDbUsageSink,
   findProjectById,
   findRuntimeProfileById,
   findTaskById,
@@ -43,6 +45,10 @@ export async function getApiRuntimeRegistry(): Promise<RuntimeRegistry> {
         },
       },
       runtimeModules: getEnv().AIF_RUNTIME_MODULES ?? [],
+      // DB-backed sink persists every successful run through the registry
+      // wrapper. Structurally matches @aif/runtime's RuntimeUsageSink —
+      // no cross-package type import needed.
+      usageSink: createDbUsageSink(),
     }).catch((error) => {
       runtimeRegistryPromise = null;
       throw error;
@@ -237,6 +243,13 @@ export async function runApiRuntimeOneShot(input: {
   systemPromptAppend?: string;
   includePartialMessages?: boolean;
   maxTurns?: number;
+  /**
+   * Scope metadata for usage tracking. Callers must pick one `UsageSource`
+   * value identifying the logical flow (fast-fix, commit, roadmap-*, ...).
+   * `projectId` is always included automatically; `taskId` is added when the
+   * caller passes one in `input.taskId`.
+   */
+  usageContext: RuntimeUsageContext;
 }): Promise<{
   result: RuntimeRunResult;
   context: RuntimeExecutionContext;
@@ -276,6 +289,14 @@ export async function runApiRuntimeOneShot(input: {
     projectRoot: input.projectRoot,
     cwd: input.projectRoot,
     headers: context.resolvedProfile.headers,
+    // Merge caller's usageContext with scope fields we already know here.
+    // The caller chooses the source (commit, fast-fix, ...); we fill in
+    // projectId + taskId so the sink has the full scope automatically.
+    usageContext: {
+      ...input.usageContext,
+      projectId: input.projectId,
+      taskId: input.taskId ?? null,
+    },
     options: {
       ...context.resolvedProfile.options,
       ...(context.resolvedProfile.baseUrl ? { baseUrl: context.resolvedProfile.baseUrl } : {}),

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -906,14 +906,6 @@ export function recordUsageEvent(event: DbUsageEvent): void {
   const { usage, context } = event;
   const db = getDb();
 
-  // Shape the usage into the snake_case form `parseTaskTokenUsage` also
-  // accepts, so all three increment helpers see identical numbers.
-  const usagePayload: Record<string, unknown> = {
-    input_tokens: usage.inputTokens,
-    output_tokens: usage.outputTokens,
-    total_cost_usd: usage.costUsd ?? 0,
-  };
-
   // Wrap insert + aggregate updates in a single transaction so the
   // append-only log and rolled-up counters stay consistent. If any
   // update fails the entire batch rolls back — no partial divergence.
@@ -937,13 +929,20 @@ export function recordUsageEvent(event: DbUsageEvent): void {
       })
       .run();
 
+    // Use usage.totalTokens (the provider's authoritative total) for all
+    // aggregates — same source of truth as the usage_events row. Never
+    // recalculate as inputTokens + outputTokens: providers may include
+    // additional token categories (cache, reasoning, etc.) in their total.
+    const totalTokensDelta = usage.totalTokens;
+    const costDelta = usage.costUsd ?? 0;
+
     if (context.taskId) {
       tx.update(tasks)
         .set({
-          tokenInput: sql<number>`coalesce(${tasks.tokenInput}, 0) + ${usagePayload.input_tokens}`,
-          tokenOutput: sql<number>`coalesce(${tasks.tokenOutput}, 0) + ${usagePayload.output_tokens}`,
-          tokenTotal: sql<number>`coalesce(${tasks.tokenTotal}, 0) + ${(usage.inputTokens ?? 0) + (usage.outputTokens ?? 0)}`,
-          costUsd: sql<number>`coalesce(${tasks.costUsd}, 0) + ${usagePayload.total_cost_usd}`,
+          tokenInput: sql<number>`coalesce(${tasks.tokenInput}, 0) + ${usage.inputTokens}`,
+          tokenOutput: sql<number>`coalesce(${tasks.tokenOutput}, 0) + ${usage.outputTokens}`,
+          tokenTotal: sql<number>`coalesce(${tasks.tokenTotal}, 0) + ${totalTokensDelta}`,
+          costUsd: sql<number>`coalesce(${tasks.costUsd}, 0) + ${costDelta}`,
         })
         .where(eq(tasks.id, context.taskId))
         .run();
@@ -951,10 +950,10 @@ export function recordUsageEvent(event: DbUsageEvent): void {
     if (context.projectId) {
       tx.update(projects)
         .set({
-          tokenInput: sql<number>`coalesce(${projects.tokenInput}, 0) + ${usagePayload.input_tokens}`,
-          tokenOutput: sql<number>`coalesce(${projects.tokenOutput}, 0) + ${usagePayload.output_tokens}`,
-          tokenTotal: sql<number>`coalesce(${projects.tokenTotal}, 0) + ${(usage.inputTokens ?? 0) + (usage.outputTokens ?? 0)}`,
-          costUsd: sql<number>`coalesce(${projects.costUsd}, 0) + ${usagePayload.total_cost_usd}`,
+          tokenInput: sql<number>`coalesce(${projects.tokenInput}, 0) + ${usage.inputTokens}`,
+          tokenOutput: sql<number>`coalesce(${projects.tokenOutput}, 0) + ${usage.outputTokens}`,
+          tokenTotal: sql<number>`coalesce(${projects.tokenTotal}, 0) + ${totalTokensDelta}`,
+          costUsd: sql<number>`coalesce(${projects.costUsd}, 0) + ${costDelta}`,
         })
         .where(eq(projects.id, context.projectId))
         .run();
@@ -962,10 +961,10 @@ export function recordUsageEvent(event: DbUsageEvent): void {
     if (context.chatSessionId) {
       tx.update(chatSessions)
         .set({
-          tokenInput: sql<number>`coalesce(${chatSessions.tokenInput}, 0) + ${usagePayload.input_tokens}`,
-          tokenOutput: sql<number>`coalesce(${chatSessions.tokenOutput}, 0) + ${usagePayload.output_tokens}`,
-          tokenTotal: sql<number>`coalesce(${chatSessions.tokenTotal}, 0) + ${(usage.inputTokens ?? 0) + (usage.outputTokens ?? 0)}`,
-          costUsd: sql<number>`coalesce(${chatSessions.costUsd}, 0) + ${usagePayload.total_cost_usd}`,
+          tokenInput: sql<number>`coalesce(${chatSessions.tokenInput}, 0) + ${usage.inputTokens}`,
+          tokenOutput: sql<number>`coalesce(${chatSessions.tokenOutput}, 0) + ${usage.outputTokens}`,
+          tokenTotal: sql<number>`coalesce(${chatSessions.tokenTotal}, 0) + ${totalTokensDelta}`,
+          costUsd: sql<number>`coalesce(${chatSessions.costUsd}, 0) + ${costDelta}`,
         })
         .where(eq(chatSessions.id, context.chatSessionId))
         .run();

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -12,6 +12,7 @@ import {
   runtimeProfiles,
   chatSessions,
   chatMessages,
+  usageEvents,
   type CreateRuntimeProfileInput,
   type EffectiveRuntimeProfileSelection,
   type RuntimeProfile,
@@ -807,6 +808,165 @@ export function incrementTaskTokenUsage(
     .run();
 
   return delta;
+}
+
+export function incrementProjectTokenUsage(
+  projectId: string,
+  usage: Record<string, unknown> | null | undefined,
+) {
+  const delta = parseTaskTokenUsage(usage);
+  if (delta.total === 0 && delta.costUsd === 0) return delta;
+
+  getDb()
+    .update(projects)
+    .set({
+      tokenInput: sql<number>`coalesce(${projects.tokenInput}, 0) + ${delta.input}`,
+      tokenOutput: sql<number>`coalesce(${projects.tokenOutput}, 0) + ${delta.output}`,
+      tokenTotal: sql<number>`coalesce(${projects.tokenTotal}, 0) + ${delta.total}`,
+      costUsd: sql<number>`coalesce(${projects.costUsd}, 0) + ${delta.costUsd}`,
+    })
+    .where(eq(projects.id, projectId))
+    .run();
+
+  return delta;
+}
+
+export function incrementChatSessionTokenUsage(
+  chatSessionId: string,
+  usage: Record<string, unknown> | null | undefined,
+) {
+  const delta = parseTaskTokenUsage(usage);
+  if (delta.total === 0 && delta.costUsd === 0) return delta;
+
+  getDb()
+    .update(chatSessions)
+    .set({
+      tokenInput: sql<number>`coalesce(${chatSessions.tokenInput}, 0) + ${delta.input}`,
+      tokenOutput: sql<number>`coalesce(${chatSessions.tokenOutput}, 0) + ${delta.output}`,
+      tokenTotal: sql<number>`coalesce(${chatSessions.tokenTotal}, 0) + ${delta.total}`,
+      costUsd: sql<number>`coalesce(${chatSessions.costUsd}, 0) + ${delta.costUsd}`,
+    })
+    .where(eq(chatSessions.id, chatSessionId))
+    .run();
+
+  return delta;
+}
+
+// ---------------------------------------------------------------------------
+// Usage event sink — structural type matching `@aif/runtime`'s RuntimeUsageSink
+// ---------------------------------------------------------------------------
+
+/**
+ * Structural shape of a usage event. Mirrors `RuntimeUsageEvent` from
+ * `@aif/runtime/usageSink` without an import so `@aif/data` stays free of
+ * a dependency on `@aif/runtime` (runtime → shared → data is the intended
+ * direction; data must not know about the runtime layer).
+ *
+ * The host process (api or agent) passes `createDbUsageSink()` to
+ * `createRuntimeRegistry({ usageSink })`, where TypeScript's structural
+ * typing verifies that the returned object satisfies `RuntimeUsageSink`.
+ */
+export interface DbUsageEvent {
+  context: {
+    source: string;
+    projectId?: string | null;
+    taskId?: string | null;
+    chatSessionId?: string | null;
+  };
+  runtimeId: string;
+  providerId: string;
+  profileId?: string | null;
+  transport?: string;
+  workflowKind?: string;
+  usageReporting: string;
+  usage: {
+    inputTokens: number;
+    outputTokens: number;
+    totalTokens: number;
+    costUsd?: number;
+  };
+  recordedAt: Date;
+}
+
+export interface DbUsageSink {
+  record(event: DbUsageEvent): void;
+}
+
+/**
+ * Insert a `usage_events` row and roll the usage delta into whichever
+ * per-entity aggregate counters the event has scope for (task, project,
+ * chat-session). Any subset of scopes may be present — a chat turn has
+ * project + chat-session but no task; a subagent run has project + task
+ * but no chat-session; a commit run has only project.
+ *
+ * Runs all four writes in a single transaction so the append-only log and
+ * the rolled-up counters stay consistent.
+ */
+export function recordUsageEvent(event: DbUsageEvent): void {
+  const { usage, context } = event;
+  const db = getDb();
+
+  // Shape the usage into the snake_case form `parseTaskTokenUsage` also
+  // accepts, so all three increment helpers see identical numbers.
+  const usagePayload: Record<string, unknown> = {
+    input_tokens: usage.inputTokens,
+    output_tokens: usage.outputTokens,
+    total_cost_usd: usage.costUsd ?? 0,
+  };
+
+  db.insert(usageEvents)
+    .values({
+      source: context.source,
+      projectId: context.projectId ?? null,
+      taskId: context.taskId ?? null,
+      chatSessionId: context.chatSessionId ?? null,
+      runtimeId: event.runtimeId,
+      providerId: event.providerId,
+      profileId: event.profileId ?? null,
+      transport: event.transport ?? null,
+      workflowKind: event.workflowKind ?? null,
+      usageReporting: event.usageReporting,
+      inputTokens: usage.inputTokens,
+      outputTokens: usage.outputTokens,
+      totalTokens: usage.totalTokens,
+      costUsd: usage.costUsd ?? null,
+    })
+    .run();
+
+  if (context.taskId) {
+    incrementTaskTokenUsage(context.taskId, usagePayload);
+  }
+  if (context.projectId) {
+    incrementProjectTokenUsage(context.projectId, usagePayload);
+  }
+  if (context.chatSessionId) {
+    incrementChatSessionTokenUsage(context.chatSessionId, usagePayload);
+  }
+}
+
+/**
+ * Build a `DbUsageSink` (structurally compatible with
+ * `@aif/runtime.RuntimeUsageSink`) that persists every event via
+ * `recordUsageEvent`. Sink methods are non-throwing: any DB error is logged
+ * and swallowed so a broken sink never breaks the caller mid-run.
+ */
+export function createDbUsageSink(): DbUsageSink {
+  return {
+    record(event) {
+      try {
+        recordUsageEvent(event);
+      } catch (err) {
+        log.error(
+          {
+            err,
+            runtimeId: event.runtimeId,
+            source: event.context.source,
+          },
+          "Failed to record usage event — dropping silently",
+        );
+      }
+    },
+  };
 }
 
 /**

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -914,34 +914,63 @@ export function recordUsageEvent(event: DbUsageEvent): void {
     total_cost_usd: usage.costUsd ?? 0,
   };
 
-  db.insert(usageEvents)
-    .values({
-      source: context.source,
-      projectId: context.projectId ?? null,
-      taskId: context.taskId ?? null,
-      chatSessionId: context.chatSessionId ?? null,
-      runtimeId: event.runtimeId,
-      providerId: event.providerId,
-      profileId: event.profileId ?? null,
-      transport: event.transport ?? null,
-      workflowKind: event.workflowKind ?? null,
-      usageReporting: event.usageReporting,
-      inputTokens: usage.inputTokens,
-      outputTokens: usage.outputTokens,
-      totalTokens: usage.totalTokens,
-      costUsd: usage.costUsd ?? null,
-    })
-    .run();
+  // Wrap insert + aggregate updates in a single transaction so the
+  // append-only log and rolled-up counters stay consistent. If any
+  // update fails the entire batch rolls back — no partial divergence.
+  db.transaction((tx) => {
+    tx.insert(usageEvents)
+      .values({
+        source: context.source,
+        projectId: context.projectId ?? null,
+        taskId: context.taskId ?? null,
+        chatSessionId: context.chatSessionId ?? null,
+        runtimeId: event.runtimeId,
+        providerId: event.providerId,
+        profileId: event.profileId ?? null,
+        transport: event.transport ?? null,
+        workflowKind: event.workflowKind ?? null,
+        usageReporting: event.usageReporting,
+        inputTokens: usage.inputTokens,
+        outputTokens: usage.outputTokens,
+        totalTokens: usage.totalTokens,
+        costUsd: usage.costUsd ?? null,
+      })
+      .run();
 
-  if (context.taskId) {
-    incrementTaskTokenUsage(context.taskId, usagePayload);
-  }
-  if (context.projectId) {
-    incrementProjectTokenUsage(context.projectId, usagePayload);
-  }
-  if (context.chatSessionId) {
-    incrementChatSessionTokenUsage(context.chatSessionId, usagePayload);
-  }
+    if (context.taskId) {
+      tx.update(tasks)
+        .set({
+          tokenInput: sql<number>`coalesce(${tasks.tokenInput}, 0) + ${usagePayload.input_tokens}`,
+          tokenOutput: sql<number>`coalesce(${tasks.tokenOutput}, 0) + ${usagePayload.output_tokens}`,
+          tokenTotal: sql<number>`coalesce(${tasks.tokenTotal}, 0) + ${(usage.inputTokens ?? 0) + (usage.outputTokens ?? 0)}`,
+          costUsd: sql<number>`coalesce(${tasks.costUsd}, 0) + ${usagePayload.total_cost_usd}`,
+        })
+        .where(eq(tasks.id, context.taskId))
+        .run();
+    }
+    if (context.projectId) {
+      tx.update(projects)
+        .set({
+          tokenInput: sql<number>`coalesce(${projects.tokenInput}, 0) + ${usagePayload.input_tokens}`,
+          tokenOutput: sql<number>`coalesce(${projects.tokenOutput}, 0) + ${usagePayload.output_tokens}`,
+          tokenTotal: sql<number>`coalesce(${projects.tokenTotal}, 0) + ${(usage.inputTokens ?? 0) + (usage.outputTokens ?? 0)}`,
+          costUsd: sql<number>`coalesce(${projects.costUsd}, 0) + ${usagePayload.total_cost_usd}`,
+        })
+        .where(eq(projects.id, context.projectId))
+        .run();
+    }
+    if (context.chatSessionId) {
+      tx.update(chatSessions)
+        .set({
+          tokenInput: sql<number>`coalesce(${chatSessions.tokenInput}, 0) + ${usagePayload.input_tokens}`,
+          tokenOutput: sql<number>`coalesce(${chatSessions.tokenOutput}, 0) + ${usagePayload.output_tokens}`,
+          tokenTotal: sql<number>`coalesce(${chatSessions.tokenTotal}, 0) + ${(usage.inputTokens ?? 0) + (usage.outputTokens ?? 0)}`,
+          costUsd: sql<number>`coalesce(${chatSessions.costUsd}, 0) + ${usagePayload.total_cost_usd}`,
+        })
+        .where(eq(chatSessions.id, context.chatSessionId))
+        .run();
+    }
+  });
 }
 
 /**

--- a/packages/runtime/src/__tests__/bootstrap.test.ts
+++ b/packages/runtime/src/__tests__/bootstrap.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import { bootstrapRuntimeRegistry } from "../bootstrap.js";
+import { UsageReporting } from "../types.js";
+
+const VALID_USAGE_REPORTING = new Set<string>(Object.values(UsageReporting));
 
 describe("bootstrapRuntimeRegistry", () => {
   it("creates registry with built-in claude, codex, opencode, and openrouter adapters", async () => {
@@ -72,6 +75,26 @@ describe("bootstrapRuntimeRegistry", () => {
     // Each call creates a fresh registry
     expect(a).not.toBe(b);
     expect(a.listRuntimes().length).toBe(b.listRuntimes().length);
+  });
+
+  // Discovery test: enforces that every built-in adapter has declared a
+  // `usageReporting` capability. A new adapter added to bootstrap.ts without
+  // that field would ship with undefined usage tracking — this test is the
+  // last line of defence against that regression.
+  it("every built-in adapter declares a valid usageReporting capability", async () => {
+    const registry = await bootstrapRuntimeRegistry();
+    const runtimes = registry.listRuntimes();
+    expect(runtimes.length).toBeGreaterThan(0);
+    for (const descriptor of runtimes) {
+      expect(
+        descriptor.capabilities.usageReporting,
+        `runtime "${descriptor.id}" is missing usageReporting capability`,
+      ).toBeDefined();
+      expect(
+        VALID_USAGE_REPORTING.has(descriptor.capabilities.usageReporting),
+        `runtime "${descriptor.id}" declared invalid usageReporting "${descriptor.capabilities.usageReporting}"`,
+      ).toBe(true);
+    }
   });
 });
 it("opencode adapter has expected capabilities", async () => {

--- a/packages/runtime/src/__tests__/capabilities.test.ts
+++ b/packages/runtime/src/__tests__/capabilities.test.ts
@@ -3,6 +3,7 @@ import {
   assertRuntimeCapabilities,
   checkRuntimeCapabilities,
   RuntimeCapabilityError,
+  UsageReporting,
 } from "../index.js";
 
 describe("runtime capability checks", () => {
@@ -14,6 +15,7 @@ describe("runtime capability checks", () => {
     supportsModelDiscovery: false,
     supportsApprovals: true,
     supportsCustomEndpoint: true,
+    usageReporting: UsageReporting.NONE,
   };
 
   it("returns ok when all required capabilities are present", () => {

--- a/packages/runtime/src/__tests__/claudeAdapter.test.ts
+++ b/packages/runtime/src/__tests__/claudeAdapter.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TEST_USAGE_CONTEXT } from "./helpers/usageContext.js";
 
 const queryMock = vi.fn();
 const listSessionsMock = vi.fn();
@@ -40,6 +41,7 @@ function createRunInput(overrides: Record<string, unknown> = {}) {
       startTimeoutMs: 10,
       startRetryDelayMs: 0,
     },
+    usageContext: TEST_USAGE_CONTEXT,
     ...overrides,
   };
 }

--- a/packages/runtime/src/__tests__/claudeAdapterTransport.test.ts
+++ b/packages/runtime/src/__tests__/claudeAdapterTransport.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { RuntimeTransport } from "../types.js";
+import { TEST_USAGE_CONTEXT } from "./helpers/usageContext.js";
 
 const runClaudeRuntimeMock = vi.fn();
 const runClaudeCliMock = vi.fn();
@@ -30,6 +31,7 @@ function createRunInput(overrides: Record<string, unknown> = {}) {
     providerId: "anthropic",
     prompt: "Implement feature",
     options: {},
+    usageContext: TEST_USAGE_CONTEXT,
     ...overrides,
   };
 }

--- a/packages/runtime/src/__tests__/claudeCli.test.ts
+++ b/packages/runtime/src/__tests__/claudeCli.test.ts
@@ -1,18 +1,28 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeRunInput } from "../types.js";
 import { getCliSpawnInvocation } from "./helpers/cliSpawn.js";
+import { TEST_USAGE_CONTEXT } from "./helpers/usageContext.js";
 
-// Mock child_process.spawn
-const mockStdout = { on: vi.fn() };
-const mockStderr = { on: vi.fn() };
-const mockStdin = { on: vi.fn(), write: vi.fn(), end: vi.fn() };
-const mockChild = {
-  stdout: mockStdout,
-  stderr: mockStderr,
-  stdin: mockStdin,
-  on: vi.fn(),
-  kill: vi.fn(),
-};
+// vi.hoisted ensures the mock fixtures initialize before vi.mock's hoisted
+// factory runs. Without this, the factory below hits a TDZ error trying to
+// read `mockChild` — vi.mock is hoisted above regular top-level code.
+const { mockStdout, mockStderr, mockStdin, mockChild } = vi.hoisted(() => {
+  const stdout = { on: vi.fn() };
+  const stderr = { on: vi.fn() };
+  const stdin = { on: vi.fn(), write: vi.fn(), end: vi.fn() };
+  return {
+    mockStdout: stdout,
+    mockStderr: stderr,
+    mockStdin: stdin,
+    mockChild: {
+      stdout,
+      stderr,
+      stdin,
+      on: vi.fn(),
+      kill: vi.fn(),
+    },
+  };
+});
 
 vi.mock("node:child_process", () => ({
   spawn: vi.fn().mockReturnValue(mockChild),
@@ -28,6 +38,7 @@ function createInput(overrides: Partial<RuntimeRunInput> = {}): RuntimeRunInput 
     prompt: "Implement the feature",
     options: {},
     projectRoot: "/tmp/project",
+    usageContext: TEST_USAGE_CONTEXT,
     ...overrides,
   };
 }

--- a/packages/runtime/src/__tests__/codexAdapter.test.ts
+++ b/packages/runtime/src/__tests__/codexAdapter.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TEST_USAGE_CONTEXT } from "./helpers/usageContext.js";
 
 const runCodexCliMock = vi.fn();
 const runCodexAgentApiMock = vi.fn();
@@ -41,6 +42,7 @@ function createRunInput(overrides: Record<string, unknown> = {}) {
     workflowKind: "implementer",
     prompt: "Implement feature",
     options: {},
+    usageContext: TEST_USAGE_CONTEXT,
     ...overrides,
   };
 }

--- a/packages/runtime/src/__tests__/codexAdapterSdk.test.ts
+++ b/packages/runtime/src/__tests__/codexAdapterSdk.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { RuntimeTransport } from "../types.js";
+import { TEST_USAGE_CONTEXT } from "./helpers/usageContext.js";
 
 const runCodexCliMock = vi.fn();
 const runCodexAgentApiMock = vi.fn();
@@ -48,6 +49,7 @@ function createRunInput(overrides: Record<string, unknown> = {}) {
     workflowKind: "implementer",
     prompt: "Implement feature",
     options: {},
+    usageContext: TEST_USAGE_CONTEXT,
     ...overrides,
   };
 }

--- a/packages/runtime/src/__tests__/codexAgentApi.test.ts
+++ b/packages/runtime/src/__tests__/codexAgentApi.test.ts
@@ -6,6 +6,7 @@ import {
   validateCodexAgentApiConnection,
 } from "../adapters/codex/api.js";
 import { CodexRuntimeAdapterError } from "../adapters/codex/errors.js";
+import { TEST_USAGE_CONTEXT } from "./helpers/usageContext.js";
 
 function createRunInput(overrides: Record<string, unknown> = {}) {
   return {
@@ -18,6 +19,7 @@ function createRunInput(overrides: Record<string, unknown> = {}) {
     sessionId: "session-1",
     resume: false,
     options: {},
+    usageContext: TEST_USAGE_CONTEXT,
     ...overrides,
   };
 }

--- a/packages/runtime/src/__tests__/codexCli.test.ts
+++ b/packages/runtime/src/__tests__/codexCli.test.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "node:events";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getCliSpawnInvocation } from "./helpers/cliSpawn.js";
+import { TEST_USAGE_CONTEXT } from "./helpers/usageContext.js";
 
 const spawnMock = vi.fn();
 
@@ -47,6 +48,7 @@ function createRunInput(overrides: Record<string, unknown> = {}) {
     model: "gpt-5.4",
     sessionId: "session-1",
     options: {},
+    usageContext: TEST_USAGE_CONTEXT,
     ...overrides,
   };
 }

--- a/packages/runtime/src/__tests__/codexSdk.test.ts
+++ b/packages/runtime/src/__tests__/codexSdk.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeRunInput } from "../types.js";
+import { TEST_USAGE_CONTEXT } from "./helpers/usageContext.js";
 
 // Mock the Codex SDK
 const mockRunStreamed = vi.fn();
@@ -32,6 +33,7 @@ function createRunInput(overrides: Partial<RuntimeRunInput> = {}): RuntimeRunInp
     providerId: "openai",
     prompt: "Implement the feature",
     options: {},
+    usageContext: TEST_USAGE_CONTEXT,
     ...overrides,
   };
 }

--- a/packages/runtime/src/__tests__/getResultSessionId.test.ts
+++ b/packages/runtime/src/__tests__/getResultSessionId.test.ts
@@ -8,13 +8,14 @@ function caps(overrides: Partial<RuntimeCapabilities> = {}): RuntimeCapabilities
 
 describe("getResultSessionId", () => {
   it("returns sessionId from result", () => {
-    const result: RuntimeRunResult = { outputText: "ok", sessionId: "sess-1" };
+    const result: RuntimeRunResult = { outputText: "ok", usage: null, sessionId: "sess-1" };
     expect(getResultSessionId(result)).toBe("sess-1");
   });
 
   it("falls back to session.id when sessionId is null", () => {
     const result: RuntimeRunResult = {
       outputText: "ok",
+      usage: null,
       sessionId: null,
       session: {
         id: "sess-2",
@@ -28,30 +29,30 @@ describe("getResultSessionId", () => {
   });
 
   it("returns null when neither sessionId nor session present", () => {
-    const result: RuntimeRunResult = { outputText: "ok" };
+    const result: RuntimeRunResult = { outputText: "ok", usage: null };
     expect(getResultSessionId(result)).toBeNull();
   });
 
   it("returns null when capabilities say no session support", () => {
-    const result: RuntimeRunResult = { outputText: "ok", sessionId: "sess-3" };
+    const result: RuntimeRunResult = { outputText: "ok", usage: null, sessionId: "sess-3" };
     const noCaps = caps({ supportsResume: false, supportsSessionList: false });
     expect(getResultSessionId(result, noCaps)).toBeNull();
   });
 
   it("returns sessionId when supportsResume is true", () => {
-    const result: RuntimeRunResult = { outputText: "ok", sessionId: "sess-4" };
+    const result: RuntimeRunResult = { outputText: "ok", usage: null, sessionId: "sess-4" };
     const resumeCaps = caps({ supportsResume: true });
     expect(getResultSessionId(result, resumeCaps)).toBe("sess-4");
   });
 
   it("returns sessionId when supportsSessionList is true", () => {
-    const result: RuntimeRunResult = { outputText: "ok", sessionId: "sess-5" };
+    const result: RuntimeRunResult = { outputText: "ok", usage: null, sessionId: "sess-5" };
     const listCaps = caps({ supportsSessionList: true });
     expect(getResultSessionId(result, listCaps)).toBe("sess-5");
   });
 
   it("returns sessionId when no capabilities passed (backwards compat)", () => {
-    const result: RuntimeRunResult = { outputText: "ok", sessionId: "sess-6" };
+    const result: RuntimeRunResult = { outputText: "ok", usage: null, sessionId: "sess-6" };
     expect(getResultSessionId(result)).toBe("sess-6");
     expect(getResultSessionId(result, undefined)).toBe("sess-6");
   });

--- a/packages/runtime/src/__tests__/helpers/usageContext.ts
+++ b/packages/runtime/src/__tests__/helpers/usageContext.ts
@@ -1,0 +1,18 @@
+import { UsageSource, type RuntimeUsageContext } from "../../types.js";
+
+/**
+ * Shared test-only usage context. Lets test fixtures build valid
+ * `RuntimeRunInput` objects without repeating the boilerplate in every file.
+ *
+ * Use as:
+ * ```ts
+ * const input: RuntimeRunInput = {
+ *   runtimeId: "claude",
+ *   prompt: "...",
+ *   usageContext: TEST_USAGE_CONTEXT,
+ * };
+ * ```
+ */
+export const TEST_USAGE_CONTEXT: RuntimeUsageContext = {
+  source: UsageSource.TEST,
+};

--- a/packages/runtime/src/__tests__/modelDiscovery.test.ts
+++ b/packages/runtime/src/__tests__/modelDiscovery.test.ts
@@ -4,6 +4,7 @@ import {
   createRuntimeRegistry,
   createRuntimeMemoryCache,
   RuntimeValidationError,
+  UsageReporting,
   type RuntimeAdapter,
   type RuntimeConnectionValidationResult,
   type RuntimeModel,
@@ -53,9 +54,10 @@ describe("runtime model discovery service", () => {
           supportsModelDiscovery: true,
           supportsApprovals: false,
           supportsCustomEndpoint: false,
+          usageReporting: UsageReporting.NONE,
         },
       },
-      run: async () => ({ outputText: "ok" }),
+      run: async () => ({ outputText: "ok", usage: null }),
       listModels: listModelsMock,
       validateConnection: async () => ({ ok: true }),
     };
@@ -111,9 +113,10 @@ describe("runtime model discovery service", () => {
           supportsModelDiscovery: true,
           supportsApprovals: false,
           supportsCustomEndpoint: false,
+          usageReporting: UsageReporting.NONE,
         },
       },
-      run: async () => ({ outputText: "ok" }),
+      run: async () => ({ outputText: "ok", usage: null }),
       listModels: listModelsMock,
       validateConnection: async () => ({ ok: true }),
     };
@@ -158,9 +161,10 @@ describe("runtime model discovery service", () => {
           supportsModelDiscovery: true,
           supportsApprovals: false,
           supportsCustomEndpoint: false,
+          usageReporting: UsageReporting.NONE,
         },
       },
-      run: async () => ({ outputText: "ok" }),
+      run: async () => ({ outputText: "ok", usage: null }),
       listModels: listModelsMock,
       validateConnection: async () => ({ ok: true }),
     };
@@ -210,9 +214,10 @@ describe("runtime model discovery service", () => {
           supportsModelDiscovery: true,
           supportsApprovals: false,
           supportsCustomEndpoint: true,
+          usageReporting: UsageReporting.NONE,
         },
       },
-      run: async () => ({ outputText: "ok" }),
+      run: async () => ({ outputText: "ok", usage: null }),
       listModels: listModelsMock,
       validateConnection: async () => ({ ok: true }),
     };
@@ -250,9 +255,10 @@ describe("runtime model discovery service", () => {
           supportsModelDiscovery: false,
           supportsApprovals: false,
           supportsCustomEndpoint: false,
+          usageReporting: UsageReporting.NONE,
         },
       },
-      run: async () => ({ outputText: "ok" }),
+      run: async () => ({ outputText: "ok", usage: null }),
     };
 
     const registry = createRuntimeRegistry({ builtInAdapters: [adapter] });
@@ -276,9 +282,10 @@ describe("runtime model discovery service", () => {
           supportsModelDiscovery: true,
           supportsApprovals: false,
           supportsCustomEndpoint: false,
+          usageReporting: UsageReporting.NONE,
         },
       },
-      run: async () => ({ outputText: "ok" }),
+      run: async () => ({ outputText: "ok", usage: null }),
       listModels: async () => {
         throw new Error("network down");
       },
@@ -307,6 +314,7 @@ describe("runtime model discovery service", () => {
           supportsModelDiscovery: false,
           supportsApprovals: false,
           supportsCustomEndpoint: false,
+          usageReporting: UsageReporting.NONE,
         },
       },
       getEffectiveCapabilities: (transport) => ({
@@ -317,8 +325,9 @@ describe("runtime model discovery service", () => {
         supportsModelDiscovery: transport === "api",
         supportsApprovals: false,
         supportsCustomEndpoint: true,
+        usageReporting: UsageReporting.NONE,
       }),
-      run: async () => ({ outputText: "ok" }),
+      run: async () => ({ outputText: "ok", usage: null }),
       listModels: listModelsMock,
     };
 
@@ -376,9 +385,10 @@ describe("runtime model discovery service", () => {
           supportsModelDiscovery: true,
           supportsApprovals: false,
           supportsCustomEndpoint: false,
+          usageReporting: UsageReporting.NONE,
         },
       },
-      run: async () => ({ outputText: "ok" }),
+      run: async () => ({ outputText: "ok", usage: null }),
       listModels: listModelsMock,
       validateConnection: async () => ({ ok: true }),
     };
@@ -412,9 +422,10 @@ describe("runtime model discovery service", () => {
           supportsModelDiscovery: true,
           supportsApprovals: false,
           supportsCustomEndpoint: false,
+          usageReporting: UsageReporting.NONE,
         },
       },
-      run: async () => ({ outputText: "ok" }),
+      run: async () => ({ outputText: "ok", usage: null }),
       validateConnection: validateConnectionMock,
     };
 
@@ -448,9 +459,10 @@ describe("runtime model discovery service", () => {
           supportsModelDiscovery: true,
           supportsApprovals: false,
           supportsCustomEndpoint: true,
+          usageReporting: UsageReporting.NONE,
         },
       },
-      run: async () => ({ outputText: "ok" }),
+      run: async () => ({ outputText: "ok", usage: null }),
       validateConnection: validateConnectionMock,
     };
 
@@ -487,9 +499,10 @@ describe("runtime model discovery service", () => {
           supportsModelDiscovery: false,
           supportsApprovals: false,
           supportsCustomEndpoint: false,
+          usageReporting: UsageReporting.NONE,
         },
       },
-      run: async () => ({ outputText: "ok" }),
+      run: async () => ({ outputText: "ok", usage: null }),
     };
 
     const registry = createRuntimeRegistry({ builtInAdapters: [adapter] });
@@ -524,9 +537,10 @@ describe("runtime model discovery service", () => {
           supportsModelDiscovery: false,
           supportsApprovals: false,
           supportsCustomEndpoint: false,
+          usageReporting: UsageReporting.NONE,
         },
       },
-      run: async () => ({ outputText: "ok" }),
+      run: async () => ({ outputText: "ok", usage: null }),
       validateConnection: async () => {
         throw new Error("validation transport failure");
       },

--- a/packages/runtime/src/__tests__/moduleLoader.test.ts
+++ b/packages/runtime/src/__tests__/moduleLoader.test.ts
@@ -4,12 +4,12 @@ import { pathToFileURL } from "node:url";
 import { tmpdir } from "node:os";
 import { unlink, writeFile } from "node:fs/promises";
 import {
-  createCodexRuntimeAdapter,
   createRuntimeRegistry,
   resolveRuntimeModuleRegistrar,
   DEFAULT_RUNTIME_CAPABILITIES,
   type RuntimeRegistry,
 } from "../index.js";
+import { createCodexRuntimeAdapter } from "../adapters/codex/index.js";
 
 describe("runtime module loader", () => {
   it("resolves registrar from default object export", () => {

--- a/packages/runtime/src/__tests__/opencodeAdapter.test.ts
+++ b/packages/runtime/src/__tests__/opencodeAdapter.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { OpenCodeRuntimeAdapterError } from "../adapters/opencode/errors.js";
+import { TEST_USAGE_CONTEXT } from "./helpers/usageContext.js";
 
 const runOpenCodeApiMock = vi.fn();
 const listOpenCodeSessionsMock = vi.fn();
@@ -28,6 +29,7 @@ function createRunInput(overrides: Record<string, unknown> = {}) {
     prompt: "Implement feature",
     model: "anthropic/claude-sonnet-4",
     options: {},
+    usageContext: TEST_USAGE_CONTEXT,
     ...overrides,
   };
 }

--- a/packages/runtime/src/__tests__/opencodeApi.test.ts
+++ b/packages/runtime/src/__tests__/opencodeApi.test.ts
@@ -8,6 +8,7 @@ import {
   validateOpenCodeApiConnection,
 } from "../adapters/opencode/api.js";
 import { OpenCodeRuntimeAdapterError } from "../adapters/opencode/errors.js";
+import { TEST_USAGE_CONTEXT } from "./helpers/usageContext.js";
 
 function createRunInput(overrides: Record<string, unknown> = {}) {
   return {
@@ -18,6 +19,7 @@ function createRunInput(overrides: Record<string, unknown> = {}) {
     prompt: "Implement feature",
     model: "anthropic/claude-sonnet-4",
     options: {},
+    usageContext: TEST_USAGE_CONTEXT,
     ...overrides,
   };
 }

--- a/packages/runtime/src/__tests__/openrouterAdapter.test.ts
+++ b/packages/runtime/src/__tests__/openrouterAdapter.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { OpenRouterRuntimeAdapterError } from "../adapters/openrouter/errors.js";
+import { TEST_USAGE_CONTEXT } from "./helpers/usageContext.js";
 
 const runOpenRouterApiMock = vi.fn();
 const runOpenRouterApiStreamingMock = vi.fn();
@@ -25,6 +26,7 @@ function createRunInput(overrides: Record<string, unknown> = {}) {
     prompt: "Implement feature",
     model: "anthropic/claude-sonnet-4",
     options: {},
+    usageContext: TEST_USAGE_CONTEXT,
     ...overrides,
   };
 }

--- a/packages/runtime/src/__tests__/openrouterApi.test.ts
+++ b/packages/runtime/src/__tests__/openrouterApi.test.ts
@@ -6,6 +6,7 @@ import {
   validateOpenRouterApiConnection,
 } from "../adapters/openrouter/api.js";
 import { OpenRouterRuntimeAdapterError } from "../adapters/openrouter/errors.js";
+import { TEST_USAGE_CONTEXT } from "./helpers/usageContext.js";
 
 function createRunInput(overrides: Record<string, unknown> = {}) {
   return {
@@ -16,6 +17,7 @@ function createRunInput(overrides: Record<string, unknown> = {}) {
     prompt: "Implement feature",
     model: "anthropic/claude-sonnet-4",
     options: {},
+    usageContext: TEST_USAGE_CONTEXT,
     ...overrides,
   };
 }

--- a/packages/runtime/src/__tests__/registry.test.ts
+++ b/packages/runtime/src/__tests__/registry.test.ts
@@ -13,8 +13,13 @@ import {
   createRuntimeRegistry,
   DEFAULT_RUNTIME_CAPABILITIES,
   resolveRuntimeModuleRegistrar,
+  UsageReporting,
+  UsageSource,
   type RuntimeAdapter,
+  type RuntimeUsageEvent,
+  type RuntimeUsageSink,
 } from "../index.js";
+import { TEST_USAGE_CONTEXT } from "./helpers/usageContext.js";
 
 function createAdapter(runtimeId: string, providerId = "provider"): RuntimeAdapter {
   return {
@@ -25,7 +30,7 @@ function createAdapter(runtimeId: string, providerId = "provider"): RuntimeAdapt
       capabilities: { ...DEFAULT_RUNTIME_CAPABILITIES },
     },
     async run() {
-      return { outputText: "ok" };
+      return { outputText: "ok", usage: null };
     },
   };
 }
@@ -251,6 +256,7 @@ describe("skill command prefix decorator", () => {
     await resolved.run({
       runtimeId: "codex",
       prompt: "/aif-plan fast @PLAN.md\n\nAlso /aif-review",
+      usageContext: TEST_USAGE_CONTEXT,
     });
 
     expect(runMock).toHaveBeenCalledTimes(1);
@@ -279,6 +285,7 @@ describe("skill command prefix decorator", () => {
     await resolved.run({
       runtimeId: "claude",
       prompt: "/aif-plan fast",
+      usageContext: TEST_USAGE_CONTEXT,
     });
 
     expect(runMock.mock.calls[0][0].prompt).toBe("/aif-plan fast");
@@ -305,6 +312,7 @@ describe("skill command prefix decorator", () => {
       runtimeId: "codex",
       prompt: "/aif-implement @PLAN.md",
       sessionId: "session-1",
+      usageContext: TEST_USAGE_CONTEXT,
     });
 
     expect(resumeMock.mock.calls[0][0].prompt).toBe("$aif-implement @PLAN.md");
@@ -367,6 +375,7 @@ describe("skill command prefix decorator", () => {
     await resolved.run({
       runtimeId: "codex",
       prompt: "/aif-commit",
+      usageContext: TEST_USAGE_CONTEXT,
     });
 
     expect(runMock.mock.calls[0][0].prompt).toBe("$aif-commit");
@@ -391,11 +400,171 @@ describe("skill command prefix decorator", () => {
     await resolved.run({
       runtimeId: "codex",
       prompt: "Check /etc/config\n/aif-plan fast",
+      usageContext: TEST_USAGE_CONTEXT,
     });
 
     const passedPrompt = runMock.mock.calls[0][0].prompt;
     expect(passedPrompt).toContain("/etc/config");
     expect(passedPrompt).toContain("$aif-plan fast");
+  });
+});
+
+describe("registry usage pipeline", () => {
+  function createCapturingSink(): RuntimeUsageSink & { events: RuntimeUsageEvent[] } {
+    const events: RuntimeUsageEvent[] = [];
+    return {
+      events,
+      record(event) {
+        events.push(event);
+      },
+    };
+  }
+
+  function createFakeAdapter(options: {
+    runtimeId?: string;
+    usageReporting: (typeof UsageReporting)[keyof typeof UsageReporting];
+    returnedUsage: RuntimeUsageEvent["usage"] | null;
+  }): RuntimeAdapter {
+    return {
+      descriptor: {
+        id: options.runtimeId ?? "fake",
+        providerId: "fake-provider",
+        displayName: "Fake",
+        capabilities: {
+          ...DEFAULT_RUNTIME_CAPABILITIES,
+          usageReporting: options.usageReporting,
+        },
+      },
+      async run() {
+        return { outputText: "ok", usage: options.returnedUsage };
+      },
+    };
+  }
+
+  const sampleUsage = { inputTokens: 10, outputTokens: 20, totalTokens: 30, costUsd: 0.0042 };
+
+  it("forwards usage to the sink when adapter returns non-null usage", async () => {
+    const sink = createCapturingSink();
+    const registry = createRuntimeRegistry({
+      usageSink: sink,
+      builtInAdapters: [
+        createFakeAdapter({ usageReporting: UsageReporting.FULL, returnedUsage: sampleUsage }),
+      ],
+    });
+    const adapter = registry.resolveRuntime("fake");
+
+    await adapter.run({
+      runtimeId: "fake",
+      prompt: "hello",
+      workflowKind: "test",
+      usageContext: { source: UsageSource.TEST, projectId: "p-1", taskId: "t-1" },
+    });
+
+    expect(sink.events).toHaveLength(1);
+    const event = sink.events[0];
+    expect(event.usage).toEqual(sampleUsage);
+    expect(event.context.source).toBe(UsageSource.TEST);
+    expect(event.context.projectId).toBe("p-1");
+    expect(event.context.taskId).toBe("t-1");
+    expect(event.runtimeId).toBe("fake");
+    expect(event.usageReporting).toBe(UsageReporting.FULL);
+    expect(event.recordedAt).toBeInstanceOf(Date);
+  });
+
+  it("does not call sink when adapter returns null usage", async () => {
+    const sink = createCapturingSink();
+    const registry = createRuntimeRegistry({
+      usageSink: sink,
+      builtInAdapters: [
+        createFakeAdapter({ usageReporting: UsageReporting.PARTIAL, returnedUsage: null }),
+      ],
+    });
+    const adapter = registry.resolveRuntime("fake");
+
+    await adapter.run({
+      runtimeId: "fake",
+      prompt: "hello",
+      usageContext: { source: UsageSource.TEST },
+    });
+
+    expect(sink.events).toHaveLength(0);
+  });
+
+  it("logs error when adapter declared FULL but returns null usage", async () => {
+    const sink = createCapturingSink();
+    const error = vi.fn();
+    const registry = createRuntimeRegistry({
+      usageSink: sink,
+      logger: { debug: vi.fn(), warn: vi.fn(), error },
+      builtInAdapters: [
+        createFakeAdapter({ usageReporting: UsageReporting.FULL, returnedUsage: null }),
+      ],
+    });
+    const adapter = registry.resolveRuntime("fake");
+
+    await adapter.run({
+      runtimeId: "fake",
+      prompt: "hello",
+      usageContext: { source: UsageSource.TEST },
+    });
+
+    expect(sink.events).toHaveLength(0);
+    expect(error).toHaveBeenCalledWith(
+      expect.objectContaining({ usageReporting: UsageReporting.FULL }),
+      expect.stringContaining("FULL"),
+    );
+  });
+
+  it("warns when adapter declared NONE but returns non-null usage", async () => {
+    const sink = createCapturingSink();
+    const warn = vi.fn();
+    const registry = createRuntimeRegistry({
+      usageSink: sink,
+      logger: { debug: vi.fn(), warn, error: vi.fn() },
+      builtInAdapters: [
+        createFakeAdapter({ usageReporting: UsageReporting.NONE, returnedUsage: sampleUsage }),
+      ],
+    });
+    const adapter = registry.resolveRuntime("fake");
+
+    await adapter.run({
+      runtimeId: "fake",
+      prompt: "hello",
+      usageContext: { source: UsageSource.TEST },
+    });
+
+    // Still records the event — we take the data when we get it — but warns.
+    expect(sink.events).toHaveLength(1);
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({ usageReporting: UsageReporting.NONE }),
+      expect.stringContaining("NONE"),
+    );
+  });
+
+  it("swallows sink errors without breaking the caller", async () => {
+    const error = vi.fn();
+    const throwingSink: RuntimeUsageSink = {
+      record() {
+        throw new Error("sink exploded");
+      },
+    };
+    const registry = createRuntimeRegistry({
+      usageSink: throwingSink,
+      logger: { debug: vi.fn(), warn: vi.fn(), error },
+      builtInAdapters: [
+        createFakeAdapter({ usageReporting: UsageReporting.FULL, returnedUsage: sampleUsage }),
+      ],
+    });
+    const adapter = registry.resolveRuntime("fake");
+
+    const result = await adapter.run({
+      runtimeId: "fake",
+      prompt: "hello",
+      usageContext: { source: UsageSource.TEST },
+    });
+
+    expect(result.outputText).toBe("ok");
+    expect(error).toHaveBeenCalled();
   });
 });
 

--- a/packages/runtime/src/__tests__/resolveAdapterCapabilities.test.ts
+++ b/packages/runtime/src/__tests__/resolveAdapterCapabilities.test.ts
@@ -18,7 +18,7 @@ function createAdapter(
       displayName: "Test",
       capabilities,
     },
-    run: async () => ({ outputText: "" }),
+    run: async () => ({ outputText: "", usage: null }),
     ...(getEffective ? { getEffectiveCapabilities: getEffective } : {}),
   };
 }

--- a/packages/runtime/src/__tests__/workflowSpec.test.ts
+++ b/packages/runtime/src/__tests__/workflowSpec.test.ts
@@ -3,6 +3,7 @@ import {
   createRuntimeWorkflowSpec,
   resolveRuntimePromptPolicy,
   transformSkillCommandPrefix,
+  UsageReporting,
   type RuntimeCapabilities,
 } from "../index.js";
 
@@ -14,6 +15,7 @@ const CODEX_CAPABILITIES: RuntimeCapabilities = {
   supportsModelDiscovery: false,
   supportsApprovals: true,
   supportsCustomEndpoint: true,
+  usageReporting: UsageReporting.NONE,
 };
 
 const CLAUDE_CAPABILITIES: RuntimeCapabilities = {
@@ -24,6 +26,7 @@ const CLAUDE_CAPABILITIES: RuntimeCapabilities = {
   supportsModelDiscovery: true,
   supportsApprovals: true,
   supportsCustomEndpoint: true,
+  usageReporting: UsageReporting.FULL,
 };
 
 describe("runtime workflow spec + prompt policy", () => {

--- a/packages/runtime/src/adapters/TEMPLATE.ts
+++ b/packages/runtime/src/adapters/TEMPLATE.ts
@@ -241,12 +241,31 @@ export function createExampleRuntimeAdapter(
         // supportsStreaming: true,
         // supportsModelDiscovery: true,
         // supportsCustomEndpoint: true,
+        //
+        // REQUIRED: declare your usage-reporting contract. DEFAULT_RUNTIME_CAPABILITIES
+        // sets this to UsageReporting.NONE — override it if your transport can surface
+        // token counts. Options:
+        //   - UsageReporting.FULL    — always returns non-null `usage` on success.
+        //                              The registry wrapper asserts this invariant.
+        //   - UsageReporting.PARTIAL — returns `usage` when the provider reports it,
+        //                              may return null on some paths.
+        //   - UsageReporting.NONE    — transport fundamentally cannot report usage.
+        //
+        // Contract tests in bootstrap.test.ts will fail the build if this field is
+        // missing. See docs/providers.md → "Usage reporting contract" for details.
+        // usageReporting: UsageReporting.FULL,
       },
     },
 
     async run(input: RuntimeRunInput): Promise<RuntimeRunResult> {
       // Implement your runtime execution here.
       // See "Reading execution options in run()" in the JSDoc above.
+      //
+      // IMPORTANT: RuntimeRunResult.usage is REQUIRED. Return either a non-null
+      // `RuntimeUsage` object (when the provider reports token counts) or `null`
+      // (when it does not). Returning `undefined` is a type error. The registry
+      // wrapper reads this field and forwards it to the usage sink for every
+      // successful run — your adapter does not need to persist usage itself.
       void input;
       throw new Error(`${runtimeId} adapter: run() not implemented`);
     },

--- a/packages/runtime/src/adapters/claude/index.ts
+++ b/packages/runtime/src/adapters/claude/index.ts
@@ -2,6 +2,8 @@ import { query } from "@anthropic-ai/claude-agent-sdk";
 import { findClaudePath } from "./findPath.js";
 import {
   RuntimeTransport,
+  UsageReporting,
+  UsageSource,
   type RuntimeAdapter,
   type RuntimeCapabilities,
   type RuntimeConnectionValidationInput,
@@ -102,6 +104,7 @@ const SDK_CAPABILITIES: RuntimeCapabilities = {
   supportsModelDiscovery: true,
   supportsApprovals: true,
   supportsCustomEndpoint: true,
+  usageReporting: UsageReporting.FULL,
 };
 
 /**
@@ -116,6 +119,7 @@ const CLI_CAPABILITIES: RuntimeCapabilities = {
   supportsModelDiscovery: true,
   supportsApprovals: false,
   supportsCustomEndpoint: false,
+  usageReporting: UsageReporting.FULL,
 };
 
 /** API transport — requires explicit key + baseUrl, no agent definitions. */
@@ -127,6 +131,7 @@ const API_CAPABILITIES: RuntimeCapabilities = {
   supportsModelDiscovery: true,
   supportsApprovals: false,
   supportsCustomEndpoint: true,
+  usageReporting: UsageReporting.FULL,
 };
 
 function readStringOption(input: RuntimeConnectionValidationInput, key: string): string | null {
@@ -165,6 +170,7 @@ function toClaudeModelDiscoveryInput(input: RuntimeModelListInput): RuntimeRunIn
     cwd: input.projectRoot,
     headers: input.headers,
     options,
+    usageContext: { source: UsageSource.MODEL_DISCOVERY },
   };
 }
 

--- a/packages/runtime/src/adapters/codex/cli.ts
+++ b/packages/runtime/src/adapters/codex/cli.ts
@@ -578,7 +578,7 @@ function finalizeCodexResult(
                 (usageRaw.outputTokens ?? usageRaw.output_tokens ?? 0),
             costUsd: usageRaw.costUsd ?? usageRaw.cost_usd,
           }
-        : undefined,
+        : null,
       events: legacyEvents,
       raw: parsed,
     };
@@ -590,6 +590,7 @@ function finalizeCodexResult(
     return {
       outputText: raw,
       sessionId: fallbackSessionId,
+      usage: null,
       raw,
     };
   }
@@ -597,7 +598,7 @@ function finalizeCodexResult(
   return {
     outputText: state.outputText,
     sessionId: state.sessionId ?? fallbackSessionId,
-    usage: state.usage ?? undefined,
+    usage: state.usage ?? null,
     events: state.events,
     raw: state.rawEvents,
   };

--- a/packages/runtime/src/adapters/codex/index.ts
+++ b/packages/runtime/src/adapters/codex/index.ts
@@ -3,6 +3,7 @@ import { getCodexMcpStatus, installCodexMcpServer, uninstallCodexMcpServer } fro
 import { initCodexProject } from "./project.js";
 import {
   RuntimeTransport,
+  UsageReporting,
   type RuntimeAdapter,
   type RuntimeCapabilities,
   type RuntimeConnectionValidationInput,
@@ -87,6 +88,10 @@ const CLI_CAPABILITIES: RuntimeCapabilities = {
   supportsModelDiscovery: true,
   supportsApprovals: false,
   supportsCustomEndpoint: true,
+  // CLI stream emits token_count events when the turn completes, but some
+  // early-termination paths (timeout, non-zero exit) may return before the
+  // event is seen — declare PARTIAL so the wrapper tolerates null usage.
+  usageReporting: UsageReporting.PARTIAL,
 };
 
 const SDK_CAPABILITIES: RuntimeCapabilities = {
@@ -97,6 +102,7 @@ const SDK_CAPABILITIES: RuntimeCapabilities = {
   supportsModelDiscovery: true,
   supportsApprovals: false,
   supportsCustomEndpoint: true,
+  usageReporting: UsageReporting.FULL,
 };
 
 const API_CAPABILITIES: RuntimeCapabilities = {
@@ -107,6 +113,7 @@ const API_CAPABILITIES: RuntimeCapabilities = {
   supportsModelDiscovery: true,
   supportsApprovals: false,
   supportsCustomEndpoint: true,
+  usageReporting: UsageReporting.FULL,
 };
 
 function resolveTransport(input: {

--- a/packages/runtime/src/adapters/opencode/api.ts
+++ b/packages/runtime/src/adapters/opencode/api.ts
@@ -458,6 +458,7 @@ export async function runOpenCodeApi(
     sessionId: activeSession.id,
     session: activeSession,
     events: outputText.length > 0 ? [event] : [],
+    usage: null,
     raw: messagePayload,
   };
 }

--- a/packages/runtime/src/adapters/opencode/index.ts
+++ b/packages/runtime/src/adapters/opencode/index.ts
@@ -1,5 +1,6 @@
 import {
   RuntimeTransport,
+  UsageReporting,
   type RuntimeAdapter,
   type RuntimeCapabilities,
   type RuntimeConnectionValidationInput,
@@ -43,6 +44,11 @@ const API_CAPABILITIES: RuntimeCapabilities = {
   supportsModelDiscovery: true,
   supportsApprovals: false,
   supportsCustomEndpoint: true,
+  // OpenCode server returns messages but does not surface token counts in its
+  // message payload. The run() path never populates RuntimeRunResult.usage,
+  // so declare the contract honestly as NONE — dashboards will show this
+  // provider as opted-out of usage tracking rather than showing phantom zeros.
+  usageReporting: UsageReporting.NONE,
 };
 
 const DEFAULT_OPENCODE_MODELS: RuntimeModel[] = [

--- a/packages/runtime/src/adapters/openrouter/index.ts
+++ b/packages/runtime/src/adapters/openrouter/index.ts
@@ -1,5 +1,6 @@
 import {
   RuntimeTransport,
+  UsageReporting,
   type RuntimeAdapter,
   type RuntimeCapabilities,
   type RuntimeConnectionValidationInput,
@@ -44,6 +45,7 @@ const API_CAPABILITIES: RuntimeCapabilities = {
   supportsModelDiscovery: true,
   supportsApprovals: false,
   supportsCustomEndpoint: true,
+  usageReporting: UsageReporting.FULL,
 };
 
 function createFallbackLogger(): OpenRouterAdapterLogger {

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -7,10 +7,18 @@ import {
   type RuntimeRegistry,
   type RuntimeRegistryLogger,
 } from "./registry.js";
+import type { RuntimeUsageSink } from "./usageSink.js";
 
 export interface BootstrapRuntimeRegistryOptions {
   logger?: RuntimeRegistryLogger;
   runtimeModules?: string[];
+  /**
+   * Sink that receives usage events for every LLM call that flows through the
+   * registry. Host processes (api, agent) pass a DB-backed sink from
+   * `@aif/data` so every run is persisted to `usage_events`. When omitted,
+   * usage is silently dropped — only suitable for tests and CLI tools.
+   */
+  usageSink?: RuntimeUsageSink;
 }
 
 /**
@@ -30,6 +38,7 @@ export async function bootstrapRuntimeRegistry(
       createOpenRouterRuntimeAdapter(),
     ],
     logger: options.logger,
+    usageSink: options.usageSink,
   });
 
   for (const moduleSpecifier of options.runtimeModules ?? []) {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -27,7 +27,12 @@ export {
   RUNTIME_TRANSPORTS,
   RuntimeTransport,
   type RuntimeUsage,
+  type RuntimeUsageContext,
+  UsageReporting,
+  UsageSource,
 } from "./types.js";
+
+export { createNoopUsageSink, type RuntimeUsageEvent, type RuntimeUsageSink } from "./usageSink.js";
 
 export {
   type RegisterRuntimeModule,
@@ -124,26 +129,33 @@ export {
   withStreamTimeouts,
 } from "./timeouts.js";
 
-export {
-  createClaudeRuntimeAdapter,
-  type ClaudeRuntimeAdapterLogger,
-  type CreateClaudeRuntimeAdapterOptions,
+/**
+ * Adapter factories are intentionally NOT re-exported from the package root.
+ *
+ * The only supported way to obtain a runtime adapter is through
+ * `bootstrapRuntimeRegistry()` / `createRuntimeRegistry()` → `resolveRuntime()`,
+ * which wraps every adapter with the usage pipeline. Importing a factory
+ * directly bypasses that wrapper and silently drops token accounting — so
+ * external consumers must never do it. The ESLint `no-restricted-imports`
+ * rule in the repo root prevents deep imports like
+ * `@aif/runtime/src/adapters/...` outside of `packages/runtime/**`.
+ */
+export type {
+  ClaudeRuntimeAdapterLogger,
+  CreateClaudeRuntimeAdapterOptions,
 } from "./adapters/claude/index.js";
 
-export {
-  createCodexRuntimeAdapter,
-  type CodexRuntimeAdapterLogger,
-  type CreateCodexRuntimeAdapterOptions,
+export type {
+  CodexRuntimeAdapterLogger,
+  CreateCodexRuntimeAdapterOptions,
 } from "./adapters/codex/index.js";
 
-export {
-  createOpenCodeRuntimeAdapter,
-  type CreateOpenCodeRuntimeAdapterOptions,
-  type OpenCodeRuntimeAdapterLogger,
+export type {
+  CreateOpenCodeRuntimeAdapterOptions,
+  OpenCodeRuntimeAdapterLogger,
 } from "./adapters/opencode/index.js";
 
-export {
-  createOpenRouterRuntimeAdapter,
-  type CreateOpenRouterRuntimeAdapterOptions,
-  type OpenRouterAdapterLogger,
+export type {
+  CreateOpenRouterRuntimeAdapterOptions,
+  OpenRouterAdapterLogger,
 } from "./adapters/openrouter/index.js";

--- a/packages/runtime/src/registry.ts
+++ b/packages/runtime/src/registry.ts
@@ -91,20 +91,23 @@ function wrapAdapter(
     const effectiveCaps = resolveAdapterCapabilities(adapter, input.transport);
     const reporting = effectiveCaps.usageReporting;
 
-    if (result.usage === null) {
+    // TypeScript enforces `usage: RuntimeUsage | null`, but external/JS
+    // adapters may return `undefined` if they forget the field entirely.
+    // Treat null and undefined identically for the contract check.
+    if (result.usage == null) {
       if (reporting === UsageReporting.FULL) {
-        // Level C runtime assert: the adapter promised FULL but returned null.
-        // Throwing here would break the caller mid-run even though the provider
-        // actually responded, so we log loudly and move on. A metric/alert on
-        // this log is the production-side safety net; dev still catches it via
-        // the contract test harness.
+        // Level C runtime assert: the adapter promised FULL but returned
+        // null/undefined. Throwing here would break the caller mid-run even
+        // though the provider actually responded, so we log loudly and move
+        // on. A metric/alert on this log is the production-side safety net;
+        // dev still catches it via the contract test harness.
         log.error?.(
           {
             runtimeId: adapter.descriptor.id,
             providerId: adapter.descriptor.providerId,
             usageReporting: reporting,
           },
-          "adapter declared usageReporting=FULL but returned null usage — likely bug in adapter",
+          "adapter declared usageReporting=FULL but returned null/undefined usage — likely bug in adapter",
         );
       }
       return;

--- a/packages/runtime/src/registry.ts
+++ b/packages/runtime/src/registry.ts
@@ -1,4 +1,5 @@
 import {
+  RuntimeExecutionError,
   RuntimeModuleLoadError,
   RuntimeModuleValidationError,
   RuntimeRegistrationError,
@@ -6,11 +7,20 @@ import {
 } from "./errors.js";
 import { resolveRuntimeModuleRegistrar } from "./module.js";
 import { transformSkillCommandPrefix } from "./promptPolicy.js";
-import type { RuntimeAdapter, RuntimeDescriptor, RuntimeRunInput } from "./types.js";
+import {
+  resolveAdapterCapabilities,
+  UsageReporting,
+  type RuntimeAdapter,
+  type RuntimeDescriptor,
+  type RuntimeRunInput,
+  type RuntimeRunResult,
+} from "./types.js";
+import { createNoopUsageSink, type RuntimeUsageSink } from "./usageSink.js";
 
 export interface RuntimeRegistryLogger {
   debug(context: Record<string, unknown>, message: string): void;
   warn(context: Record<string, unknown>, message: string): void;
+  error?(context: Record<string, unknown>, message: string): void;
 }
 
 export interface RegisterRuntimeOptions {
@@ -21,6 +31,13 @@ export interface RegisterRuntimeOptions {
 export interface RuntimeRegistryOptions {
   logger?: RuntimeRegistryLogger;
   builtInAdapters?: RuntimeAdapter[];
+  /**
+   * Sink that receives a `RuntimeUsageEvent` for every successful run whose
+   * adapter returned a non-null `usage`. Defaults to a no-op sink. The API and
+   * agent processes pass a DB-backed sink from `@aif/data` so every LLM call
+   * is recorded to `usage_events` and rolled up into task/project aggregates.
+   */
+  usageSink?: RuntimeUsageSink;
 }
 
 function createFallbackLogger(): RuntimeRegistryLogger {
@@ -31,6 +48,9 @@ function createFallbackLogger(): RuntimeRegistryLogger {
     warn(context, message) {
       console.warn("WARN [runtime-module]", message, context);
     },
+    error(context, message) {
+      console.error("ERROR [runtime-registry]", message, context);
+    },
   };
 }
 
@@ -39,38 +59,143 @@ function normalizeRuntimeId(runtimeId: string): string {
 }
 
 /**
- * Wrap an adapter so that `run()` and `resume()` automatically transform
- * skill command prefixes in the prompt before forwarding to the real adapter.
+ * Wrap an adapter so that `run()` and `resume()` get two cross-cutting concerns
+ * applied in the single place every call site flows through:
  *
- * This is the single place where cross-cutting prompt transforms are applied,
- * so callers never need to remember to transform manually.
+ * 1. **Prompt transforms** — rewrite skill-command prefixes so callers don't
+ *    need to know per-runtime conventions (e.g. `/aif-plan` → `$aif-plan`).
+ * 2. **Usage pipeline** — read `result.usage` after every successful run and
+ *    forward it to the configured `RuntimeUsageSink`, while asserting the
+ *    adapter's declared `usageReporting` contract. This is what makes usage
+ *    tracking impossible to forget at the call site: any new caller that
+ *    provides a `usageContext` automatically gets its tokens recorded, and
+ *    the TypeScript compiler refuses to compile calls without it.
  */
-function wrapAdapterWithTransforms(adapter: RuntimeAdapter): RuntimeAdapter {
+function wrapAdapter(
+  adapter: RuntimeAdapter,
+  usageSink: RuntimeUsageSink,
+  log: RuntimeRegistryLogger,
+): RuntimeAdapter {
   const prefix = adapter.descriptor.skillCommandPrefix;
-  if (!prefix || prefix === "/") return adapter;
+  const needsPromptTransform = Boolean(prefix) && prefix !== "/";
 
   function transformPrompt(input: RuntimeRunInput): RuntimeRunInput {
+    if (!needsPromptTransform) return input;
     return { ...input, prompt: transformSkillCommandPrefix(input.prompt, prefix!) };
+  }
+
+  function recordUsage(input: RuntimeRunInput, result: RuntimeRunResult): void {
+    // Resolve per-transport capability so multi-transport adapters (e.g. codex
+    // with SDK/CLI/API) can declare different usage-reporting contracts per
+    // transport. Falls back to descriptor default when transport is unknown.
+    const effectiveCaps = resolveAdapterCapabilities(adapter, input.transport);
+    const reporting = effectiveCaps.usageReporting;
+
+    if (result.usage === null) {
+      if (reporting === UsageReporting.FULL) {
+        // Level C runtime assert: the adapter promised FULL but returned null.
+        // Throwing here would break the caller mid-run even though the provider
+        // actually responded, so we log loudly and move on. A metric/alert on
+        // this log is the production-side safety net; dev still catches it via
+        // the contract test harness.
+        log.error?.(
+          {
+            runtimeId: adapter.descriptor.id,
+            providerId: adapter.descriptor.providerId,
+            usageReporting: reporting,
+          },
+          "adapter declared usageReporting=FULL but returned null usage — likely bug in adapter",
+        );
+      }
+      return;
+    }
+
+    if (reporting === UsageReporting.NONE) {
+      log.warn(
+        {
+          runtimeId: adapter.descriptor.id,
+          providerId: adapter.descriptor.providerId,
+          usageReporting: reporting,
+        },
+        "adapter declared usageReporting=NONE but returned non-null usage — descriptor may be stale",
+      );
+    }
+
+    // Level 3 runtime assert: caller provided usageContext at the type level,
+    // but a cast could still wash it out. Guard the sink against garbage.
+    const context = input.usageContext;
+    if (!context || typeof context.source !== "string" || context.source.length === 0) {
+      log.error?.(
+        {
+          runtimeId: adapter.descriptor.id,
+          providerId: adapter.descriptor.providerId,
+        },
+        "RuntimeRunInput.usageContext.source is required but was missing — usage event dropped",
+      );
+      return;
+    }
+
+    try {
+      usageSink.record({
+        context,
+        runtimeId: adapter.descriptor.id,
+        providerId: adapter.descriptor.providerId,
+        profileId: input.profileId ?? null,
+        transport: input.transport,
+        workflowKind: input.workflowKind,
+        usageReporting: reporting,
+        usage: result.usage,
+        recordedAt: new Date(),
+      });
+    } catch (sinkError) {
+      // Sink contract says it must not throw, but defense in depth: an error
+      // here must never surface to the caller, which already got its result.
+      log.error?.(
+        {
+          runtimeId: adapter.descriptor.id,
+          error: sinkError instanceof Error ? sinkError.message : String(sinkError),
+        },
+        "usageSink.record threw — dropping event",
+      );
+    }
+  }
+
+  async function wrappedRun(input: RuntimeRunInput): Promise<RuntimeRunResult> {
+    const transformed = transformPrompt(input);
+    const result = await adapter.run(transformed);
+    recordUsage(transformed, result);
+    return result;
+  }
+
+  async function wrappedResume(
+    input: RuntimeRunInput & { sessionId: string },
+  ): Promise<RuntimeRunResult> {
+    if (!adapter.resume) {
+      throw new RuntimeExecutionError(
+        `Runtime "${adapter.descriptor.id}" does not implement resume()`,
+      );
+    }
+    const transformed = transformPrompt(input) as RuntimeRunInput & { sessionId: string };
+    const result = await adapter.resume(transformed);
+    recordUsage(transformed, result);
+    return result;
   }
 
   return {
     ...adapter,
-    run(input) {
-      return adapter.run(transformPrompt(input));
-    },
-    resume: adapter.resume
-      ? (input) =>
-          adapter.resume!(transformPrompt(input) as RuntimeRunInput & { sessionId: string })
-      : undefined,
+    run: wrappedRun,
+    resume: adapter.resume ? wrappedResume : undefined,
   };
 }
 
 export class RuntimeRegistry {
   private readonly adapters = new Map<string, RuntimeAdapter>();
   private readonly log: RuntimeRegistryLogger;
+  private readonly usageSink: RuntimeUsageSink;
 
   constructor(options: RuntimeRegistryOptions = {}) {
     this.log = options.logger ?? createFallbackLogger();
+    this.usageSink = options.usageSink ?? createNoopUsageSink();
 
     if (options.builtInAdapters?.length) {
       this.registerBuiltInRuntimes(options.builtInAdapters);
@@ -119,7 +244,7 @@ export class RuntimeRegistry {
     }
 
     this.log.debug({ runtimeId: normalizedRuntimeId }, "Resolved runtime adapter");
-    return wrapAdapterWithTransforms(adapter);
+    return wrapAdapter(adapter, this.usageSink, this.log);
   }
 
   tryResolveRuntime(runtimeId: string): RuntimeAdapter | null {
@@ -130,7 +255,7 @@ export class RuntimeRegistry {
       this.log.debug({ runtimeId: normalizedRuntimeId }, "Resolved runtime adapter");
     }
 
-    return adapter ? wrapAdapterWithTransforms(adapter) : null;
+    return adapter ? wrapAdapter(adapter, this.usageSink, this.log) : null;
   }
 
   hasRuntime(runtimeId: string): boolean {

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -11,6 +11,59 @@ export const RUNTIME_TRANSPORTS = _RUNTIME_TRANSPORTS;
 export const isRuntimeTransport = _isRuntimeTransport;
 
 /**
+ * Usage reporting contract — declares whether an adapter can populate
+ * `RuntimeRunResult.usage` after a successful run.
+ *
+ * - `FULL`    — adapter always returns a non-null `usage` on successful run.
+ *               The registry wrapper logs loudly on violation (production) or
+ *               fails the contract test (development).
+ * - `PARTIAL` — adapter returns `usage` when the provider reports it, but may
+ *               return `null` for some transports/streaming paths where the
+ *               provider doesn't emit a final token count.
+ * - `NONE`    — the transport fundamentally cannot report usage. The wrapper
+ *               warns if `usage` is non-null (unexpected) and skips sink.record.
+ *
+ * Defined as a const object (not a string union or TS enum) to match the
+ * `RuntimeTransport` convention in this codebase: callers reference
+ * `UsageReporting.FULL` instead of magic strings, the TS compiler catches
+ * typos, and adding a new variant requires editing one central file.
+ */
+export const UsageReporting = {
+  FULL: "full",
+  PARTIAL: "partial",
+  NONE: "none",
+} as const;
+export type UsageReporting = (typeof UsageReporting)[keyof typeof UsageReporting];
+
+/**
+ * Canonical set of usage-context sources. Every call site that invokes a
+ * runtime declares which logical flow it belongs to by picking one of these,
+ * so dashboards can group traffic and "unknown source" is impossible.
+ *
+ * Adding a new source is a deliberate one-line edit here — this is the
+ * single place the set of sources is defined across the whole monorepo.
+ */
+export const UsageSource = {
+  /** User-facing chat route (packages/api/src/routes/chat.ts). */
+  CHAT: "chat",
+  /** Fire-and-forget /aif-commit runner (services/commitGeneration.ts). */
+  COMMIT: "commit",
+  /** First roadmap pass that writes ROADMAP.md (services/roadmapGeneration.ts). */
+  ROADMAP_GENERATE: "roadmap-generate",
+  /** Second roadmap pass that extracts JSON tasks (services/roadmapGeneration.ts). */
+  ROADMAP_EXTRACT: "roadmap-extract",
+  /** Fast Fix on a task (services/fastFix.ts). */
+  FAST_FIX: "fast-fix",
+  /** Subagent execution from the agent coordinator (agent/subagentQuery.ts). */
+  SUBAGENT: "subagent",
+  /** Adapter-internal probe used by listModels() discovery flows. */
+  MODEL_DISCOVERY: "model-discovery",
+  /** Test fixtures — only valid inside vitest runs. */
+  TEST: "test",
+} as const;
+export type UsageSource = (typeof UsageSource)[keyof typeof UsageSource];
+
+/**
  * Capability flags declared by each adapter.
  * The system checks these before calling optional methods — if a flag is false,
  * the corresponding optional method on RuntimeAdapter will never be called.
@@ -30,6 +83,12 @@ export interface RuntimeCapabilities {
   supportsApprovals: boolean;
   /** Adapter supports custom baseUrl / endpoint configuration. */
   supportsCustomEndpoint: boolean;
+  /**
+   * Adapter's usage-reporting contract. Required so every new adapter makes an
+   * explicit decision — the registry wrapper uses this to enforce invariants
+   * on `RuntimeRunResult.usage`.
+   */
+  usageReporting: UsageReporting;
 }
 
 export const DEFAULT_RUNTIME_CAPABILITIES: RuntimeCapabilities = {
@@ -40,6 +99,7 @@ export const DEFAULT_RUNTIME_CAPABILITIES: RuntimeCapabilities = {
   supportsModelDiscovery: false,
   supportsApprovals: false,
   supportsCustomEndpoint: false,
+  usageReporting: UsageReporting.NONE,
 };
 
 export interface RuntimeDescriptor {
@@ -125,6 +185,26 @@ export interface RuntimeExecutionIntent {
   hooks?: Record<string, unknown>;
 }
 
+/**
+ * Scope metadata attached to every run so the registry-level usage sink can
+ * record who/what/where consumed tokens. `source` is mandatory — the TypeScript
+ * compiler forces every call site to make a conscious decision about tagging.
+ *
+ * Optional scope fields (`projectId`, `taskId`, `chatSessionId`) let the sink
+ * aggregate usage per entity; callers pass whichever ones are known.
+ */
+export interface RuntimeUsageContext {
+  /**
+   * Logical source of the run. Must be one of the canonical `UsageSource`
+   * values — the enum is the single source of truth for where tokens are
+   * coming from, so dashboards can group traffic without freeform tags.
+   */
+  source: UsageSource;
+  projectId?: string | null;
+  taskId?: string | null;
+  chatSessionId?: string | null;
+}
+
 export interface RuntimeRunInput {
   runtimeId: string;
   providerId?: string;
@@ -143,6 +223,12 @@ export interface RuntimeRunInput {
   headers?: Record<string, string>;
   options?: Record<string, unknown>;
   execution?: RuntimeExecutionIntent;
+  /**
+   * Scope metadata for usage tracking. Required: the registry wrapper reads
+   * this to record every successful run to the usage sink. Call sites cannot
+   * omit it — new code that forgets scoping fails TypeScript compilation.
+   */
+  usageContext: RuntimeUsageContext;
 }
 
 export interface RuntimeEvent {
@@ -177,7 +263,14 @@ export interface RuntimeRunResult {
   sessionId?: string | null;
   session?: RuntimeSession | null;
   events?: RuntimeEvent[];
-  usage?: RuntimeUsage | null;
+  /**
+   * Token/cost usage for this run. REQUIRED: adapters must explicitly return
+   * either a `RuntimeUsage` object or `null`. `undefined` is not valid — it
+   * would silently hide a missing implementation. Adapters whose transport
+   * cannot report usage declare `capabilities.usageReporting = "none"` and
+   * return `null` here.
+   */
+  usage: RuntimeUsage | null;
   raw?: unknown;
 }
 

--- a/packages/runtime/src/usageSink.ts
+++ b/packages/runtime/src/usageSink.ts
@@ -1,0 +1,53 @@
+import type {
+  RuntimeTransport,
+  RuntimeUsage,
+  RuntimeUsageContext,
+  UsageReporting,
+} from "./types.js";
+
+/**
+ * Event recorded by the registry wrapper after every successful adapter run
+ * that returned a non-null `usage`. The sink is the single point of persistence
+ * for token/cost accounting across the whole system.
+ */
+export interface RuntimeUsageEvent {
+  /** Scope metadata passed in via `RuntimeRunInput.usageContext`. */
+  context: RuntimeUsageContext;
+  /** Which runtime produced this usage. */
+  runtimeId: string;
+  providerId: string;
+  profileId?: string | null;
+  transport?: RuntimeTransport;
+  /** Workflow kind declared on the run (planner, chat, commit, ...). */
+  workflowKind?: string;
+  /** Adapter's declared usage-reporting contract at the time of recording. */
+  usageReporting: UsageReporting;
+  /** Concrete token counts and cost from the run. */
+  usage: RuntimeUsage;
+  /** When the wrapper observed the event. */
+  recordedAt: Date;
+}
+
+/**
+ * Usage sink contract. Implementations persist the event (typically into a
+ * `usage_events` table and rolled-up aggregates on projects/tasks/chat-sessions).
+ *
+ * `record` must be synchronous and non-throwing — the wrapper calls it in the
+ * hot path of every run, and a failure here must never break the caller.
+ * Implementations should catch and log their own errors internally.
+ */
+export interface RuntimeUsageSink {
+  record(event: RuntimeUsageEvent): void;
+}
+
+/**
+ * No-op sink used when no explicit sink is configured (tests, isolated tools).
+ * Discards every event silently.
+ */
+export function createNoopUsageSink(): RuntimeUsageSink {
+  return {
+    record() {
+      /* intentionally empty */
+    },
+  };
+}

--- a/packages/shared/src/db.ts
+++ b/packages/shared/src/db.ts
@@ -333,6 +333,19 @@ const MIGRATIONS: Migration[] = [
       ALTER TABLE chat_sessions ADD COLUMN cost_usd REAL NOT NULL DEFAULT 0;
     `,
   },
+  {
+    version: 10,
+    description: "Backfill project token aggregates from existing task-level usage",
+    sql: `
+      UPDATE projects
+      SET
+        token_input  = token_input  + coalesce((SELECT sum(token_input)  FROM tasks WHERE tasks.project_id = projects.id), 0),
+        token_output = token_output + coalesce((SELECT sum(token_output) FROM tasks WHERE tasks.project_id = projects.id), 0),
+        token_total  = token_total  + coalesce((SELECT sum(token_total)  FROM tasks WHERE tasks.project_id = projects.id), 0),
+        cost_usd     = cost_usd     + coalesce((SELECT sum(cost_usd)     FROM tasks WHERE tasks.project_id = projects.id), 0)
+      WHERE EXISTS (SELECT 1 FROM tasks WHERE tasks.project_id = projects.id AND tasks.token_total > 0)
+    `,
+  },
 ];
 
 function splitSqlStatements(sqlText: string): string[] {

--- a/packages/shared/src/db.ts
+++ b/packages/shared/src/db.ts
@@ -155,6 +155,26 @@ function ensureTables(sqlite: Database.Database): void {
       created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
     )
   `);
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS usage_events (
+      id TEXT PRIMARY KEY,
+      source TEXT NOT NULL,
+      project_id TEXT,
+      task_id TEXT,
+      chat_session_id TEXT,
+      runtime_id TEXT NOT NULL,
+      provider_id TEXT NOT NULL,
+      profile_id TEXT,
+      transport TEXT,
+      workflow_kind TEXT,
+      usage_reporting TEXT NOT NULL,
+      input_tokens INTEGER NOT NULL DEFAULT 0,
+      output_tokens INTEGER NOT NULL DEFAULT 0,
+      total_tokens INTEGER NOT NULL DEFAULT 0,
+      cost_usd REAL,
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+    )
+  `);
 
   runMigrations(sqlite);
   ensureTriggers(sqlite);
@@ -279,6 +299,38 @@ const MIGRATIONS: Migration[] = [
     sql: `
       ALTER TABLE projects ADD COLUMN default_plan_runtime_profile_id TEXT;
       ALTER TABLE projects ADD COLUMN default_review_runtime_profile_id TEXT;
+    `,
+  },
+  {
+    version: 9,
+    description: "Add usage_events table and per-entity token aggregates (projects, chat_sessions)",
+    sql: `
+      CREATE TABLE IF NOT EXISTS usage_events (
+        id TEXT PRIMARY KEY,
+        source TEXT NOT NULL,
+        project_id TEXT,
+        task_id TEXT,
+        chat_session_id TEXT,
+        runtime_id TEXT NOT NULL,
+        provider_id TEXT NOT NULL,
+        profile_id TEXT,
+        transport TEXT,
+        workflow_kind TEXT,
+        usage_reporting TEXT NOT NULL,
+        input_tokens INTEGER NOT NULL DEFAULT 0,
+        output_tokens INTEGER NOT NULL DEFAULT 0,
+        total_tokens INTEGER NOT NULL DEFAULT 0,
+        cost_usd REAL,
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+      );
+      ALTER TABLE projects ADD COLUMN token_input INTEGER NOT NULL DEFAULT 0;
+      ALTER TABLE projects ADD COLUMN token_output INTEGER NOT NULL DEFAULT 0;
+      ALTER TABLE projects ADD COLUMN token_total INTEGER NOT NULL DEFAULT 0;
+      ALTER TABLE projects ADD COLUMN cost_usd REAL NOT NULL DEFAULT 0;
+      ALTER TABLE chat_sessions ADD COLUMN token_input INTEGER NOT NULL DEFAULT 0;
+      ALTER TABLE chat_sessions ADD COLUMN token_output INTEGER NOT NULL DEFAULT 0;
+      ALTER TABLE chat_sessions ADD COLUMN token_total INTEGER NOT NULL DEFAULT 0;
+      ALTER TABLE chat_sessions ADD COLUMN cost_usd REAL NOT NULL DEFAULT 0;
     `,
   },
 ];
@@ -465,6 +517,12 @@ function ensureIndexes(sqlite: Database.Database): void {
     "CREATE INDEX IF NOT EXISTS idx_tasks_runtime_profile_id ON tasks(runtime_profile_id)",
     // Runtime profile lookups for chat sessions
     "CREATE INDEX IF NOT EXISTS idx_chat_sessions_runtime_profile_id ON chat_sessions(runtime_profile_id)",
+    // Usage event scope lookups for per-entity aggregation queries and dashboards
+    "CREATE INDEX IF NOT EXISTS idx_usage_events_project ON usage_events(project_id, created_at)",
+    "CREATE INDEX IF NOT EXISTS idx_usage_events_task ON usage_events(task_id, created_at)",
+    "CREATE INDEX IF NOT EXISTS idx_usage_events_chat_session ON usage_events(chat_session_id, created_at)",
+    "CREATE INDEX IF NOT EXISTS idx_usage_events_source ON usage_events(source, created_at)",
+    "CREATE INDEX IF NOT EXISTS idx_usage_events_runtime ON usage_events(runtime_id, provider_id, created_at)",
   ];
 
   for (const ddl of indexDefs) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -6,6 +6,7 @@ export {
   runtimeProfiles,
   chatSessions,
   chatMessages,
+  usageEvents,
 } from "./schema.js";
 export type {
   ProjectRow,
@@ -20,6 +21,8 @@ export type {
   NewChatSessionRow,
   ChatMessageRow,
   NewChatMessageRow,
+  UsageEventRow,
+  NewUsageEventRow,
 } from "./schema.js";
 
 // Types

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -17,6 +17,10 @@ export const projects = sqliteTable("projects", {
   defaultPlanRuntimeProfileId: text("default_plan_runtime_profile_id"),
   defaultReviewRuntimeProfileId: text("default_review_runtime_profile_id"),
   defaultChatRuntimeProfileId: text("default_chat_runtime_profile_id"),
+  tokenInput: integer("token_input").notNull().default(0),
+  tokenOutput: integer("token_output").notNull().default(0),
+  tokenTotal: integer("token_total").notNull().default(0),
+  costUsd: real("cost_usd").notNull().default(0),
   createdAt: text("created_at")
     .notNull()
     .default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
@@ -135,6 +139,10 @@ export const chatSessions = sqliteTable("chat_sessions", {
   agentSessionId: text("agent_session_id"),
   runtimeProfileId: text("runtime_profile_id"),
   runtimeSessionId: text("runtime_session_id"),
+  tokenInput: integer("token_input").notNull().default(0),
+  tokenOutput: integer("token_output").notNull().default(0),
+  tokenTotal: integer("token_total").notNull().default(0),
+  costUsd: real("cost_usd").notNull().default(0),
   createdAt: text("created_at")
     .notNull()
     .default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
@@ -161,3 +169,38 @@ export const chatMessages = sqliteTable("chat_messages", {
 
 export type ChatMessageRow = typeof chatMessages.$inferSelect;
 export type NewChatMessageRow = typeof chatMessages.$inferInsert;
+
+/**
+ * Append-only token usage log. Every successful LLM call that flows through
+ * the runtime registry wrapper produces one row here. Per-entity aggregate
+ * counters (on tasks / projects / chat_sessions) are updated in the same
+ * transaction so reads stay cheap, but this table is the source of truth for
+ * auditing and per-source breakdowns. Scope fields are nullable — a chat run
+ * has a `chat_session_id` but no `task_id`, a subagent run has `task_id` but
+ * no `chat_session_id`, a commit run has only `project_id`, and so on.
+ */
+export const usageEvents = sqliteTable("usage_events", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  source: text("source").notNull(),
+  projectId: text("project_id"),
+  taskId: text("task_id"),
+  chatSessionId: text("chat_session_id"),
+  runtimeId: text("runtime_id").notNull(),
+  providerId: text("provider_id").notNull(),
+  profileId: text("profile_id"),
+  transport: text("transport"),
+  workflowKind: text("workflow_kind"),
+  usageReporting: text("usage_reporting").notNull(),
+  inputTokens: integer("input_tokens").notNull().default(0),
+  outputTokens: integer("output_tokens").notNull().default(0),
+  totalTokens: integer("total_tokens").notNull().default(0),
+  costUsd: real("cost_usd"),
+  createdAt: text("created_at")
+    .notNull()
+    .default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
+});
+
+export type UsageEventRow = typeof usageEvents.$inferSelect;
+export type NewUsageEventRow = typeof usageEvents.$inferInsert;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -24,6 +24,11 @@ export interface Project {
   defaultPlanRuntimeProfileId?: string | null;
   defaultReviewRuntimeProfileId?: string | null;
   defaultChatRuntimeProfileId?: string | null;
+  /** Aggregate token/cost usage across ALL sources (tasks, chat, commit, roadmap). */
+  tokenInput?: number;
+  tokenOutput?: number;
+  tokenTotal?: number;
+  costUsd?: number;
   createdAt: string;
   updatedAt: string;
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -430,8 +430,22 @@ export interface ChatStreamTokenPayload {
   token: string;
 }
 
+/**
+ * Per-turn token usage reported to the frontend alongside the `chat:done`
+ * event. Matches `RuntimeUsage` from `@aif/runtime` structurally, duplicated
+ * here to avoid forcing `@aif/shared` to depend on the runtime layer.
+ */
+export interface ChatDoneUsage {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  costUsd?: number;
+}
+
 export interface ChatDonePayload {
   conversationId: string;
+  /** Null when the adapter/transport does not report usage for this turn. */
+  usage?: ChatDoneUsage | null;
 }
 
 export interface ChatErrorPayload {

--- a/packages/web/src/components/layout/Header.tsx
+++ b/packages/web/src/components/layout/Header.tsx
@@ -224,7 +224,12 @@ export function Header({
       </div>
 
       <NotificationsDialog open={settingsOpen} onOpenChange={setSettingsOpen} />
-      <MetricsDialog open={metricsOpen} onOpenChange={setMetricsOpen} taskMetrics={taskMetrics} />
+      <MetricsDialog
+        open={metricsOpen}
+        onOpenChange={setMetricsOpen}
+        taskMetrics={taskMetrics}
+        project={selectedProject}
+      />
       <RoadmapDialog
         open={roadmapOpen}
         onOpenChange={setRoadmapOpen}

--- a/packages/web/src/components/layout/MetricsDialog.tsx
+++ b/packages/web/src/components/layout/MetricsDialog.tsx
@@ -6,11 +6,13 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import type { TaskMetricsSummary } from "@/lib/taskMetrics";
+import type { Project } from "@aif/shared/browser";
 
 interface MetricsDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   taskMetrics: TaskMetricsSummary;
+  project: Project | null;
 }
 
 const integerFmt = new Intl.NumberFormat("en-US");
@@ -25,13 +27,20 @@ const fmtInt = (v: number) => integerFmt.format(Math.round(v));
 const fmtUsd = (v: number) => usdFmt.format(v);
 const fmtPct = (v: number) => `${v.toFixed(1)}%`;
 
-export function MetricsDialog({ open, onOpenChange, taskMetrics }: MetricsDialogProps) {
+export function MetricsDialog({ open, onOpenChange, taskMetrics, project }: MetricsDialogProps) {
+  // Project-level totals include ALL sources (tasks + chat + commit + roadmap).
+  // Fall back to task-only totals when no project is selected.
+  const projectTokenTotal = project?.tokenTotal ?? taskMetrics.totalTokenTotal;
+  const projectTokenInput = project?.tokenInput ?? taskMetrics.totalTokenInput;
+  const projectTokenOutput = project?.tokenOutput ?? taskMetrics.totalTokenOutput;
+  const projectCostUsd = project?.costUsd ?? taskMetrics.totalCostUsd;
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-2xl">
         <DialogClose onClose={() => onOpenChange(false)} />
         <DialogHeader>
-          <DialogTitle>Task Metrics</DialogTitle>
+          <DialogTitle>Metrics</DialogTitle>
         </DialogHeader>
         <div className="grid gap-3 sm:grid-cols-2">
           <div className="border border-border bg-card/50 px-3 py-2">
@@ -43,16 +52,16 @@ export function MetricsDialog({ open, onOpenChange, taskMetrics }: MetricsDialog
           </div>
           <div className="border border-border bg-card/50 px-3 py-2">
             <p className="text-xs text-muted-foreground">Total token usage</p>
-            <p className="text-lg font-semibold">{fmtInt(taskMetrics.totalTokenTotal)}</p>
+            <p className="text-lg font-semibold">{fmtInt(projectTokenTotal)}</p>
             <p className="text-xs text-muted-foreground">
-              in {fmtInt(taskMetrics.totalTokenInput)} / out {fmtInt(taskMetrics.totalTokenOutput)}
+              in {fmtInt(projectTokenInput)} / out {fmtInt(projectTokenOutput)}
             </p>
           </div>
           <div className="border border-border bg-card/50 px-3 py-2">
             <p className="text-xs text-muted-foreground">Total cost</p>
-            <p className="text-lg font-semibold">{fmtUsd(taskMetrics.totalCostUsd)}</p>
+            <p className="text-lg font-semibold">{fmtUsd(projectCostUsd)}</p>
             <p className="text-xs text-muted-foreground">
-              avg {fmtUsd(taskMetrics.averageCostPerTaskUsd)} per task
+              tasks: {fmtUsd(taskMetrics.totalCostUsd)}
             </p>
           </div>
           <div className="border border-border bg-card/50 px-3 py-2">


### PR DESCRIPTION
## Summary

- Adds an end-to-end usage-tracking pipeline so every successful LLM call that flows through the runtime registry is persisted to a new `usage_events` table, rolled up into per-task / per-project / per-chat-session aggregates, and tagged with a canonical `source`.
- Enforced via types + runtime wrapper + discovery test: new call sites that forget to pass `usageContext` fail compilation, and new adapters that omit `usageReporting` fail the build on `bootstrap.test.ts`.
- Fixes the three previously-untracked call sites (chat, commit generation, roadmap generate) and removes the three manual `incrementTaskTokenUsage` call sites that are now handled by the sink (subagentQuery, fastFix, roadmap-extract).

## Architecture

Two independent safety contours:

**Call-site contour — "new route cannot forget to tag a run":**
- `RuntimeRunInput.usageContext` is required (`source: UsageSource`, optional `projectId` / `taskId` / `chatSessionId`).
- Registry wrapper reads `result.usage` after every successful run and forwards the event to a `RuntimeUsageSink`.
- Adapter factories are no longer re-exported from `@aif/runtime` public API, so callers cannot bypass the wrapper.

**Adapter contour — "new adapter cannot forget to report usage":**
- `RuntimeRunResult.usage` is required (`RuntimeUsage | null`, no `undefined`).
- `RuntimeCapabilities.usageReporting` is required (const-object enum: `UsageReporting.FULL` / `PARTIAL` / `NONE`, same pattern as `RuntimeTransport`).
- Registry wrapper enforces the contract: `FULL` must return non-null, `NONE` warns if usage appears, `PARTIAL` accepts both.
- Discovery test in `bootstrap.test.ts` iterates every built-in adapter and fails the build if any is missing a valid `usageReporting` value.

## Data layer

- Drizzle migration `9` adds `usage_events` table (append-only, indexed on `project_id`, `task_id`, `chat_session_id`, `source`, `runtime_id`) and token/cost aggregate columns on `projects` and `chat_sessions`.
- `@aif/data` exposes `createDbUsageSink()` — structurally compatible with `RuntimeUsageSink` so `@aif/data` stays free of a dependency on `@aif/runtime`.
- `recordUsageEvent` inserts the event row and fans out to `incrementTaskTokenUsage` / `incrementProjectTokenUsage` / `incrementChatSessionTokenUsage` based on the event's scope.

## Call sites wired

| Call site | Previous state | New source |
|---|---|---|
| Chat route | Usage ignored | `UsageSource.CHAT` (+ `chat:done` WS event now carries usage) |
| Commit generation | Fire-and-forget, usage dropped | `UsageSource.COMMIT` |
| Roadmap generate | Usage dropped | `UsageSource.ROADMAP_GENERATE` |
| Roadmap extract | Manual increment | `UsageSource.ROADMAP_EXTRACT` |
| Fast fix | Manual increment | `UsageSource.FAST_FIX` |
| Subagents | Manual increment | `UsageSource.SUBAGENT` |
| Claude CLI model discovery | n/a (no usageContext existed) | `UsageSource.MODEL_DISCOVERY` |

Manual `incrementTaskTokenUsage` calls in `subagentQuery.ts`, `fastFix.ts`, and `roadmapGeneration.ts` have been removed — the sink records once at the registry layer, so there is no double counting.

## Adapter declarations

| Adapter | Transport | `usageReporting` |
|---|---|---|
| Claude | SDK / CLI / API | `FULL` |
| Codex | SDK / API | `FULL` |
| Codex | CLI | `PARTIAL` (early-termination paths may return null) |
| OpenRouter | API | `FULL` |
| OpenCode | API | `NONE` (transport does not surface token counts) |

## Tests added

- `packages/runtime/src/__tests__/bootstrap.test.ts` — discovery test asserting every built-in adapter declares a valid `usageReporting` value.
- `packages/runtime/src/__tests__/registry.test.ts` — 5 new sink-contract tests: forwards usage to sink with correct context, skips when `usage === null`, logs error on FULL-but-null violation, warns on NONE-but-non-null, and swallows sink errors without breaking the caller.

## Docs

- `docs/providers.md` — new `Usage Reporting` column in Supported Runtimes table + new "Usage reporting contract" section.
- `CLAUDE.md` + `AGENTS.md` — Runtime Adapter Sync Rule now requires declaring `usageReporting` and references the discovery test as the safety net.
- `packages/runtime/src/adapters/TEMPLATE.ts` — required-fields comments on `usageReporting` and `usage: null`.

## Test plan

- [x] `npx turbo build` — 7/7 successful
- [x] `npx turbo test` — 10/10 successful (485+ runtime tests, 203 api tests, all agent/data/shared/mcp tests)
- [x] `npx turbo lint` — 10/10 clean
- [x] `npm run format:check` — clean
- [x] `npx tsc --noEmit` across all packages — zero errors
- [ ] Smoke test: start API + agent, trigger chat / commit / fast-fix / subagent flows, verify rows appear in `usage_events` with correct `source` and scope columns
- [ ] Manual check: `chat:done` WS event payload now contains `usage` shape for per-turn display