### PR TITLE
stabilize Codex runtime defaults and MCP port handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ npm run init
 npm run dev
 ```
 
-Set `MCP_PORT` in your shell or root `.env` before `npm run dev` if you also want the MCP HTTP server in local development.
+Set `MCP_PORT` in your shell or root `.env` before `npm run dev` if you also want the MCP HTTP server in local development. Use an integer port between `1` and `65535`; invalid values are ignored by the dev launcher and the settings install route falls back to the local `stdio` entry instead of writing an HTTP MCP endpoint.
 
 ### With Docker
 
@@ -55,7 +55,7 @@ cd aif-handoff
 docker compose up --build
 ```
 
-Development starts three services by default. If `MCP_PORT` is set, it starts a fourth service for MCP over HTTP. Docker starts all four services.
+Development starts three services by default. If `MCP_PORT` is set to a valid integer port, it starts a fourth service for MCP over HTTP. Docker starts all four services.
 
 | Service   | URL                               | Description                                  |
 | --------- | --------------------------------- | -------------------------------------------- |
@@ -176,18 +176,18 @@ Authentication: set `ANTHROPIC_API_KEY` in `.env`, or log in via `docker compose
 
 Only ports 80/443 are exposed. API is bound to localhost only. Includes security hardening (no-new-privileges, resource limits), healthchecks, log rotation, and automatic SSL via Let's Encrypt (ACME).
 
-| Variable            | Default      | Description                            |
-| ------------------- | ------------ | -------------------------------------- |
-| `ANTHROPIC_API_KEY` | —            | API key (or use `claude login`)        |
-| `DOMAIN`            | `localhost`  | Domain for SSL certificate (ACME)      |
-| `PORT`              | `3009`       | Host port for API                      |
-| `MCP_PORT`          | `3100`       | Host port for MCP HTTP server          |
-| `WEB_PORT`          | `5180`       | Host port for Web UI (dev)             |
-| `WEB_HOST`          | `localhost`  | Web UI dev server host (Vite)          |
-| `HTTP_PORT`         | `80`         | Host port for Web UI (production)      |
-| `HTTPS_PORT`        | `443`        | HTTPS port (production)                |
-| `PROJECTS_DIR`      | `./projects` | Host directory for project files (dev) |
-| `PROJECTS_MOUNT`    | `/home/www`  | Project files path inside containers   |
+| Variable            | Default      | Description                               |
+| ------------------- | ------------ | ----------------------------------------- |
+| `ANTHROPIC_API_KEY` | —            | API key (or use `claude login`)           |
+| `DOMAIN`            | `localhost`  | Domain for SSL certificate (ACME)         |
+| `PORT`              | `3009`       | Host port for API                         |
+| `MCP_PORT`          | `3100`       | Host port for MCP HTTP server (`1-65535`) |
+| `WEB_PORT`          | `5180`       | Host port for Web UI (dev)                |
+| `WEB_HOST`          | `localhost`  | Web UI dev server host (Vite)             |
+| `HTTP_PORT`         | `80`         | Host port for Web UI (production)         |
+| `HTTPS_PORT`        | `443`        | HTTPS port (production)                   |
+| `PROJECTS_DIR`      | `./projects` | Host directory for project files (dev)    |
+| `PROJECTS_MOUNT`    | `/home/www`  | Project files path inside containers      |
 
 A `.devcontainer/` config is also included for JetBrains / VS Code.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -588,7 +588,7 @@ The WebSocket endpoint is a simple broadcast channel — no authentication, no s
 
 The Handoff MCP server (`packages/mcp`) provides bidirectional sync between AIF tooling and Handoff via the Model Context Protocol. When MCP tools modify tasks, they broadcast `sync:*` events over the WebSocket system so the Kanban UI reflects changes in real time.
 
-The web settings route `POST /settings/mcp/install` installs the MCP server into supported runtimes. When `MCP_PORT` is set in the server environment, it writes a streamable HTTP entry pointing to `http://localhost:<MCP_PORT>/mcp`; otherwise it writes the local `stdio` launcher entry.
+The web settings route `POST /settings/mcp/install` installs the MCP server into supported runtimes. When `MCP_PORT` is a valid integer port in the server environment, it writes a streamable HTTP entry pointing to `http://localhost:<MCP_PORT>/mcp`; otherwise it writes the local `stdio` launcher entry. The response includes per-runtime success/error entries, so partial install failures are surfaced without hiding runtimes that succeeded.
 
 See [MCP Sync Server](mcp-sync.md) for full documentation.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,6 +91,7 @@ Optional runtime defaults:
 - `CODEX_CLI_PATH` for CLI transport adapters
 - `AIF_RUNTIME_MODULES` for loading additional runtime modules at startup (`registerRuntimeModule(registry)`)
 - `API_RUNTIME_START_TIMEOUT_MS` / `API_RUNTIME_RUN_TIMEOUT_MS` for API one-shot runtime calls
+- `MCP_PORT` must be a valid integer port (`1-65535`) anywhere HTTP MCP mode is enabled. `npm run dev` and `POST /settings/mcp/install` ignore invalid values and fall back to non-HTTP behavior; the standalone MCP HTTP server fails fast on invalid configuration.
 
 ### Runtime Readiness Check
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -93,25 +93,25 @@ cp .env.example .env
 
 `npm run dev`, `api`, and `agent` automatically read env from root `.env` (`.env.local` overrides when present), so no extra export step is required.
 
