### PR TITLE
fix(runtime): forward HTTP proxy env vars to spawned subprocesses

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,6 +1,17 @@
 # ---- Base ----
 FROM node:22-slim AS base
 WORKDIR /app
+# Proxy (optional) — propagated to all downstream stages via ENV,
+# so apt-get / npm / npx all pick it up during build.
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG NO_PROXY
+ENV HTTP_PROXY=${HTTP_PROXY} \
+    HTTPS_PROXY=${HTTPS_PROXY} \
+    NO_PROXY=${NO_PROXY} \
+    http_proxy=${HTTP_PROXY} \
+    https_proxy=${HTTPS_PROXY} \
+    no_proxy=${NO_PROXY}
 
 # ---- Dependencies ----
 FROM base AS deps
@@ -38,6 +49,16 @@ CMD ["npx", "tsx", "packages/api/src/index.ts"]
 
 # ---- Web (Angie reverse proxy + static) ----
 FROM docker.angie.software/angie:1.11.4-alpine AS web
+# Proxy (optional) — separate ARGs because this stage does NOT inherit from `base`.
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG NO_PROXY
+ENV HTTP_PROXY=${HTTP_PROXY} \
+    HTTPS_PROXY=${HTTPS_PROXY} \
+    NO_PROXY=${NO_PROXY} \
+    http_proxy=${HTTP_PROXY} \
+    https_proxy=${HTTPS_PROXY} \
+    no_proxy=${NO_PROXY}
 RUN apk add --no-cache gettext
 COPY --from=build /app/packages/web/dist /usr/share/angie/html
 COPY .docker/angie.conf /etc/angie/http.d/default.conf

--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,18 @@ DATABASE_URL=./data/aif.sqlite
 # Mount path for project files inside containers
 # PROJECTS_MOUNT=/home/www
 
+# ----------------------------------------------------------
+# HTTP(S) proxy — used at build time (npm/apt/apk) and runtime
+# ----------------------------------------------------------
+# Leave unset if you don't need a proxy. When set, compose passes
+# these to `docker build` as build-args AND injects them into
+# running containers via `env_file: .env`.
+# NO_PROXY must include compose service names (api/agent/web/mcp)
+# so internal calls do not go through the proxy.
+# HTTP_PROXY=http://proxy.example.com:8080
+# HTTPS_PROXY=http://proxy.example.com:8080
+# NO_PROXY=localhost,127.0.0.1,::1,api,agent,web,mcp
+
 # Production: domain for SSL certificate (Let's Encrypt via ACME)
 # DOMAIN=example.com
 

--- a/packages/runtime/src/adapters/claude/cli.ts
+++ b/packages/runtime/src/adapters/claude/cli.ts
@@ -51,6 +51,12 @@ const ALLOWED_ENV_PREFIXES = [
   "VISUAL",
   "FORCE_COLOR",
   "NO_COLOR",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "NO_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "no_proxy",
 ];
 
 function buildCuratedEnv(

--- a/packages/runtime/src/adapters/claude/options.ts
+++ b/packages/runtime/src/adapters/claude/options.ts
@@ -164,6 +164,12 @@ const ALLOWED_ENV_PREFIXES = [
   "VISUAL",
   "FORCE_COLOR",
   "NO_COLOR",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "NO_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "no_proxy",
 ];
 
 function isAllowedEnvKey(key: string): boolean {

--- a/packages/runtime/src/adapters/codex/cli.ts
+++ b/packages/runtime/src/adapters/codex/cli.ts
@@ -186,6 +186,12 @@ const ALLOWED_ENV_PREFIXES = [
   "XDG_",
   "FORCE_COLOR",
   "NO_COLOR",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "NO_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "no_proxy",
 ];
 
 /**

--- a/packages/runtime/src/adapters/codex/modelDiscovery/process.ts
+++ b/packages/runtime/src/adapters/codex/modelDiscovery/process.ts
@@ -36,6 +36,12 @@ const ALLOWED_ENV_PREFIXES = [
   "XDG_",
   "FORCE_COLOR",
   "NO_COLOR",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "NO_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "no_proxy",
 ];
 const BLOCKED_ENV_KEYS = new Set(["OPENAI_BASE_URL"]);
 

--- a/packages/runtime/src/adapters/codex/sdk.ts
+++ b/packages/runtime/src/adapters/codex/sdk.ts
@@ -80,6 +80,12 @@ const ALLOWED_ENV_PREFIXES = [
   "XDG_",
   "FORCE_COLOR",
   "NO_COLOR",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "NO_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "no_proxy",
 ];
 
 function buildCuratedEnv(


### PR DESCRIPTION
## Summary

- Add `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` (and lowercase variants) to all five
  `ALLOWED_ENV_PREFIXES` allowlists across Claude and Codex adapters
- Add build-time proxy `ARG`/`ENV` to Dockerfile (`base` + `web` stages)
- Document proxy configuration in `.env.example`

## Problem

In closed-network environments where outbound traffic goes through an HTTP proxy,
agent subprocesses (Claude SDK, Claude CLI, Codex SDK/CLI) fail because the runtime
adapters filter out proxy environment variables before spawning child processes.

The proxy vars are set at the container level via `env_file`, but the adapter's
`buildCuratedEnv()` / `resolveEnvironment()` functions only forward variables matching
an explicit allowlist — proxy vars were not on it.

## Affected files

| File | Transport |
|------|-----------|
| `packages/runtime/src/adapters/claude/options.ts` | Claude SDK |
| `packages/runtime/src/adapters/claude/cli.ts` | Claude CLI |
| `packages/runtime/src/adapters/codex/cli.ts` | Codex CLI |
| `packages/runtime/src/adapters/codex/sdk.ts` | Codex SDK |
| `packages/runtime/src/adapters/codex/modelDiscovery/process.ts` | Codex model discovery |
| `.docker/Dockerfile` | Build-time proxy |
| `.env.example` | Documentation |

## Test plan

- [x] `docker compose exec -T -u node agent claude -p "respond with OK"` succeeds through proxy
- [x] Agent picks up task and `plan-coordinator` completes without errors
- [x] Verified proxy vars are present in spawned subprocess environment
