### PR TITLE
Fix/projects retry on api restart

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,6 +1,17 @@
 # ---- Base ----
 FROM node:22-slim AS base
 WORKDIR /app
+# Proxy (optional) — propagated to all downstream stages via ENV,
+# so apt-get / npm / npx all pick it up during build.
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG NO_PROXY
+ENV HTTP_PROXY=${HTTP_PROXY} \
+    HTTPS_PROXY=${HTTPS_PROXY} \
+    NO_PROXY=${NO_PROXY} \
+    http_proxy=${HTTP_PROXY} \
+    https_proxy=${HTTPS_PROXY} \
+    no_proxy=${NO_PROXY}
 
 # ---- Dependencies ----
 FROM base AS deps
@@ -38,6 +49,16 @@ CMD ["npx", "tsx", "packages/api/src/index.ts"]
 
 # ---- Web (Angie reverse proxy + static) ----
 FROM docker.angie.software/angie:1.11.4-alpine AS web
+# Proxy (optional) — separate ARGs because this stage does NOT inherit from `base`.
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG NO_PROXY
+ENV HTTP_PROXY=${HTTP_PROXY} \
+    HTTPS_PROXY=${HTTPS_PROXY} \
+    NO_PROXY=${NO_PROXY} \
+    http_proxy=${HTTP_PROXY} \
+    https_proxy=${HTTPS_PROXY} \
+    no_proxy=${NO_PROXY}
 RUN apk add --no-cache gettext
 COPY --from=build /app/packages/web/dist /usr/share/angie/html
 COPY .docker/angie.conf /etc/angie/http.d/default.conf

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -24,14 +24,14 @@ FROM base AS api
 ENV NODE_ENV=production HOME=/home/node
 RUN apt-get update && apt-get install -y --no-install-recommends gosu git && rm -rf /var/lib/apt/lists/* \
     && npm i -g @anthropic-ai/claude-code @openai/codex
-COPY --from=deps /app/node_modules ./node_modules
-COPY --from=build /app/packages/shared ./packages/shared
-COPY --from=build /app/packages/data ./packages/data
-COPY --from=build /app/packages/runtime ./packages/runtime
-COPY --from=build /app/packages/api ./packages/api
-COPY package.json .
+COPY --chown=node:node --from=deps /app/node_modules ./node_modules
+COPY --chown=node:node --from=build /app/packages/shared ./packages/shared
+COPY --chown=node:node --from=build /app/packages/data ./packages/data
+COPY --chown=node:node --from=build /app/packages/runtime ./packages/runtime
+COPY --chown=node:node --from=build /app/packages/api ./packages/api
+COPY --chown=node:node package.json .
 COPY .docker/docker-entrypoint.sh /usr/local/bin/
-RUN mkdir -p /data /home/www && chown -R node:node /app /data /home/www
+RUN mkdir -p /data /home/www && chown node:node /data /home/www /app
 EXPOSE 3009
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["npx", "tsx", "packages/api/src/index.ts"]
@@ -49,14 +49,14 @@ FROM base AS agent
 ENV NODE_ENV=production HOME=/home/node
 RUN apt-get update && apt-get install -y --no-install-recommends gosu git && rm -rf /var/lib/apt/lists/* \
     && npm i -g @anthropic-ai/claude-code @openai/codex
-COPY --from=deps /app/node_modules ./node_modules
-COPY --from=build /app/packages/shared ./packages/shared
-COPY --from=build /app/packages/data ./packages/data
-COPY --from=build /app/packages/runtime ./packages/runtime
-COPY --from=build /app/packages/agent ./packages/agent
-COPY package.json .
+COPY --chown=node:node --from=deps /app/node_modules ./node_modules
+COPY --chown=node:node --from=build /app/packages/shared ./packages/shared
+COPY --chown=node:node --from=build /app/packages/data ./packages/data
+COPY --chown=node:node --from=build /app/packages/runtime ./packages/runtime
+COPY --chown=node:node --from=build /app/packages/agent ./packages/agent
+COPY --chown=node:node package.json .
 COPY .docker/docker-entrypoint.sh /usr/local/bin/
-RUN mkdir -p /data /home/www && chown -R node:node /app /data /home/www
+RUN mkdir -p /data /home/www && chown node:node /data /home/www /app
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["npx", "tsx", "packages/agent/src/index.ts"]
 
@@ -64,14 +64,14 @@ CMD ["npx", "tsx", "packages/agent/src/index.ts"]
 FROM base AS mcp
 ENV NODE_ENV=production HOME=/home/node
 RUN apt-get update && apt-get install -y --no-install-recommends gosu && rm -rf /var/lib/apt/lists/*
-COPY --from=deps /app/node_modules ./node_modules
-COPY --from=build /app/packages/shared ./packages/shared
-COPY --from=build /app/packages/data ./packages/data
-COPY --from=build /app/packages/runtime ./packages/runtime
-COPY --from=build /app/packages/mcp ./packages/mcp
-COPY package.json .
+COPY --chown=node:node --from=deps /app/node_modules ./node_modules
+COPY --chown=node:node --from=build /app/packages/shared ./packages/shared
+COPY --chown=node:node --from=build /app/packages/data ./packages/data
+COPY --chown=node:node --from=build /app/packages/runtime ./packages/runtime
+COPY --chown=node:node --from=build /app/packages/mcp ./packages/mcp
+COPY --chown=node:node package.json .
 COPY .docker/docker-entrypoint.sh /usr/local/bin/
-RUN mkdir -p /data /home/www && chown -R node:node /app /data /home/www
+RUN mkdir -p /data /home/www && chown node:node /data /home/www /app
 EXPOSE 3100
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["npx", "tsx", "packages/mcp/src/index.ts"]

--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,18 @@ DATABASE_URL=./data/aif.sqlite
 # Mount path for project files inside containers
 # PROJECTS_MOUNT=/home/www
 
+# ----------------------------------------------------------
+# HTTP(S) proxy — used at build time (npm/apt/apk) and runtime
+# ----------------------------------------------------------
+# Leave unset if you don't need a proxy. When set, compose passes
+# these to `docker build` as build-args AND injects them into
+# running containers via `env_file: .env`.
+# NO_PROXY must include compose service names (api/agent/web/mcp)
+# so internal calls do not go through the proxy.
+# HTTP_PROXY=http://proxy.example.com:8080
+# HTTPS_PROXY=http://proxy.example.com:8080
+# NO_PROXY=localhost,127.0.0.1,::1,api,agent,web,mcp
+
 # Production: domain for SSL certificate (Let's Encrypt via ACME)
 # DOMAIN=example.com
 

--- a/packages/runtime/src/adapters/claude/cli.ts
+++ b/packages/runtime/src/adapters/claude/cli.ts
@@ -51,6 +51,12 @@ const ALLOWED_ENV_PREFIXES = [
   "VISUAL",
   "FORCE_COLOR",
   "NO_COLOR",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "NO_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "no_proxy",
 ];
 
 function buildCuratedEnv(

--- a/packages/runtime/src/adapters/claude/options.ts
+++ b/packages/runtime/src/adapters/claude/options.ts
@@ -164,6 +164,12 @@ const ALLOWED_ENV_PREFIXES = [
   "VISUAL",
   "FORCE_COLOR",
   "NO_COLOR",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "NO_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "no_proxy",
 ];
 
 function isAllowedEnvKey(key: string): boolean {

--- a/packages/runtime/src/adapters/codex/cli.ts
+++ b/packages/runtime/src/adapters/codex/cli.ts
@@ -186,6 +186,12 @@ const ALLOWED_ENV_PREFIXES = [
   "XDG_",
   "FORCE_COLOR",
   "NO_COLOR",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "NO_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "no_proxy",
 ];
 
 /**

--- a/packages/runtime/src/adapters/codex/modelDiscovery/process.ts
+++ b/packages/runtime/src/adapters/codex/modelDiscovery/process.ts
@@ -36,6 +36,12 @@ const ALLOWED_ENV_PREFIXES = [
   "XDG_",
   "FORCE_COLOR",
   "NO_COLOR",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "NO_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "no_proxy",
 ];
 const BLOCKED_ENV_KEYS = new Set(["OPENAI_BASE_URL"]);
 

--- a/packages/runtime/src/adapters/codex/sdk.ts
+++ b/packages/runtime/src/adapters/codex/sdk.ts
@@ -80,6 +80,12 @@ const ALLOWED_ENV_PREFIXES = [
   "XDG_",
   "FORCE_COLOR",
   "NO_COLOR",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "NO_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "no_proxy",
 ];
 
 function buildCuratedEnv(

--- a/packages/web/src/hooks/useProjects.ts
+++ b/packages/web/src/hooks/useProjects.ts
@@ -6,6 +6,10 @@ export function useProjects() {
   return useQuery<Project[]>({
     queryKey: ["projects"],
     queryFn: api.listProjects,
+    // Projects are critical bootstrap data — keep retrying until the API is reachable.
+    // Prevents empty UI when the page loads before the API is fully ready (e.g. docker restart).
+    retry: true,
+    retryDelay: (attempt) => Math.min(2000 * 2 ** attempt, 15_000),
   });
 }
 


### PR DESCRIPTION
## Summary

`docker compose restart` causes the web UI to lose project state and show an empty "Select project" screen with no way to recover without a manual page reload.

- **Problem:** `docker compose restart` makes the API briefly unavailable (10-15s). If the browser page is open or reloaded during that window, React Query's default 3 retries (~7s) exhaust before the API recovers. The `useProjects()` query permanently enters error state — the UI shows "Select project" with an empty board and never self-heals.
- **Root cause:** `useProjects()` used React Query defaults (`retry: 3`), which is insufficient for bootstrap data that the entire UI depends on.
- **Fix:** Set `retry: true` (infinite) with exponential backoff (2s → 4s → 8s → capped at 15s). The query keeps retrying until the API is reachable instead of giving up.

## Test plan

- [x] Playwright: stop API → reload page → wait 15s → start API → UI auto-recovers to selected project
- [x] Playwright: `docker compose restart` during page reload (race condition) → UI recovers after brief 502
- [x] Playwright: page stays open during restart → project selection persists
- [x] Full test suite passes (`npm run ai:validate`)