-| Variable                          | Default             | Description                                                                                   |
-| --------------------------------- | ------------------- | --------------------------------------------------------------------------------------------- |
-| `ANTHROPIC_API_KEY`               | _(optional)_        | API key. Agent SDK uses `~/.claude/` auth by default                                          |
-| `PORT`                            | `3009`              | API server port                                                                               |
-| `MCP_PORT`                        | _(optional)_        | When set, `npm run dev` also starts the MCP HTTP server on this port                          |
-| `WEB_PORT`                        | `5180`              | Web UI dev server port                                                                        |
-| `WEB_HOST`                        | `localhost`         | Web UI dev server host                                                                        |
-| `POLL_INTERVAL_MS`                | `30000`             | Agent coordinator polling interval (ms)                                                       |
-| `AGENT_STAGE_STALE_TIMEOUT_MS`    | `5400000`           | Stale-stage watchdog timeout (ms) before auto-recovery                                        |
-| `AGENT_STAGE_STALE_MAX_RETRY`     | `3`                 | Max stale auto-recover attempts before quarantine in `blocked_external`                       |
-| `AGENT_STAGE_RUN_TIMEOUT_MS`      | `3600000`           | Per-stage timeout (ms) before coordinator marks run as failed                                 |
-| `AGENT_FIRST_ACTIVITY_TIMEOUT_MS` | `60000`             | First-activity watchdog: kill + restart agent if no tool call within this window after start  |
-| `API_RUNTIME_START_TIMEOUT_MS`    | `60000`             | Timeout waiting for first output from API one-shot runtime calls                              |
-| `API_RUNTIME_RUN_TIMEOUT_MS`      | `120000`            | Hard timeout for API one-shot runtime calls                                                   |
-| `AGENT_USE_SUBAGENTS`             | `true`              | Default for per-task "Use subagents" toggle. `true`: custom subagents, `false`: aif-\* skills |
-| `DATABASE_URL`                    | `./data/aif.sqlite` | SQLite database path                                                                          |
-| `AGENT_QUERY_AUDIT_ENABLED`       | `true`              | Enable/disable query audit logs in `logs/*.log`                                               |
-| `LOG_LEVEL`                       | `debug`             | Log level: `fatal`, `error`, `warn`, `info`, `debug`, `trace`                                 |
-| `ACTIVITY_LOG_MODE`               | `sync`              | Activity logging strategy: `sync` or `batch`                                                  |
+| Variable                          | Default             | Description                                                                                              |
+| --------------------------------- | ------------------- | -------------------------------------------------------------------------------------------------------- |
+| `ANTHROPIC_API_KEY`               | _(optional)_        | API key. Agent SDK uses `~/.claude/` auth by default                                                     |
+| `PORT`                            | `3009`              | API server port                                                                                          |
+| `MCP_PORT`                        | _(optional)_        | When set to a valid integer port (`1-65535`), `npm run dev` also starts the MCP HTTP server on this port |
+| `WEB_PORT`                        | `5180`              | Web UI dev server port                                                                                   |
+| `WEB_HOST`                        | `localhost`         | Web UI dev server host                                                                                   |
+| `POLL_INTERVAL_MS`                | `30000`             | Agent coordinator polling interval (ms)                                                                  |
+| `AGENT_STAGE_STALE_TIMEOUT_MS`    | `5400000`           | Stale-stage watchdog timeout (ms) before auto-recovery                                                   |
+| `AGENT_STAGE_STALE_MAX_RETRY`     | `3`                 | Max stale auto-recover attempts before quarantine in `blocked_external`                                  |
+| `AGENT_STAGE_RUN_TIMEOUT_MS`      | `3600000`           | Per-stage timeout (ms) before coordinator marks run as failed                                            |
+| `AGENT_FIRST_ACTIVITY_TIMEOUT_MS` | `60000`             | First-activity watchdog: kill + restart agent if no tool call within this window after start             |
+| `API_RUNTIME_START_TIMEOUT_MS`    | `60000`             | Timeout waiting for first output from API one-shot runtime calls                                         |
+| `API_RUNTIME_RUN_TIMEOUT_MS`      | `120000`            | Hard timeout for API one-shot runtime calls                                                              |
+| `AGENT_USE_SUBAGENTS`             | `true`              | Default for per-task "Use subagents" toggle. `true`: custom subagents, `false`: aif-\* skills            |
+| `DATABASE_URL`                    | `./data/aif.sqlite` | SQLite database path                                                                                     |
+| `AGENT_QUERY_AUDIT_ENABLED`       | `true`              | Enable/disable query audit logs in `logs/*.log`                                                          |
+| `LOG_LEVEL`                       | `debug`             | Log level: `fatal`, `error`, `warn`, `info`, `debug`, `trace`                                            |
+| `ACTIVITY_LOG_MODE`               | `sync`              | Activity logging strategy: `sync` or `batch`                                                             |
 
 You can set planner/plan-checker/implementer/review budgets per project in the project edit dialog. Leave any budget field empty for unlimited.
 
@@ -125,7 +125,7 @@ Start all services with hot reload:
 npm run dev
 ```
 
-This runs three processes in parallel via Turborepo by default. If `MCP_PORT` is set, it starts a fourth process for MCP over HTTP.
+This runs three processes in parallel via Turborepo by default. If `MCP_PORT` is set to a valid integer port, it starts a fourth process for MCP over HTTP. Invalid values are ignored here and the local MCP install flow falls back to `stdio`.
 
 | Service   | URL                         | Description                                               |
 | --------- | --------------------------- | --------------------------------------------------------- |

--- a/docs/mcp-sync.md
+++ b/docs/mcp-sync.md
@@ -47,7 +47,7 @@ Claude Code auto-discovers the Handoff MCP server from `.mcp.json` — no build 
 
 #### HTTP — Docker / remote
 
-When running in Docker, or in local development with `MCP_PORT` set, the MCP server uses Streamable HTTP transport and listens on `MCP_PORT` (default `3100`):
+When running in Docker, or in local development with `MCP_PORT` set to a valid integer port (`1-65535`), the MCP server uses Streamable HTTP transport and listens on `MCP_PORT` (default `3100`):
 
 ```json
 {
@@ -61,20 +61,20 @@ When running in Docker, or in local development with `MCP_PORT` set, the MCP ser
 
 The HTTP mode also exposes a `/health` endpoint for Docker healthchecks.
 
-When the web settings UI calls `POST /settings/mcp/install`, the API installs this HTTP URL form automatically whenever `MCP_PORT` is set. If `MCP_PORT` is not set, it falls back to the local `stdio`/`npx tsx packages/mcp/src/index.ts` entry.
+When the web settings UI calls `POST /settings/mcp/install`, the API installs this HTTP URL form automatically whenever `MCP_PORT` is a valid integer port. If `MCP_PORT` is missing or invalid, it falls back to the local `stdio`/`npx tsx packages/mcp/src/index.ts` entry. Direct MCP HTTP startup (`packages/mcp`) is stricter: invalid `MCP_PORT` values fail fast during startup instead of silently coercing the port.
 
 ### Environment Variables
 
 The MCP server uses the shared monorepo environment (`packages/shared/src/env.ts`) for database and API configuration. MCP-specific variables:
 
-| Variable                     | Default | Description                                     |
-| ---------------------------- | ------- | ----------------------------------------------- |
-| `MCP_TRANSPORT`              | `stdio` | Transport mode: `stdio` or `http`               |
-| `MCP_PORT`                   | `3100`  | HTTP port (only used when `MCP_TRANSPORT=http`) |
-| `MCP_RATE_LIMIT_READ_RPM`    | `120`   | Read tool rate limit (requests/minute)          |
-| `MCP_RATE_LIMIT_READ_BURST`  | `10`    | Read tool burst capacity                        |
-| `MCP_RATE_LIMIT_WRITE_RPM`   | `30`    | Write tool rate limit (requests/minute)         |
-| `MCP_RATE_LIMIT_WRITE_BURST` | `5`     | Write tool burst capacity                       |
+| Variable                     | Default | Description                                                |
+| ---------------------------- | ------- | ---------------------------------------------------------- |
+| `MCP_TRANSPORT`              | `stdio` | Transport mode: `stdio` or `http`                          |
+| `MCP_PORT`                   | `3100`  | HTTP port (`1-65535`, only used when `MCP_TRANSPORT=http`) |
+| `MCP_RATE_LIMIT_READ_RPM`    | `120`   | Read tool rate limit (requests/minute)                     |
+| `MCP_RATE_LIMIT_READ_BURST`  | `10`    | Read tool burst capacity                                   |
+| `MCP_RATE_LIMIT_WRITE_RPM`   | `30`    | Write tool rate limit (requests/minute)                    |
+| `MCP_RATE_LIMIT_WRITE_BURST` | `5`     | Write tool burst capacity                                  |
 
 Shared variables (from `@aif/shared`):
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -149,6 +149,8 @@ SDK-specific options:
 - `modelReasoningEffort` — one of `minimal`, `low`, `medium`, `high`, `xhigh`
 - `skipGitRepoCheck` — bypass the Codex guard that refuses to run outside a git repo (both SDK and CLI)
 
+Invalid `options.approvalPolicy` / `options.sandboxMode` values are ignored with a runtime warning, and the adapter falls back to the effective default for that execution path.
+
 ### Codex (CLI transport)
 
 ```json

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build": "turbo build",
     "lint": "turbo lint",
     "test": "turbo test",
-    "coverage": "turbo test -- --coverage",
+    "coverage": "npm run coverage --workspaces --if-present",
     "db:setup": "npm run db:setup --workspace=@aif/shared",
     "db:push": "turbo db:push --filter=@aif/shared",
     "format": "prettier --write .",

--- a/packages/api/src/__tests__/settings.test.ts
+++ b/packages/api/src/__tests__/settings.test.ts
@@ -227,6 +227,78 @@ describe("settings API — config routes", () => {
       expect(codexToml).not.toContain('command = "npx"');
     });
 
+    it("POST /settings/mcp/install falls back to stdio when MCP_PORT is invalid", async () => {
+      process.env.MCP_PORT = "3100abc";
+      writeFileSync(claudeConfigPath, "{}");
+
+      const res = await app.request("/settings/mcp/install", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+
+      const claudeConfig = JSON.parse(readFileSync(claudeConfigPath, "utf-8"));
+      expect(claudeConfig.mcpServers.handoff).toEqual({
+        type: "stdio",
+        command: "npx",
+        args: ["tsx", join(tempRoot, "packages/mcp/src/index.ts")],
+        cwd: tempRoot,
+        env: {
+          DATABASE_URL: join(tempRoot, "data", "aif.sqlite"),
+          LOG_DESTINATION: "stderr",
+          LOG_LEVEL: "info",
+          MCP_TRANSPORT: "stdio",
+          PROJECTS_DIR: join(tempRoot, ".projects"),
+        },
+      });
+
+      const codexToml = readFileSync(codexConfigPath, "utf-8");
+      expect(codexToml).toContain("[mcp_servers.handoff]");
+      expect(codexToml).toContain('command = "npx"');
+      expect(codexToml).not.toContain('url = "http://localhost:3100/mcp"');
+    });
+
+    it("POST /settings/mcp/install reports partial runtime failures", async () => {
+      writeFileSync(claudeConfigPath, "{}");
+      writeFileSync(join(fakeHome, ".codex"), "not-a-directory");
+
+      const res = await app.request("/settings/mcp/install", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(false);
+      expect(body.runtimes).toEqual(
+        expect.arrayContaining([
+          { runtimeId: "claude", success: true },
+          expect.objectContaining({
+            runtimeId: "codex",
+            success: false,
+          }),
+        ]),
+      );
+
+      const claudeConfig = JSON.parse(readFileSync(claudeConfigPath, "utf-8"));
+      expect(claudeConfig.mcpServers.handoff).toEqual({
+        type: "stdio",
+        command: "npx",
+        args: ["tsx", join(tempRoot, "packages/mcp/src/index.ts")],
+        cwd: tempRoot,
+        env: {
+          DATABASE_URL: join(tempRoot, "data", "aif.sqlite"),
+          LOG_DESTINATION: "stderr",
+          LOG_LEVEL: "info",
+          MCP_TRANSPORT: "stdio",
+          PROJECTS_DIR: join(tempRoot, ".projects"),
+        },
+      });
+    });
+
     it("DELETE /settings/mcp removes handoff server", async () => {
       writeFileSync(
         claudeConfigPath,

--- a/packages/api/src/routes/settings.ts
+++ b/packages/api/src/routes/settings.ts
@@ -4,7 +4,13 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import YAML from "yaml";
 import { findProjectById } from "@aif/data";
-import { logger, findMonorepoRoot, getEnv, clearProjectConfigCache } from "@aif/shared";
+import {
+  logger,
+  findMonorepoRoot,
+  getEnv,
+  clearProjectConfigCache,
+  parseMcpPortSetting,
+} from "@aif/shared";
 import type { RuntimeMcpInstallInput } from "@aif/runtime";
 import { getApiRuntimeRegistry } from "../services/runtime.js";
 
@@ -13,26 +19,15 @@ const log = logger("api:settings");
 const MCP_SERVER_NAME = "handoff";
 const MONOREPO_ROOT = findMonorepoRoot(import.meta.dirname);
 
-// Keep in sync with resolveMcpPort in scripts/dev.mjs and packages/mcp/src/env.ts.
-function resolveMcpPort(value: string | undefined): string | null {
-  const trimmed = value?.trim();
-  if (!trimmed) {
-    return null;
-  }
-
-  const port = Number(trimmed);
-  return Number.isInteger(port) && port > 0 && port <= 65_535 ? String(port) : null;
-}
-
 function buildMcpServerEntry(): RuntimeMcpInstallInput {
   const env = getEnv();
-  const mcpPort = resolveMcpPort(process.env.MCP_PORT);
+  const parsedPort = parseMcpPortSetting(process.env.MCP_PORT);
 
-  if (mcpPort) {
+  if (parsedPort.status === "valid") {
     return {
       serverName: MCP_SERVER_NAME,
       transport: "streamable_http",
-      url: `http://localhost:${mcpPort}/mcp`,
+      url: `http://localhost:${parsedPort.value}/mcp`,
     };
   }
 

