### PR TITLE
perf(docker): use COPY --chown instead of recursive chown -R

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -24,14 +24,14 @@ FROM base AS api
 ENV NODE_ENV=production HOME=/home/node
 RUN apt-get update && apt-get install -y --no-install-recommends gosu git && rm -rf /var/lib/apt/lists/* \
     && npm i -g @anthropic-ai/claude-code @openai/codex
-COPY --from=deps /app/node_modules ./node_modules
-COPY --from=build /app/packages/shared ./packages/shared
-COPY --from=build /app/packages/data ./packages/data
-COPY --from=build /app/packages/runtime ./packages/runtime
-COPY --from=build /app/packages/api ./packages/api
-COPY package.json .
+COPY --chown=node:node --from=deps /app/node_modules ./node_modules
+COPY --chown=node:node --from=build /app/packages/shared ./packages/shared
+COPY --chown=node:node --from=build /app/packages/data ./packages/data
+COPY --chown=node:node --from=build /app/packages/runtime ./packages/runtime
+COPY --chown=node:node --from=build /app/packages/api ./packages/api
+COPY --chown=node:node package.json .
 COPY .docker/docker-entrypoint.sh /usr/local/bin/
-RUN mkdir -p /data /home/www && chown -R node:node /app /data /home/www
+RUN mkdir -p /data /home/www && chown node:node /data /home/www /app
 EXPOSE 3009
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["npx", "tsx", "packages/api/src/index.ts"]
@@ -49,14 +49,14 @@ FROM base AS agent
 ENV NODE_ENV=production HOME=/home/node
 RUN apt-get update && apt-get install -y --no-install-recommends gosu git && rm -rf /var/lib/apt/lists/* \
     && npm i -g @anthropic-ai/claude-code @openai/codex
-COPY --from=deps /app/node_modules ./node_modules
-COPY --from=build /app/packages/shared ./packages/shared
-COPY --from=build /app/packages/data ./packages/data
-COPY --from=build /app/packages/runtime ./packages/runtime
-COPY --from=build /app/packages/agent ./packages/agent
-COPY package.json .
+COPY --chown=node:node --from=deps /app/node_modules ./node_modules
+COPY --chown=node:node --from=build /app/packages/shared ./packages/shared
+COPY --chown=node:node --from=build /app/packages/data ./packages/data
+COPY --chown=node:node --from=build /app/packages/runtime ./packages/runtime
+COPY --chown=node:node --from=build /app/packages/agent ./packages/agent
+COPY --chown=node:node package.json .
 COPY .docker/docker-entrypoint.sh /usr/local/bin/
-RUN mkdir -p /data /home/www && chown -R node:node /app /data /home/www
+RUN mkdir -p /data /home/www && chown node:node /data /home/www /app
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["npx", "tsx", "packages/agent/src/index.ts"]
 
@@ -64,14 +64,14 @@ CMD ["npx", "tsx", "packages/agent/src/index.ts"]
 FROM base AS mcp
 ENV NODE_ENV=production HOME=/home/node
 RUN apt-get update && apt-get install -y --no-install-recommends gosu && rm -rf /var/lib/apt/lists/*
-COPY --from=deps /app/node_modules ./node_modules
-COPY --from=build /app/packages/shared ./packages/shared
-COPY --from=build /app/packages/data ./packages/data
-COPY --from=build /app/packages/runtime ./packages/runtime
-COPY --from=build /app/packages/mcp ./packages/mcp
-COPY package.json .
+COPY --chown=node:node --from=deps /app/node_modules ./node_modules
+COPY --chown=node:node --from=build /app/packages/shared ./packages/shared
+COPY --chown=node:node --from=build /app/packages/data ./packages/data
+COPY --chown=node:node --from=build /app/packages/runtime ./packages/runtime
+COPY --chown=node:node --from=build /app/packages/mcp ./packages/mcp
+COPY --chown=node:node package.json .
 COPY .docker/docker-entrypoint.sh /usr/local/bin/
-RUN mkdir -p /data /home/www && chown -R node:node /app /data /home/www
+RUN mkdir -p /data /home/www && chown node:node /data /home/www /app
 EXPOSE 3100
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["npx", "tsx", "packages/mcp/src/index.ts"]


### PR DESCRIPTION
## Summary

Replace `chown -R node:node /app /data /home/www` with `COPY --chown=node:node`
on all COPY directives in api, agent, and mcp stages.

## Problem

The `chown -R` command walks the entire `/app` directory tree (over 9k :) files in
node_modules) in a separate layer. On cold builds this single step took many time.

## Solution

Set file ownership at copy time via `--chown=node:node` flag on each `COPY` directive.
The remaining `chown node:node /data /home/www /app` (non-recursive, 3 directories only)
runs faster.

## Test plan

- [x] `docker compose build` completes successfully
- [x] All containers start and function correctly under `node` user
- [x] File permissions inside containers verified (`ls -la` shows `node:node` ownership)