--- a/packages/api/src/routes/settings.ts
+++ b/packages/api/src/routes/settings.ts
@@ -13,7 +13,7 @@ const log = logger("api:settings");
 const MCP_SERVER_NAME = "handoff";
 const MONOREPO_ROOT = findMonorepoRoot(import.meta.dirname);
 
-// Keep in sync with resolveMcpPort in scripts/dev.mjs.
+// Keep in sync with resolveMcpPort in scripts/dev.mjs and packages/mcp/src/env.ts.
 function resolveMcpPort(value: string | undefined): string | null {
   const trimmed = value?.trim();
   if (!trimmed) {
@@ -21,7 +21,7 @@ function resolveMcpPort(value: string | undefined): string | null {
   }
 
   const port = Number(trimmed);
-  return Number.isInteger(port) && port > 0 ? String(port) : null;
+  return Number.isInteger(port) && port > 0 && port <= 65_535 ? String(port) : null;
 }
 
 function buildMcpServerEntry(): RuntimeMcpInstallInput {

--- a/packages/mcp/scripts/dev-http.mjs
+++ b/packages/mcp/scripts/dev-http.mjs
@@ -4,6 +4,8 @@ import { spawnDev } from "../../../scripts/lib/spawn-dev.mjs";
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
+// This script always starts MCP in HTTP mode, so invalid values are fatal here.
+// The root dev launcher in scripts/dev.mjs treats MCP HTTP as optional instead.
 function resolveMcpPort(value) {
   const trimmed = value?.trim();
   if (!trimmed) {

--- a/packages/mcp/scripts/dev-http.mjs
+++ b/packages/mcp/scripts/dev-http.mjs
@@ -3,7 +3,22 @@ import { fileURLToPath } from "node:url";
 import { spawnDev } from "../../../scripts/lib/spawn-dev.mjs";
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const port = process.env.MCP_PORT || "3100";
+
+function resolveMcpPort(value) {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return "3100";
+  }
+
+  const port = Number(trimmed);
+  if (Number.isInteger(port) && port > 0 && port <= 65535) {
+    return String(port);
+  }
+
+  throw new Error(`Invalid MCP_PORT: ${trimmed}. Must be an integer between 1 and 65535.`);
+}
+
+const port = resolveMcpPort(process.env.MCP_PORT);
 console.log(`[mcp] Starting HTTP transport on port ${port}`);
 
 spawnDev({

--- a/packages/mcp/src/__tests__/env.test.ts
+++ b/packages/mcp/src/__tests__/env.test.ts
@@ -65,10 +65,25 @@ describe("loadMcpEnv", () => {
     expect(env.rateLimitWriteBurst).toBe(8);
   });
 
-  it.each(["3100abc", "0", "-1", "70000"])("throws on invalid MCP_PORT value %s", (value) => {
-    process.env.MCP_PORT = value;
-    expect(() => loadMcpEnv()).toThrow(
-      `Invalid MCP_PORT: ${value}. Must be an integer between 1 and 65535.`,
-    );
-  });
+  it.each(["3100abc", "0", "-1", "70000"])(
+    "ignores invalid MCP_PORT value %s in stdio mode",
+    (value) => {
+      process.env.MCP_PORT = value;
+
+      const env = loadMcpEnv();
+      expect(env.transport).toBe("stdio");
+      expect(env.httpPort).toBe(3100);
+    },
+  );
+
+  it.each(["3100abc", "0", "-1", "70000"])(
+    "throws on invalid MCP_PORT value %s in http mode",
+    (value) => {
+      process.env.MCP_TRANSPORT = "http";
+      process.env.MCP_PORT = value;
+      expect(() => loadMcpEnv()).toThrow(
+        `Invalid MCP_PORT: ${value}. Must be an integer between 1 and 65535.`,
+      );
+    },
+  );
 });

--- a/packages/mcp/src/__tests__/env.test.ts
+++ b/packages/mcp/src/__tests__/env.test.ts
@@ -17,6 +17,8 @@ const { loadMcpEnv } = await import("../env.js");
 
 describe("loadMcpEnv", () => {
   beforeEach(() => {
+    delete process.env.MCP_TRANSPORT;
+    delete process.env.MCP_PORT;
     delete process.env.MCP_RATE_LIMIT_READ_RPM;
     delete process.env.MCP_RATE_LIMIT_WRITE_RPM;
     delete process.env.MCP_RATE_LIMIT_READ_BURST;
@@ -36,6 +38,20 @@ describe("loadMcpEnv", () => {
     expect(env.apiUrl).toBe("http://test:3009");
   });
 
+  it("uses the default MCP port when MCP_PORT is unset", () => {
+    const env = loadMcpEnv();
+    expect(env.httpPort).toBe(3100);
+  });
+
+  it("trims and parses a valid MCP_PORT override", () => {
+    process.env.MCP_TRANSPORT = "http";
+    process.env.MCP_PORT = " 3200 ";
+
+    const env = loadMcpEnv();
+    expect(env.transport).toBe("http");
+    expect(env.httpPort).toBe(3200);
+  });
+
   it("reads custom rate limits from env vars", () => {
     process.env.MCP_RATE_LIMIT_READ_RPM = "200";
     process.env.MCP_RATE_LIMIT_WRITE_RPM = "50";
@@ -47,5 +63,12 @@ describe("loadMcpEnv", () => {
     expect(env.rateLimitWriteRpm).toBe(50);
     expect(env.rateLimitReadBurst).toBe(20);
     expect(env.rateLimitWriteBurst).toBe(8);
+  });
+
+  it.each(["3100abc", "0", "-1", "70000"])("throws on invalid MCP_PORT value %s", (value) => {
+    process.env.MCP_PORT = value;
+    expect(() => loadMcpEnv()).toThrow(
+      `Invalid MCP_PORT: ${value}. Must be an integer between 1 and 65535.`,
+    );
   });
 });

--- a/packages/mcp/src/env.ts
+++ b/packages/mcp/src/env.ts
@@ -19,7 +19,7 @@ export interface McpEnv {
   rateLimitWriteBurst: number;
 }
 
-function resolveMcpPort(value: string | undefined): number {
+function resolveMcpPort(value: string | undefined, transport: McpEnv["transport"]): number {
   const trimmed = value?.trim();
   if (!trimmed) {
     return 3100;
@@ -28,6 +28,18 @@ function resolveMcpPort(value: string | undefined): number {
   const port = Number(trimmed);
   if (Number.isInteger(port) && port > 0 && port <= 65_535) {
     return port;
+  }
+
+  if (transport === "stdio") {
+    log.warn(
+      {
+        transport,
+        invalidValue: trimmed,
+        fallbackPort: 3100,
+      },
+      "[FIX] Ignoring invalid MCP_PORT because MCP transport is stdio",
+    );
+    return 3100;
   }
 
   throw new Error(`Invalid MCP_PORT: ${trimmed}. Must be an integer between 1 and 65535.`);
@@ -49,7 +61,7 @@ export function loadMcpEnv(): McpEnv {
   const env: McpEnv = {
     apiUrl: sharedEnv.API_BASE_URL,
     transport,
-    httpPort: resolveMcpPort(process.env.MCP_PORT),
+    httpPort: resolveMcpPort(process.env.MCP_PORT, transport),
     rateLimitReadRpm: parseInt(process.env.MCP_RATE_LIMIT_READ_RPM || "120", 10),
     rateLimitWriteRpm: parseInt(process.env.MCP_RATE_LIMIT_WRITE_RPM || "30", 10),
     rateLimitReadBurst: parseInt(process.env.MCP_RATE_LIMIT_READ_BURST || "10", 10),

--- a/packages/mcp/src/env.ts
+++ b/packages/mcp/src/env.ts
@@ -1,4 +1,4 @@
-import { logger, getEnv } from "@aif/shared";
+import { logger, getEnv, parseMcpPortSetting } from "@aif/shared";
 
 const log = logger("mcp:env");
 
@@ -20,29 +20,28 @@ export interface McpEnv {
 }
 
 function resolveMcpPort(value: string | undefined, transport: McpEnv["transport"]): number {
-  const trimmed = value?.trim();
-  if (!trimmed) {
+  const parsed = parseMcpPortSetting(value);
+  if (parsed.status === "unset") {
     return 3100;
   }
 
-  const port = Number(trimmed);
-  if (Number.isInteger(port) && port > 0 && port <= 65_535) {
-    return port;
+  if (parsed.status === "valid") {
+    return parsed.port;
   }
 
   if (transport === "stdio") {
     log.warn(
       {
         transport,
-        invalidValue: trimmed,
+        invalidValue: parsed.value,
         fallbackPort: 3100,
       },
-      "[FIX] Ignoring invalid MCP_PORT because MCP transport is stdio",
+      "Ignoring invalid MCP_PORT because MCP transport is stdio",
     );
     return 3100;
   }
 
-  throw new Error(`Invalid MCP_PORT: ${trimmed}. Must be an integer between 1 and 65535.`);
+  throw new Error(`Invalid MCP_PORT: ${parsed.value}. Must be an integer between 1 and 65535.`);
 }
 
 /**

--- a/packages/mcp/src/env.ts
+++ b/packages/mcp/src/env.ts
@@ -19,6 +19,20 @@ export interface McpEnv {
   rateLimitWriteBurst: number;
 }
 
+function resolveMcpPort(value: string | undefined): number {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return 3100;
+  }
+
+  const port = Number(trimmed);
+  if (Number.isInteger(port) && port > 0 && port <= 65_535) {
+    return port;
+  }
+
+  throw new Error(`Invalid MCP_PORT: ${trimmed}. Must be an integer between 1 and 65535.`);
+}
+
 /**
  * Load MCP-specific environment config.
  * DB connection uses the shared getDb() from @aif/shared/server (same as api/agent).
@@ -35,7 +49,7 @@ export function loadMcpEnv(): McpEnv {
   const env: McpEnv = {
     apiUrl: sharedEnv.API_BASE_URL,
     transport,
-    httpPort: parseInt(process.env.MCP_PORT || "3100", 10),
+    httpPort: resolveMcpPort(process.env.MCP_PORT),
     rateLimitReadRpm: parseInt(process.env.MCP_RATE_LIMIT_READ_RPM || "120", 10),
     rateLimitWriteRpm: parseInt(process.env.MCP_RATE_LIMIT_WRITE_RPM || "30", 10),
     rateLimitReadBurst: parseInt(process.env.MCP_RATE_LIMIT_READ_BURST || "10", 10),
@@ -44,9 +58,8 @@ export function loadMcpEnv(): McpEnv {
 
   log.info(
     {
-      apiUrl: env.apiUrl,
-      rateLimitReadRpm: env.rateLimitReadRpm,
-      rateLimitWriteRpm: env.rateLimitWriteRpm,
+      transport: env.transport,
+      httpPort: env.httpPort,
     },
     "MCP environment loaded",
   );

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -103,8 +103,7 @@ async function main() {
   log.info(
     {
       transport: env.transport,
-      readRpm: env.rateLimitReadRpm,
-      writeRpm: env.rateLimitWriteRpm,
+      httpPort: env.httpPort,
     },
     "MCP server starting",
   );

--- a/packages/runtime/src/__tests__/codexCli.test.ts
+++ b/packages/runtime/src/__tests__/codexCli.test.ts
@@ -289,7 +289,7 @@ describe("codex cli transport", () => {
         field: "approvalPolicy",
         invalidValue: "bad-policy",
       }),
-      "WARN [runtime:codex] Ignoring invalid Codex approvalPolicy override",
+      "Ignoring invalid Codex approvalPolicy override",
     );
     expect(logger.warn).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -298,7 +298,7 @@ describe("codex cli transport", () => {
         field: "sandboxMode",
         invalidValue: "bad-sandbox",
       }),
-      "WARN [runtime:codex] Ignoring invalid Codex sandboxMode override",
+      "Ignoring invalid Codex sandboxMode override",
     );
     expect(logger.debug).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -307,7 +307,7 @@ describe("codex cli transport", () => {
         approvalPolicy: "on-request",
         sandboxMode: "workspace-write",
       }),
-      "DEBUG [runtime:codex] Resolved Codex CLI approval and sandbox settings",
+      "Resolved Codex CLI approval and sandbox settings",
     );
 
     child.stdout.emit("data", "ok");

--- a/packages/runtime/src/__tests__/codexCli.test.ts
+++ b/packages/runtime/src/__tests__/codexCli.test.ts
@@ -262,6 +262,59 @@ describe("codex cli transport", () => {
     await runPromise;
   });
 
+  it("warns and falls back to defaults when permission overrides are invalid", async () => {
+    const child = createMockChildProcess();
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    spawnMock.mockReturnValueOnce(child);
+
+    const runPromise = runCodexCli(
+      createRunInput({
+        options: { approvalPolicy: "bad-policy", sandboxMode: "bad-sandbox" },
+      }),
+      logger,
+    );
+
+    const { cliArgs: args } = getSpawnInvocation();
+    expect(args).toContain('approval_policy="on-request"');
+    expect(args).toContain('sandbox_mode="workspace-write"');
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeId: "codex",
+        transport: "cli",
+        field: "approvalPolicy",
+        invalidValue: "bad-policy",
+      }),
+      "WARN [runtime:codex] Ignoring invalid Codex approvalPolicy override",
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeId: "codex",
+        transport: "cli",
+        field: "sandboxMode",
+        invalidValue: "bad-sandbox",
+      }),
+      "WARN [runtime:codex] Ignoring invalid Codex sandboxMode override",
+    );
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeId: "codex",
+        transport: "cli",
+        approvalPolicy: "on-request",
+        sandboxMode: "workspace-write",
+      }),
+      "DEBUG [runtime:codex] Resolved Codex CLI approval and sandbox settings",
+    );
+
+    child.stdout.emit("data", "ok");
+    child.emit("close", 0);
+    await runPromise;
+  });
+
   it("custom codexCliArgs is a full escape hatch — adapter-managed flags are NOT injected", async () => {
     const child = createMockChildProcess();
     spawnMock.mockReturnValueOnce(child);

--- a/packages/runtime/src/__tests__/codexSdk.test.ts
+++ b/packages/runtime/src/__tests__/codexSdk.test.ts
@@ -489,7 +489,7 @@ describe("runCodexSdk", () => {
         source: "options",
         invalidValue: "bad-policy",
       }),
-      "WARN [runtime:codex] Ignoring invalid Codex approvalPolicy override",
+      "Ignoring invalid Codex approvalPolicy override",
     );
     expect(logger.warn).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -499,7 +499,7 @@ describe("runCodexSdk", () => {
         source: "options",
         invalidValue: "bad-sandbox",
       }),
-      "WARN [runtime:codex] Ignoring invalid Codex sandboxMode override",
+      "Ignoring invalid Codex sandboxMode override",
     );
     expect(logger.debug).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -508,7 +508,7 @@ describe("runCodexSdk", () => {
         approvalPolicy: "on-request",
         sandboxMode: "workspace-write",
       }),
-      "DEBUG [runtime:codex] Resolved Codex SDK approval and sandbox settings",
+      "Resolved Codex SDK approval and sandbox settings",
     );
   });
 });

--- a/packages/runtime/src/__tests__/codexSdk.test.ts
+++ b/packages/runtime/src/__tests__/codexSdk.test.ts
@@ -450,4 +450,65 @@ describe("runCodexSdk", () => {
     expect(constructorOptions.env?.OPENAI_API_KEY).toBe("sk-sdk");
     expect(constructorOptions.env?.npm_config_registry).toBeUndefined();
   });
+
+  it("warns and falls back to stable defaults when thread permission overrides are invalid", async () => {
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    mockRunStreamed.mockResolvedValue({
+      events: createMockEvents([
+        { type: "thread.started", thread_id: "thread-invalid-overrides" },
+        {
+          type: "turn.completed",
+          usage: { input_tokens: 0, output_tokens: 0, cached_input_tokens: 0 },
+        },
+      ]),
+    });
+
+    await runCodexSdk(
+      createRunInput({
+        options: { approvalPolicy: "bad-policy", sandboxMode: "bad-sandbox" },
+      }),
+      logger,
+    );
+
+    expect(mockStartThread).toHaveBeenCalledWith(
+      expect.objectContaining({
+        approvalPolicy: "on-request",
+        sandboxMode: "workspace-write",
+      }),
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeId: "codex",
+        transport: "sdk",
+        field: "approvalPolicy",
+        source: "options",
+        invalidValue: "bad-policy",
+      }),
+      "WARN [runtime:codex] Ignoring invalid Codex approvalPolicy override",
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeId: "codex",
+        transport: "sdk",
+        field: "sandboxMode",
+        source: "options",
+        invalidValue: "bad-sandbox",
+      }),
+      "WARN [runtime:codex] Ignoring invalid Codex sandboxMode override",
+    );
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeId: "codex",
+        transport: "sdk",
+        approvalPolicy: "on-request",
+        sandboxMode: "workspace-write",
+      }),
+      "DEBUG [runtime:codex] Resolved Codex SDK approval and sandbox settings",
+    );
+  });
 });

--- a/packages/runtime/src/adapters/codex/cli.ts
+++ b/packages/runtime/src/adapters/codex/cli.ts
@@ -8,6 +8,13 @@ import {
   withProcessTimeouts,
 } from "../../timeouts.js";
 import { classifyCodexRuntimeError } from "./errors.js";
+import {
+  normalizeCodexApprovalPolicy,
+  normalizeCodexSandboxMode,
+  warnOnInvalidCodexPermissionOverride,
+  type CodexApprovalPolicy,
+  type CodexSandboxMode,
+} from "./permissions.js";
 
 const IS_WINDOWS = process.platform === "win32";
 
@@ -40,61 +47,6 @@ function normalizeCodexCliEffort(value: unknown): CodexCliEffortLevel | null {
     }
   }
   return null;
-}
-
-const CODEX_APPROVAL_POLICIES = new Set([
-  "untrusted",
-  "on-failure",
-  "on-request",
-  "never",
-] as const);
-
-type CodexApprovalPolicy = "untrusted" | "on-failure" | "on-request" | "never";
-
-function normalizeCodexApprovalPolicy(value: unknown): CodexApprovalPolicy | null {
-  if (typeof value !== "string") return null;
-  const trimmed = value.trim();
-  return CODEX_APPROVAL_POLICIES.has(trimmed as CodexApprovalPolicy)
-    ? (trimmed as CodexApprovalPolicy)
-    : null;
-}
-
-const CODEX_SANDBOX_MODES = new Set([
-  "read-only",
-  "workspace-write",
-  "danger-full-access",
-] as const);
-
-type CodexSandboxMode = "read-only" | "workspace-write" | "danger-full-access";
-
-function normalizeCodexSandboxMode(value: unknown): CodexSandboxMode | null {
-  if (typeof value !== "string") return null;
-  const trimmed = value.trim();
-  return CODEX_SANDBOX_MODES.has(trimmed as CodexSandboxMode)
-    ? (trimmed as CodexSandboxMode)
-    : null;
-}
-
-function warnOnInvalidCodexPermissionOverride(input: {
-  logger?: CodexCliLogger;
-  runtimeId: string;
-  field: "approvalPolicy" | "sandboxMode";
-  rawValue: string | null;
-  normalizedValue: string | null;
-}): void {
-  if (!input.rawValue || input.normalizedValue) {
-    return;
-  }
-
-  input.logger?.warn?.(
-    {
-      runtimeId: input.runtimeId,
-      transport: "cli",
-      field: input.field,
-      invalidValue: input.rawValue,
-    },
-    `WARN [runtime:codex] Ignoring invalid Codex ${input.field} override`,
-  );
 }
 
 /**
@@ -134,6 +86,7 @@ function resolveCodexPermissionOverrides(
   warnOnInvalidCodexPermissionOverride({
     logger,
     runtimeId: input.runtimeId,
+    transport: "cli",
     field: "approvalPolicy",
     rawValue: rawApproval,
     normalizedValue: explicitApproval,
@@ -141,6 +94,7 @@ function resolveCodexPermissionOverrides(
   warnOnInvalidCodexPermissionOverride({
     logger,
     runtimeId: input.runtimeId,
+    transport: "cli",
     field: "sandboxMode",
     rawValue: rawSandbox,
     normalizedValue: explicitSandbox,
@@ -161,7 +115,7 @@ function resolveCodexPermissionOverrides(
       sandboxSource: explicitSandbox ? "options" : bypass ? "bypass-default" : "default",
       bypassPermissions: bypass,
     },
-    "DEBUG [runtime:codex] Resolved Codex CLI approval and sandbox settings",
+    "Resolved Codex CLI approval and sandbox settings",
   );
 
   return resolved;

--- a/packages/runtime/src/adapters/codex/cli.ts
+++ b/packages/runtime/src/adapters/codex/cli.ts
@@ -75,6 +75,28 @@ function normalizeCodexSandboxMode(value: unknown): CodexSandboxMode | null {
     : null;
 }
 
+function warnOnInvalidCodexPermissionOverride(input: {
+  logger?: CodexCliLogger;
+  runtimeId: string;
+  field: "approvalPolicy" | "sandboxMode";
+  rawValue: string | null;
+  normalizedValue: string | null;
+}): void {
+  if (!input.rawValue || input.normalizedValue) {
+    return;
+  }
+
+  input.logger?.warn?.(
+    {
+      runtimeId: input.runtimeId,
+      transport: "cli",
+      field: input.field,
+      invalidValue: input.rawValue,
+    },
+    `WARN [runtime:codex] Ignoring invalid Codex ${input.field} override`,
+  );
+}
+
 /**
  * Resolve the effective approval policy and sandbox mode for a Codex CLI run.
  *
@@ -95,19 +117,54 @@ function normalizeCodexSandboxMode(value: unknown): CodexSandboxMode | null {
  * `--dangerously-bypass-approvals-and-sandbox` flag is required because the
  * `codex exec resume` subcommand rejects `--sandbox` outright.
  */
-function resolveCodexPermissionOverrides(input: RuntimeRunInput): {
+function resolveCodexPermissionOverrides(
+  input: RuntimeRunInput,
+  logger?: CodexCliLogger,
+): {
   approvalPolicy: CodexApprovalPolicy;
   sandboxMode: CodexSandboxMode;
 } {
   const options = asRecord(input.options);
-  const explicitApproval = normalizeCodexApprovalPolicy(options.approvalPolicy);
-  const explicitSandbox = normalizeCodexSandboxMode(options.sandboxMode);
+  const rawApproval = readString(options.approvalPolicy);
+  const rawSandbox = readString(options.sandboxMode);
+  const explicitApproval = normalizeCodexApprovalPolicy(rawApproval);
+  const explicitSandbox = normalizeCodexSandboxMode(rawSandbox);
   const bypass = input.execution?.bypassPermissions === true;
 
-  return {
+  warnOnInvalidCodexPermissionOverride({
+    logger,
+    runtimeId: input.runtimeId,
+    field: "approvalPolicy",
+    rawValue: rawApproval,
+    normalizedValue: explicitApproval,
+  });
+  warnOnInvalidCodexPermissionOverride({
+    logger,
+    runtimeId: input.runtimeId,
+    field: "sandboxMode",
+    rawValue: rawSandbox,
+    normalizedValue: explicitSandbox,
+  });
+
+  const resolved = {
     approvalPolicy: explicitApproval ?? (bypass ? "never" : "on-request"),
     sandboxMode: explicitSandbox ?? (bypass ? "danger-full-access" : "workspace-write"),
   };
+
+  logger?.debug?.(
+    {
+      runtimeId: input.runtimeId,
+      transport: "cli",
+      approvalPolicy: resolved.approvalPolicy,
+      sandboxMode: resolved.sandboxMode,
+      approvalSource: explicitApproval ? "options" : bypass ? "bypass-default" : "default",
+      sandboxSource: explicitSandbox ? "options" : bypass ? "bypass-default" : "default",
+      bypassPermissions: bypass,
+    },
+    "DEBUG [runtime:codex] Resolved Codex CLI approval and sandbox settings",
+  );
+
+  return resolved;
 }
 
 function readStringArray(value: unknown): string[] | null {
@@ -116,7 +173,7 @@ function readStringArray(value: unknown): string[] | null {
   return parsed.length > 0 ? parsed : null;
 }
 
-function normalizeCliArgs(input: RuntimeRunInput): string[] {
+function normalizeCliArgs(input: RuntimeRunInput, logger?: CodexCliLogger): string[] {
   const options = asRecord(input.options);
   const configured = readStringArray(options.codexCliArgs);
 
@@ -161,7 +218,7 @@ function normalizeCliArgs(input: RuntimeRunInput): string[] {
   // `--dangerously-bypass-approvals-and-sandbox` flag — `codex exec resume`
   // rejects `--sandbox`, and `-c` overrides work uniformly across both the
   // fresh exec and resume paths.
-  const { approvalPolicy, sandboxMode } = resolveCodexPermissionOverrides(input);
+  const { approvalPolicy, sandboxMode } = resolveCodexPermissionOverrides(input, logger);
   args.push("-c", `approval_policy="${approvalPolicy}"`);
   args.push("-c", `sandbox_mode="${sandboxMode}"`);
 
@@ -751,7 +808,7 @@ export async function runCodexCli(
   logger?: CodexCliLogger,
 ): Promise<RuntimeRunResult> {
   const cliPath = resolveCliPath(input);
-  const args = normalizeCliArgs(input);
+  const args = normalizeCliArgs(input, logger);
   const options = asRecord(input.options);
   const apiKeyEnvVar =
     typeof options.apiKeyEnvVar === "string" ? options.apiKeyEnvVar : "OPENAI_API_KEY";

--- a/packages/runtime/src/adapters/codex/permissions.ts
+++ b/packages/runtime/src/adapters/codex/permissions.ts
@@ -1,0 +1,61 @@
+interface CodexPermissionLogger {
+  warn?(context: Record<string, unknown>, message: string): void;
+}
+
+const CODEX_APPROVAL_POLICIES = new Set([
+  "untrusted",
+  "on-failure",
+  "on-request",
+  "never",
+] as const);
+
+export type CodexApprovalPolicy = "untrusted" | "on-failure" | "on-request" | "never";
+
+export function normalizeCodexApprovalPolicy(value: unknown): CodexApprovalPolicy | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return CODEX_APPROVAL_POLICIES.has(trimmed as CodexApprovalPolicy)
+    ? (trimmed as CodexApprovalPolicy)
+    : null;
+}
+
+const CODEX_SANDBOX_MODES = new Set([
+  "read-only",
+  "workspace-write",
+  "danger-full-access",
+] as const);
+
+export type CodexSandboxMode = "read-only" | "workspace-write" | "danger-full-access";
+
+export function normalizeCodexSandboxMode(value: unknown): CodexSandboxMode | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return CODEX_SANDBOX_MODES.has(trimmed as CodexSandboxMode)
+    ? (trimmed as CodexSandboxMode)
+    : null;
+}
+
+export function warnOnInvalidCodexPermissionOverride(input: {
+  logger?: CodexPermissionLogger;
+  runtimeId: string;
+  transport: "cli" | "sdk";
+  field: "approvalPolicy" | "sandboxMode";
+  rawValue: string | null;
+  normalizedValue: string | null;
+  source?: "options" | "hooks";
+}): void {
+  if (!input.rawValue || input.normalizedValue) {
+    return;
+  }
+
+  input.logger?.warn?.(
+    {
+      runtimeId: input.runtimeId,
+      transport: input.transport,
+      field: input.field,
+      invalidValue: input.rawValue,
+      ...(input.source ? { source: input.source } : {}),
+    },
+    `Ignoring invalid Codex ${input.field} override`,
+  );
+}

--- a/packages/runtime/src/adapters/codex/sdk.ts
+++ b/packages/runtime/src/adapters/codex/sdk.ts
@@ -21,6 +21,11 @@ import {
   withStreamTimeouts,
 } from "../../timeouts.js";
 import { classifyCodexRuntimeError } from "./errors.js";
+import {
+  normalizeCodexApprovalPolicy,
+  normalizeCodexSandboxMode,
+  warnOnInvalidCodexPermissionOverride,
+} from "./permissions.js";
 
 export interface CodexSdkLogger {
   debug?(context: Record<string, unknown>, message: string): void;
@@ -41,30 +46,6 @@ function asRecord(value: unknown): Record<string, unknown> {
 
 function readString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
-}
-
-function warnOnInvalidCodexThreadOverride(input: {
-  logger?: CodexSdkLogger;
-  runtimeId: string;
-  field: "approvalPolicy" | "sandboxMode";
-  source: "options" | "hooks";
-  rawValue: string | null;
-  normalizedValue: string | null;
-}): void {
-  if (!input.rawValue || input.normalizedValue) {
-    return;
-  }
-
-  input.logger?.warn?.(
-    {
-      runtimeId: input.runtimeId,
-      transport: "sdk",
-      field: input.field,
-      source: input.source,
-      invalidValue: input.rawValue,
-    },
-    `WARN [runtime:codex] Ignoring invalid Codex ${input.field} override`,
-  );
 }
 
 function formatToolDetail(value: unknown, maxLength = 200): string {
@@ -239,27 +220,18 @@ function buildThreadOptions(input: RuntimeRunInput, logger?: CodexSdkLogger): Th
   const rawApprovalOption = readString(options.approvalPolicy);
   const rawApprovalHook = readString(hooks.approvalPolicy);
   const explicitApproval = rawApprovalOption ?? rawApprovalHook;
-  warnOnInvalidCodexThreadOverride({
+  const normalizedApproval = normalizeCodexApprovalPolicy(explicitApproval);
+  warnOnInvalidCodexPermissionOverride({
     logger,
     runtimeId: input.runtimeId,
+    transport: "sdk",
     field: "approvalPolicy",
     source: rawApprovalOption ? "options" : "hooks",
     rawValue: explicitApproval,
-    normalizedValue:
-      explicitApproval === "never" ||
-      explicitApproval === "on-request" ||
-      explicitApproval === "on-failure" ||
-      explicitApproval === "untrusted"
-        ? explicitApproval
-        : null,
+    normalizedValue: normalizedApproval,
   });
-  if (
-    explicitApproval === "never" ||
-    explicitApproval === "on-request" ||
-    explicitApproval === "on-failure" ||
-    explicitApproval === "untrusted"
-  ) {
-    threadOpts.approvalPolicy = explicitApproval;
+  if (normalizedApproval) {
+    threadOpts.approvalPolicy = normalizedApproval;
   } else if (execution?.bypassPermissions) {
     threadOpts.approvalPolicy = "never";
   } else {
@@ -274,25 +246,18 @@ function buildThreadOptions(input: RuntimeRunInput, logger?: CodexSdkLogger): Th
   const rawSandboxOption = readString(options.sandboxMode);
   const rawSandboxHook = readString(hooks.sandboxMode);
   const explicitSandbox = rawSandboxOption ?? rawSandboxHook;
-  warnOnInvalidCodexThreadOverride({
+  const normalizedSandbox = normalizeCodexSandboxMode(explicitSandbox);
+  warnOnInvalidCodexPermissionOverride({
     logger,
     runtimeId: input.runtimeId,
+    transport: "sdk",
     field: "sandboxMode",
     source: rawSandboxOption ? "options" : "hooks",
     rawValue: explicitSandbox,
-    normalizedValue:
-      explicitSandbox === "read-only" ||
-      explicitSandbox === "workspace-write" ||
-      explicitSandbox === "danger-full-access"
-        ? explicitSandbox
-        : null,
+    normalizedValue: normalizedSandbox,
   });
-  if (
-    explicitSandbox === "read-only" ||
-    explicitSandbox === "workspace-write" ||
-    explicitSandbox === "danger-full-access"
-  ) {
-    threadOpts.sandboxMode = explicitSandbox;
+  if (normalizedSandbox) {
+    threadOpts.sandboxMode = normalizedSandbox;
   } else if (execution?.bypassPermissions) {
     threadOpts.sandboxMode = "danger-full-access";
   } else {
@@ -345,7 +310,7 @@ function buildThreadOptions(input: RuntimeRunInput, logger?: CodexSdkLogger): Th
               : "default",
       bypassPermissions: execution?.bypassPermissions === true,
     },
-    "DEBUG [runtime:codex] Resolved Codex SDK approval and sandbox settings",
+    "Resolved Codex SDK approval and sandbox settings",
   );
 
   return threadOpts;

--- a/packages/runtime/src/adapters/codex/sdk.ts
+++ b/packages/runtime/src/adapters/codex/sdk.ts
@@ -43,6 +43,30 @@ function readString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
+function warnOnInvalidCodexThreadOverride(input: {
+  logger?: CodexSdkLogger;
+  runtimeId: string;
+  field: "approvalPolicy" | "sandboxMode";
+  source: "options" | "hooks";
+  rawValue: string | null;
+  normalizedValue: string | null;
+}): void {
+  if (!input.rawValue || input.normalizedValue) {
+    return;
+  }
+
+  input.logger?.warn?.(
+    {
+      runtimeId: input.runtimeId,
+      transport: "sdk",
+      field: input.field,
+      source: input.source,
+      invalidValue: input.rawValue,
+    },
+    `WARN [runtime:codex] Ignoring invalid Codex ${input.field} override`,
+  );
+}
+
 function formatToolDetail(value: unknown, maxLength = 200): string {
   if (value == null) return "";
 
@@ -186,7 +210,7 @@ function buildCodexOptions(input: RuntimeRunInput, logger?: CodexSdkLogger): Cod
   return codexOpts;
 }
 
-function buildThreadOptions(input: RuntimeRunInput): ThreadOptions {
+function buildThreadOptions(input: RuntimeRunInput, logger?: CodexSdkLogger): ThreadOptions {
   const cwd = input.cwd ?? input.projectRoot;
   const options = asRecord(input.options);
   const execution = input.execution;
@@ -212,7 +236,23 @@ function buildThreadOptions(input: RuntimeRunInput): ThreadOptions {
   // to the bypass-permissions refactor these defaults were set by a
   // Codex-specific hook factory in the API layer; the logic now lives inside
   // the adapter so api/agent/runtime all see the same contract.
-  const explicitApproval = readString(options.approvalPolicy) ?? readString(hooks.approvalPolicy);
+  const rawApprovalOption = readString(options.approvalPolicy);
+  const rawApprovalHook = readString(hooks.approvalPolicy);
+  const explicitApproval = rawApprovalOption ?? rawApprovalHook;
+  warnOnInvalidCodexThreadOverride({
+    logger,
+    runtimeId: input.runtimeId,
+    field: "approvalPolicy",
+    source: rawApprovalOption ? "options" : "hooks",
+    rawValue: explicitApproval,
+    normalizedValue:
+      explicitApproval === "never" ||
+      explicitApproval === "on-request" ||
+      explicitApproval === "on-failure" ||
+      explicitApproval === "untrusted"
+        ? explicitApproval
+        : null,
+  });
   if (
     explicitApproval === "never" ||
     explicitApproval === "on-request" ||
@@ -231,7 +271,22 @@ function buildThreadOptions(input: RuntimeRunInput): ThreadOptions {
     threadOpts.skipGitRepoCheck = true;
   }
 
-  const explicitSandbox = readString(options.sandboxMode) ?? readString(hooks.sandboxMode);
+  const rawSandboxOption = readString(options.sandboxMode);
+  const rawSandboxHook = readString(hooks.sandboxMode);
+  const explicitSandbox = rawSandboxOption ?? rawSandboxHook;
+  warnOnInvalidCodexThreadOverride({
+    logger,
+    runtimeId: input.runtimeId,
+    field: "sandboxMode",
+    source: rawSandboxOption ? "options" : "hooks",
+    rawValue: explicitSandbox,
+    normalizedValue:
+      explicitSandbox === "read-only" ||
+      explicitSandbox === "workspace-write" ||
+      explicitSandbox === "danger-full-access"
+        ? explicitSandbox
+        : null,
+  });
   if (
     explicitSandbox === "read-only" ||
     explicitSandbox === "workspace-write" ||
@@ -265,6 +320,33 @@ function buildThreadOptions(input: RuntimeRunInput): ThreadOptions {
   ) {
     threadOpts.modelReasoningEffort = effort;
   }
+
+  logger?.debug?.(
+    {
+      runtimeId: input.runtimeId,
+      transport: "sdk",
+      approvalPolicy: threadOpts.approvalPolicy ?? null,
+      sandboxMode: threadOpts.sandboxMode ?? null,
+      approvalSource:
+        rawApprovalOption != null
+          ? "options"
+          : rawApprovalHook != null
+            ? "hooks"
+            : execution?.bypassPermissions
+              ? "bypass-default"
+              : "default",
+      sandboxSource:
+        rawSandboxOption != null
+          ? "options"
+          : rawSandboxHook != null
+            ? "hooks"
+            : execution?.bypassPermissions
+              ? "bypass-default"
+              : "default",
+      bypassPermissions: execution?.bypassPermissions === true,
+    },
+    "DEBUG [runtime:codex] Resolved Codex SDK approval and sandbox settings",
+  );
 
   return threadOpts;
 }
@@ -423,7 +505,7 @@ async function runCodexSdkAttempt(
   logger?: CodexSdkLogger,
 ): Promise<RuntimeRunResult> {
   const codexOpts = buildCodexOptions(input, logger);
-  const threadOpts = buildThreadOptions(input);
+  const threadOpts = buildThreadOptions(input, logger);
   const turnOpts = buildTurnOptions(input.execution);
   const execution = input.execution;
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -135,3 +135,4 @@ export {
 
 // Utilities
 export { withTimeout } from "./withTimeout.js";
+export { parseMcpPortSetting, type ParsedMcpPortSetting } from "./mcpPort.js";

--- a/packages/shared/src/mcpPort.ts
+++ b/packages/shared/src/mcpPort.ts
@@ -1,0 +1,18 @@
+export type ParsedMcpPortSetting =
+  | { status: "unset" }
+  | { status: "valid"; value: string; port: number }
+  | { status: "invalid"; value: string };
+
+export function parseMcpPortSetting(value: string | undefined): ParsedMcpPortSetting {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return { status: "unset" };
+  }
+
+  const port = Number(trimmed);
+  if (Number.isInteger(port) && port > 0 && port <= 65_535) {
+    return { status: "valid", value: String(port), port };
+  }
+
+  return { status: "invalid", value: trimmed };
+}

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -48,7 +48,8 @@ function loadRootEnv() {
   }
 }
 
-// Keep in sync with resolveMcpPort in packages/api/src/routes/settings.ts and packages/mcp/src/env.ts.
+// MCP HTTP is optional in the root dev launcher, so invalid values disable the
+// extra HTTP process instead of aborting the whole dev stack.
 function resolveMcpPort(value) {
   const trimmed = value?.trim();
   if (!trimmed) {

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -48,7 +48,7 @@ function loadRootEnv() {
   }
 }
 
-// Keep in sync with resolveMcpPort in packages/api/src/routes/settings.ts.
+// Keep in sync with resolveMcpPort in packages/api/src/routes/settings.ts and packages/mcp/src/env.ts.
 function resolveMcpPort(value) {
   const trimmed = value?.trim();
   if (!trimmed) {
@@ -56,7 +56,7 @@ function resolveMcpPort(value) {
   }
 
   const port = Number(trimmed);
-  return Number.isInteger(port) && port > 0 ? String(port) : null;
+  return Number.isInteger(port) && port > 0 && port <= 65535 ? String(port) : null;
 }
 
 loadRootEnv();


### PR DESCRIPTION
## Summary

This PR hardens the remaining Codex runtime and MCP edge cases found during the stabilization audit.

### What changed

- added stable fallback behavior for invalid Codex `approvalPolicy` and `sandboxMode` overrides in both CLI and SDK adapters
- added DEBUG/WARN logging for resolved Codex permission settings and ignored invalid overrides
- normalized `MCP_PORT` parsing across the API route, local dev scripts, and the MCP package entrypoints
- kept MCP install behavior aligned by falling back to `stdio` when `MCP_PORT` is invalid instead of generating a broken HTTP config
- added regression coverage for:
  - invalid Codex permission overrides
  - invalid `MCP_PORT` values
  - partial `/settings/mcp/install` failures
- fixed the root coverage script so `npm run ai:validate` runs end-to-end in the monorepo
- updated runtime/MCP docs to match the current behavior

## Validation

- `npm run test --workspace=@aif/runtime -- src/__tests__/codexCli.test.ts src/__tests__/codexSdk.test.ts`
- `npm run test --workspace=@aif/mcp -- src/__tests__/env.test.ts`
- `npm run test --workspace=@aif/api -- src/__tests__/settings.test.ts`
- `npm run ai:validate`
