### PR TITLE
feat(tasks): mode-driven defaults for review/docs/tests + scoped review sidecars

### DIFF
--- a/packages/agent/src/constants.ts
+++ b/packages/agent/src/constants.ts
@@ -6,3 +6,16 @@ export const PROJECT_SCOPE_SYSTEM_APPEND =
   "Project scope rule: work strictly inside the current working directory (project root). " +
   "Do not inspect or modify files in the orchestrator monorepo or in parent/sibling directories " +
   "unless the user explicitly asks for that path. Avoid broad discovery outside the current project root.";
+
+/**
+ * Scope rule injected automatically into review-style subagent queries
+ * (profileMode === "review"). Keeps review/security sidecars focused on the
+ * current task's diff instead of auditing unrelated code paths.
+ */
+export const REVIEW_DIFF_SCOPE_SYSTEM_APPEND =
+  "Review scope rule: review ONLY code that changed as part of this task's implementation " +
+  "(the diff introduced by the current plan's tasks). Do NOT audit unrelated files, " +
+  "pre-existing code paths, or broader project concerns. If a concern is outside the changed " +
+  'scope, note it briefly as "out of scope" and move on. Reference changed files/lines ' +
+  "explicitly. Ignore pre-existing issues unless they are directly aggravated by the change. " +
+  "Your job is to validate the delta, not the whole codebase.";

--- a/packages/agent/src/subagentQuery.ts
+++ b/packages/agent/src/subagentQuery.ts
@@ -29,7 +29,7 @@ import {
 } from "@aif/runtime";
 import { getEnv, logger } from "@aif/shared";
 import { logActivity } from "./hooks.js";
-import { PROJECT_SCOPE_SYSTEM_APPEND } from "./constants.js";
+import { PROJECT_SCOPE_SYSTEM_APPEND, REVIEW_DIFF_SCOPE_SYSTEM_APPEND } from "./constants.js";
 import { createStderrCollector } from "./stderrCollector.js";
 import { writeQueryAudit } from "./queryAudit.js";
 import { getActiveStageAbortController } from "./stageAbort.js";
@@ -314,6 +314,14 @@ async function resolveExecutionContext(options: SubagentQueryOptions): Promise<{
     },
   });
 
+  // Review-stage subagents (review-sidecar, security-sidecar) must only audit
+  // the current task's diff, not the full codebase. Inject the scope rule here
+  // so every review-mode query gets it regardless of the agent definition file.
+  const effectiveSystemPromptAppend =
+    (options.profileMode ?? "task") === "review"
+      ? `${promptPolicy.systemPromptAppend}\n\n${REVIEW_DIFF_SCOPE_SYSTEM_APPEND}`.trim()
+      : promptPolicy.systemPromptAppend;
+
   const canResume =
     workflow.sessionReusePolicy === "resume_if_available" && capabilities.supportsResume;
 
@@ -357,7 +365,7 @@ async function resolveExecutionContext(options: SubagentQueryOptions): Promise<{
       projectRoot: options.projectRoot,
     },
     prompt: promptPolicy.prompt,
-    systemPromptAppend: promptPolicy.systemPromptAppend,
+    systemPromptAppend: effectiveSystemPromptAppend,
     agentDefinitionName: promptPolicy.agentDefinitionName,
     canResume,
   };

--- a/packages/api/src/__tests__/roadmapGeneration.test.ts
+++ b/packages/api/src/__tests__/roadmapGeneration.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { generatePlanPath, projects } from "@aif/shared";
+import { eq } from "drizzle-orm";
 import { createTestDb } from "@aif/shared/server";
 import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
@@ -351,10 +352,45 @@ describe("roadmapGeneration", () => {
       const stored = findTasksByRoadmapAlias(projectId, "sprint-1");
       expect(stored).toHaveLength(2);
       // Every generated task must have skipReview=true so the auto-pipeline
-      // doesn't pause on review for roadmap imports.
+      // doesn't pause on review for roadmap imports. Regular (non-parallel)
+      // projects fall back to fast-mode flag defaults.
       for (const task of stored) {
         expect(task.skipReview).toBe(true);
+        expect(task.plannerMode).toBe("fast");
+        expect(task.planDocs).toBe(false);
+        expect(task.planTests).toBe(false);
       }
+    });
+
+    it("should apply full-mode defaults for parallel-enabled projects (still skipReview=true)", () => {
+      const { projectId } = createProjectWithRoadmap("# Roadmap");
+      // Force parallelEnabled — roadmap import must honor the same rule
+      // POST /tasks applies: parallel projects are locked to full mode.
+      testDb.current
+        .update(projects)
+        .set({ parallelEnabled: true })
+        .where(eq(projects.id, projectId))
+        .run();
+
+      const result = importGeneratedTasks(projectId, {
+        alias: "sprint-parallel",
+        tasks: [
+          {
+            title: "Parallel task",
+            description: "",
+            phase: 1,
+            phaseName: "P",
+            sequence: 1,
+          },
+        ],
+      });
+
+      expect(result.created).toBe(1);
+      const [task] = findTasksByRoadmapAlias(projectId, "sprint-parallel");
+      expect(task.plannerMode).toBe("full");
+      expect(task.planDocs).toBe(true);
+      expect(task.planTests).toBe(true);
+      expect(task.skipReview).toBe(true);
     });
 
     it("should skip duplicates by normalized title", () => {

--- a/packages/api/src/__tests__/roadmapGeneration.test.ts
+++ b/packages/api/src/__tests__/roadmapGeneration.test.ts
@@ -350,6 +350,11 @@ describe("roadmapGeneration", () => {
 
       const stored = findTasksByRoadmapAlias(projectId, "sprint-1");
       expect(stored).toHaveLength(2);
+      // Every generated task must have skipReview=true so the auto-pipeline
+      // doesn't pause on review for roadmap imports.
+      for (const task of stored) {
+        expect(task.skipReview).toBe(true);
+      }
     });
 
     it("should skip duplicates by normalized title", () => {

--- a/packages/api/src/__tests__/tasks.test.ts
+++ b/packages/api/src/__tests__/tasks.test.ts
@@ -264,19 +264,62 @@ describe("tasks API", () => {
       expect(body.skipReview).toBe(true);
     });
 
-    it("should default skipReview to false", async () => {
+    it("should apply fast-mode flag defaults when flags are omitted (default plannerMode=fast)", async () => {
       const res = await app.request("/tasks", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          title: "Task without skip review",
+          title: "Task without flags",
           projectId: "test-project",
         }),
       });
 
       expect(res.status).toBe(201);
       const body = await res.json();
+      expect(body.plannerMode).toBe("fast");
+      expect(body.skipReview).toBe(true);
+      expect(body.planDocs).toBe(false);
+      expect(body.planTests).toBe(false);
+    });
+
+    it("should apply full-mode flag defaults when plannerMode=full and flags omitted", async () => {
+      const res = await app.request("/tasks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: "Full mode task",
+          projectId: "test-project",
+          plannerMode: "full",
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.plannerMode).toBe("full");
       expect(body.skipReview).toBe(false);
+      expect(body.planDocs).toBe(true);
+      expect(body.planTests).toBe(true);
+    });
+
+    it("should respect explicit false flag values over mode defaults", async () => {
+      const res = await app.request("/tasks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: "Explicit flags",
+          projectId: "test-project",
+          plannerMode: "full",
+          skipReview: false,
+          planDocs: false,
+          planTests: false,
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.skipReview).toBe(false);
+      expect(body.planDocs).toBe(false);
+      expect(body.planTests).toBe(false);
     });
 
     it("should persist useSubagents from create payload", async () => {

--- a/packages/api/src/__tests__/tasks.test.ts
+++ b/packages/api/src/__tests__/tasks.test.ts
@@ -651,6 +651,87 @@ describe("tasks API", () => {
       expect(body.planTests).toBe(true);
     });
 
+    it("should apply full-mode flag defaults when PUT sends only plannerMode=full", async () => {
+      const db = testDb.current;
+      db.insert(tasks)
+        .values({
+          id: "upd-mode-full",
+          projectId: "test-project",
+          title: "Mode switch",
+          plannerMode: "fast",
+          skipReview: true,
+          planDocs: false,
+          planTests: false,
+        })
+        .run();
+
+      const res = await app.request("/tasks/upd-mode-full", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ plannerMode: "full" }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.plannerMode).toBe("full");
+      expect(body.skipReview).toBe(false);
+      expect(body.planDocs).toBe(true);
+      expect(body.planTests).toBe(true);
+    });
+
+    it("should respect explicit flag values over mode defaults on PUT", async () => {
+      const db = testDb.current;
+      db.insert(tasks)
+        .values({ id: "upd-mode-explicit", projectId: "test-project", title: "Explicit" })
+        .run();
+
+      const res = await app.request("/tasks/upd-mode-explicit", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          plannerMode: "full",
+          skipReview: true,
+          planDocs: false,
+          planTests: false,
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.plannerMode).toBe("full");
+      expect(body.skipReview).toBe(true);
+      expect(body.planDocs).toBe(false);
+      expect(body.planTests).toBe(false);
+    });
+
+    it("should not touch flags when PUT omits plannerMode", async () => {
+      const db = testDb.current;
+      db.insert(tasks)
+        .values({
+          id: "upd-mode-absent",
+          projectId: "test-project",
+          title: "No mode",
+          plannerMode: "fast",
+          skipReview: true,
+          planDocs: false,
+          planTests: false,
+        })
+        .run();
+
+      const res = await app.request("/tasks/upd-mode-absent", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: "renamed" }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.plannerMode).toBe("fast");
+      expect(body.skipReview).toBe(true);
+      expect(body.planDocs).toBe(false);
+      expect(body.planTests).toBe(false);
+    });
+
     it("should handle attachments update via PUT", async () => {
       const db = testDb.current;
       const rootPath = mkdtempSync(join(tmpdir(), "aif-put-attach-"));

--- a/packages/api/src/routes/tasks.ts
+++ b/packages/api/src/routes/tasks.ts
@@ -322,6 +322,25 @@ tasksRouter.put("/:id", jsonValidator(updateTaskSchema), async (c) => {
 
   const { plan, attachments: incomingAttachments, ...updatePayload } = body;
 
+  // Mirror POST /tasks: when plannerMode changes, fill omitted flags from mode defaults.
+  if (updatePayload.plannerMode !== undefined) {
+    const modeDefaults = defaultsForMode(updatePayload.plannerMode);
+    const filled = {
+      skipReview: updatePayload.skipReview === undefined,
+      planDocs: updatePayload.planDocs === undefined,
+      planTests: updatePayload.planTests === undefined,
+    };
+    updatePayload.skipReview = updatePayload.skipReview ?? modeDefaults.skipReview;
+    updatePayload.planDocs = updatePayload.planDocs ?? modeDefaults.planDocs;
+    updatePayload.planTests = updatePayload.planTests ?? modeDefaults.planTests;
+    if (filled.skipReview || filled.planDocs || filled.planTests) {
+      log.debug(
+        { taskId: id, plannerMode: updatePayload.plannerMode, filled },
+        "Applied mode-driven task flag defaults on update",
+      );
+    }
+  }
+
   const hasPlanUpdate = Object.prototype.hasOwnProperty.call(body, "plan");
   if (hasPlanUpdate) {
     try {

--- a/packages/api/src/routes/tasks.ts
+++ b/packages/api/src/routes/tasks.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { jsonValidator } from "../middleware/zodValidator.js";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
-import { logger, parseAttachments, getProjectConfig } from "@aif/shared";
+import { logger, parseAttachments, getProjectConfig, defaultsForMode } from "@aif/shared";
 import {
   createTaskSchema,
   updateTaskSchema,
@@ -103,6 +103,29 @@ tasksRouter.post("/", jsonValidator(createTaskSchema), async (c) => {
     body.plannerMode = "full";
   }
 
+  // Fill omitted flag values from mode-driven defaults (mirror of web UI behavior).
+  const modeDefaults = defaultsForMode(body.plannerMode);
+  const resolvedSkipReview = body.skipReview ?? modeDefaults.skipReview;
+  const resolvedPlanDocs = body.planDocs ?? modeDefaults.planDocs;
+  const resolvedPlanTests = body.planTests ?? modeDefaults.planTests;
+  if (
+    body.skipReview === undefined ||
+    body.planDocs === undefined ||
+    body.planTests === undefined
+  ) {
+    log.debug(
+      {
+        plannerMode: body.plannerMode,
+        filled: {
+          skipReview: body.skipReview === undefined,
+          planDocs: body.planDocs === undefined,
+          planTests: body.planTests === undefined,
+        },
+      },
+      "Applied mode-driven task flag defaults",
+    );
+  }
+
   // Pre-create the task to get an ID, then persist attachments to storage
   const created = createTask({
     projectId: body.projectId,
@@ -114,9 +137,9 @@ tasksRouter.post("/", jsonValidator(createTaskSchema), async (c) => {
     isFix: body.isFix,
     plannerMode: body.plannerMode,
     planPath: body.planPath ?? defaultPlanPath,
-    planDocs: body.planDocs,
-    planTests: body.planTests,
-    skipReview: body.skipReview,
+    planDocs: resolvedPlanDocs,
+    planTests: resolvedPlanTests,
+    skipReview: resolvedSkipReview,
     useSubagents: body.useSubagents,
     maxReviewIterations: body.maxReviewIterations,
     paused: body.paused,

--- a/packages/api/src/schemas.ts
+++ b/packages/api/src/schemas.ts
@@ -55,9 +55,9 @@ export const createTaskSchema = z.object({
   isFix: z.boolean().default(false),
   plannerMode: z.enum(["fast", "full"]).default("fast"),
   planPath: z.string().max(500).optional(),
-  planDocs: z.boolean().default(false),
-  planTests: z.boolean().default(false),
-  skipReview: z.boolean().default(false),
+  planDocs: z.boolean().optional(),
+  planTests: z.boolean().optional(),
+  skipReview: z.boolean().optional(),
   useSubagents: z.boolean().default(getEnv().AGENT_USE_SUBAGENTS),
   maxReviewIterations: z
     .number()

--- a/packages/api/src/services/roadmapGeneration.ts
+++ b/packages/api/src/services/roadmapGeneration.ts
@@ -518,6 +518,7 @@ export function importGeneratedTasks(
       roadmapAlias: alias,
       tags,
       planPath,
+      skipReview: true,
       useSubagents: getEnv().AGENT_USE_SUBAGENTS,
     });
 

--- a/packages/api/src/services/roadmapGeneration.ts
+++ b/packages/api/src/services/roadmapGeneration.ts
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { z } from "zod";
-import { logger, getEnv, getProjectConfig, generatePlanPath } from "@aif/shared";
+import { logger, getEnv, getProjectConfig, generatePlanPath, defaultsForMode } from "@aif/shared";
 import { createTask, findProjectById, findTasksByRoadmapAlias, listTasks } from "@aif/data";
 import { UsageSource } from "@aif/runtime";
 import { resolveApiLightModel, runApiRuntimeOneShot } from "./runtime.js";
@@ -506,11 +506,13 @@ export function importGeneratedTasks(
     }
 
     const tags = buildTaskTags(alias, genTask);
-    // "full" here is just the path-shape selector (`<plansDir>/<slug>.md`),
-    // NOT a planner-mode override — plannerMode is left untouched so the
-    // project/task defaults still apply (fast for regular projects,
-    // parallelEnabled projects already force full via POST /tasks).
+    // Roadmap import bypasses POST /tasks, so mode-driven defaults must be
+    // applied here too. parallelEnabled projects force "full" (same rule POST
+    // applies); otherwise fall back to "fast". skipReview is always forced
+    // true for roadmap imports so the batch pipeline doesn't pause on review.
     const planPath = reserveUniquePlanPath(genTask.title);
+    const plannerMode = project.parallelEnabled ? "full" : "fast";
+    const modeDefaults = defaultsForMode(plannerMode);
     const created = createTask({
       projectId,
       title: genTask.title,
@@ -518,6 +520,9 @@ export function importGeneratedTasks(
       roadmapAlias: alias,
       tags,
       planPath,
+      plannerMode,
+      planDocs: modeDefaults.planDocs,
+      planTests: modeDefaults.planTests,
       skipReview: true,
       useSubagents: getEnv().AGENT_USE_SUBAGENTS,
     });

--- a/packages/shared/src/browser.ts
+++ b/packages/shared/src/browser.ts
@@ -60,3 +60,7 @@ export type { GeneratePlanPathOptions } from "./planPath.js";
 
 // Sync types (browser-safe subset — types only, no Node.js logger dependency)
 export type { SyncDirection, ConflictResolution, SyncEvent, PlanAnnotation } from "./sync.js";
+
+// Planner mode defaults (pure, browser-safe)
+export { defaultsForMode } from "./plannerDefaults.js";
+export type { PlannerMode, PlannerFlagDefaults } from "./plannerDefaults.js";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -142,6 +142,10 @@ export {
   type TelegramNotificationOptions,
 } from "./telegram.js";
 
+// Planner mode defaults
+export { defaultsForMode } from "./plannerDefaults.js";
+export type { PlannerMode, PlannerFlagDefaults } from "./plannerDefaults.js";
+
 // Utilities
 export { withTimeout } from "./withTimeout.js";
 export { parseMcpPortSetting, type ParsedMcpPortSetting } from "./mcpPort.js";

--- a/packages/shared/src/plannerDefaults.ts
+++ b/packages/shared/src/plannerDefaults.ts
@@ -1,0 +1,13 @@
+export type PlannerMode = "full" | "fast";
+
+export interface PlannerFlagDefaults {
+  skipReview: boolean;
+  planDocs: boolean;
+  planTests: boolean;
+}
+
+export function defaultsForMode(mode: PlannerMode): PlannerFlagDefaults {
+  return mode === "full"
+    ? { skipReview: false, planDocs: true, planTests: true }
+    : { skipReview: true, planDocs: false, planTests: false };
+}

--- a/packages/web/src/__tests__/AddTaskForm.test.tsx
+++ b/packages/web/src/__tests__/AddTaskForm.test.tsx
@@ -360,12 +360,13 @@ describe("AddTaskForm", () => {
     // Toggle through both planner modes to cover both onChange branches
     fireEvent.click(screen.getByLabelText("Full"));
     fireEvent.click(screen.getByLabelText("Fast"));
+    // Re-enable docs/tests after fast-mode reset flipped them off
     fireEvent.click(screen.getByLabelText("Docs"));
     fireEvent.click(screen.getByLabelText("Tests"));
     fireEvent.change(screen.getByPlaceholderText(".ai-factory/PLAN.md"), {
       target: { value: ".ai-factory/custom-plan.md" },
     });
-    // Toggle skip review and use subagents
+    // Fast mode seeded skipReview=true; toggling once disables it (explicit user intent).
     const checkboxes = screen.getAllByRole("checkbox");
     const skipReviewCheckbox = checkboxes.find((cb) =>
       cb.closest("label")?.textContent?.includes("Skip review"),
@@ -388,8 +389,67 @@ describe("AddTaskForm", () => {
         planPath: ".ai-factory/custom-plan.md",
         planDocs: true,
         planTests: true,
-        skipReview: true,
+        skipReview: false,
         useSubagents: false,
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("uses fast-mode flag defaults by default (skipReview=true, planDocs=false, planTests=false)", () => {
+    render(<AddTaskForm projectId="p-1" />);
+    fireEvent.click(screen.getByText("Add task"));
+    fireEvent.change(screen.getByPlaceholderText("Task title"), {
+      target: { value: "Default flags" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+    expect(mutateCreateTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plannerMode: "fast",
+        skipReview: true,
+        planDocs: false,
+        planTests: false,
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("flips flags to full-mode defaults when switching to Full, and back to fast defaults on Fast", () => {
+    render(<AddTaskForm projectId="p-1" />);
+    fireEvent.click(screen.getByText("Add task"));
+    fireEvent.click(screen.getByRole("button", { name: "Planner settings" }));
+    fireEvent.click(screen.getByLabelText("Full"));
+    fireEvent.change(screen.getByPlaceholderText("Task title"), {
+      target: { value: "Full mode defaults" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+    expect(mutateCreateTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plannerMode: "full",
+        skipReview: false,
+        planDocs: true,
+        planTests: true,
+      }),
+      expect.any(Object),
+    );
+
+    // Simulate onSuccess: form resets to fast-mode defaults.
+    const options = mutateCreateTask.mock.calls[0][1] as { onSuccess?: () => void };
+    act(() => {
+      options.onSuccess?.();
+    });
+    // Reopen the form and submit — should now send fast-mode defaults.
+    fireEvent.click(screen.getByText("Add task"));
+    fireEvent.change(screen.getByPlaceholderText("Task title"), {
+      target: { value: "After reset" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+    expect(mutateCreateTask).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        plannerMode: "fast",
+        skipReview: true,
+        planDocs: false,
+        planTests: false,
       }),
       expect.any(Object),
     );

--- a/packages/web/src/__tests__/TaskSettings.test.tsx
+++ b/packages/web/src/__tests__/TaskSettings.test.tsx
@@ -112,11 +112,14 @@ describe("TaskSettings", () => {
     });
   });
 
-  it("saves planner settings changes", () => {
+  it("saves planner settings changes (fast mode flips flags to fast defaults, then docs/tests re-enabled)", () => {
     render(<TaskSettings task={mockTask} onSave={onSave} />);
     fireEvent.click(screen.getByText("Settings"));
 
+    // Switching to Fast auto-flips flags to fast-mode defaults
+    // (skipReview=true, planDocs=false, planTests=false).
     fireEvent.click(screen.getByLabelText("Fast"));
+    // Re-enable docs and tests manually.
     fireEvent.click(screen.getByLabelText("Docs"));
     fireEvent.click(screen.getByLabelText("Tests"));
     fireEvent.change(screen.getByPlaceholderText(".ai-factory/PLAN.md"), {
@@ -128,6 +131,42 @@ describe("TaskSettings", () => {
     expect(onSave).toHaveBeenCalledWith({
       plannerMode: "fast",
       planPath: ".ai-factory/custom.md",
+      planDocs: true,
+      planTests: true,
+      skipReview: true,
+    });
+  });
+
+  it("preserves saved task values on mount (no auto-flip)", () => {
+    const savedTask: Task = {
+      ...mockTask,
+      plannerMode: "full",
+      skipReview: true,
+      planDocs: false,
+      planTests: false,
+    };
+    render(<TaskSettings task={savedTask} onSave={onSave} />);
+    fireEvent.click(screen.getByText("Settings"));
+    // No Save button — nothing changed on mount.
+    expect(screen.queryByText("Save")).toBeNull();
+  });
+
+  it("flips flags to full-mode defaults when user manually selects Full", () => {
+    const fastTask: Task = {
+      ...mockTask,
+      plannerMode: "fast",
+      skipReview: true,
+      planDocs: false,
+      planTests: false,
+    };
+    render(<TaskSettings task={fastTask} onSave={onSave} />);
+    fireEvent.click(screen.getByText("Settings"));
+    fireEvent.click(screen.getByLabelText("Full"));
+    fireEvent.click(screen.getByText("Save"));
+
+    expect(onSave).toHaveBeenCalledWith({
+      plannerMode: "full",
+      skipReview: false,
       planDocs: true,
       planTests: true,
     });

--- a/packages/web/src/components/kanban/AddTaskForm.tsx
+++ b/packages/web/src/components/kanban/AddTaskForm.tsx
@@ -11,7 +11,7 @@ import { useKeyboardShortcut } from "@/hooks/useKeyboardShortcut";
 import { useProjects } from "@/hooks/useProjects";
 import { useSettings, useProjectDefaults } from "@/hooks/useSettings";
 import { useRuntimeProfiles, useRuntimes } from "@/hooks/useRuntimeProfiles";
-import { generatePlanPath } from "@aif/shared/browser";
+import { generatePlanPath, defaultsForMode } from "@aif/shared/browser";
 import { PlannerSettings } from "./PlannerSettings";
 
 interface Props {
@@ -29,9 +29,10 @@ export function AddTaskForm({ projectId }: Props) {
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [plannerMode, setPlannerMode] = useState<"full" | "fast">("fast");
   const [planPath, setPlanPath] = useState(DEFAULT_PLAN_PATH);
-  const [planDocs, setPlanDocs] = useState(false);
-  const [planTests, setPlanTests] = useState(false);
-  const [skipReview, setSkipReview] = useState(false);
+  const initialFlagDefaults = defaultsForMode("fast");
+  const [planDocs, setPlanDocs] = useState(initialFlagDefaults.planDocs);
+  const [planTests, setPlanTests] = useState(initialFlagDefaults.planTests);
+  const [skipReview, setSkipReview] = useState(initialFlagDefaults.skipReview);
   const [useSubagents, setUseSubagents] = useState(true);
   const [maxReviewIterations, setMaxReviewIterations] = useState(3);
   const [runtimeProfileId, setRuntimeProfileId] = useState("");
@@ -87,6 +88,12 @@ export function AddTaskForm({ projectId }: Props) {
     setRuntimeProfileId("");
     setModelOverride("");
     setPriority(0);
+    // Apply mode-driven flag defaults; isParallel forces full mode defaults.
+    const seededMode = isParallel ? "full" : plannerMode;
+    const flags = defaultsForMode(seededMode);
+    setSkipReview(flags.skipReview);
+    setPlanDocs(flags.planDocs);
+    setPlanTests(flags.planTests);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [syncGen]);
 
@@ -116,6 +123,10 @@ export function AddTaskForm({ projectId }: Props) {
   const handleModeChange = (mode: "full" | "fast") => {
     setPlannerMode(mode);
     syncPlanPath(title, mode);
+    const flags = defaultsForMode(mode);
+    setSkipReview(flags.skipReview);
+    setPlanDocs(flags.planDocs);
+    setPlanTests(flags.planTests);
   };
 
   // Effective values: parallel projects force full mode
@@ -154,11 +165,14 @@ export function AddTaskForm({ projectId }: Props) {
           setAutoMode(true);
           setIsFix(false);
           setShowAdvanced(false);
-          setPlannerMode("full");
+          setPlannerMode("fast");
           setPlanPath(defaultPlanPath);
-          setPlanDocs(false);
-          setPlanTests(false);
-          setSkipReview(false);
+          {
+            const resetFlags = defaultsForMode("fast");
+            setPlanDocs(resetFlags.planDocs);
+            setPlanTests(resetFlags.planTests);
+            setSkipReview(resetFlags.skipReview);
+          }
           setUseSubagents(useSubagentsDefault);
           setMaxReviewIterations(maxReviewIterationsDefault);
           setRuntimeProfileId("");
@@ -400,11 +414,14 @@ export function AddTaskForm({ projectId }: Props) {
             setAutoMode(true);
             setIsFix(false);
             setShowAdvanced(false);
-            setPlannerMode("full");
+            setPlannerMode("fast");
             setPlanPath(defaultPlanPath);
-            setPlanDocs(false);
-            setPlanTests(false);
-            setSkipReview(false);
+            {
+              const resetFlags = defaultsForMode("fast");
+              setPlanDocs(resetFlags.planDocs);
+              setPlanTests(resetFlags.planTests);
+              setSkipReview(resetFlags.skipReview);
+            }
             setUseSubagents(useSubagentsDefault);
             setMaxReviewIterations(maxReviewIterationsDefault);
             setRuntimeProfileId("");

--- a/packages/web/src/components/task/TaskSettings.tsx
+++ b/packages/web/src/components/task/TaskSettings.tsx
@@ -7,7 +7,7 @@ import { Radio } from "@/components/ui/radio";
 import { Select } from "@/components/ui/select";
 import { useProjects } from "@/hooks/useProjects";
 import { useRuntimeProfiles, useRuntimes } from "@/hooks/useRuntimeProfiles";
-import type { Task, UpdateTaskInput } from "@aif/shared/browser";
+import { defaultsForMode, type Task, type UpdateTaskInput } from "@aif/shared/browser";
 
 interface Props {
   task: Task;
@@ -183,7 +183,13 @@ export function TaskSettings({ task, onSave }: Props) {
                 <Radio
                   name="plannerModeDetail"
                   checked={plannerMode === "full"}
-                  onChange={() => setPlannerMode("full")}
+                  onChange={() => {
+                    setPlannerMode("full");
+                    const flags = defaultsForMode("full");
+                    setSkipReview(flags.skipReview);
+                    setPlanDocs(flags.planDocs);
+                    setPlanTests(flags.planTests);
+                  }}
                   className="h-3.5 w-3.5"
                 />
                 <span className="font-medium text-foreground">Full</span>
@@ -192,7 +198,13 @@ export function TaskSettings({ task, onSave }: Props) {
                 <Radio
                   name="plannerModeDetail"
                   checked={plannerMode === "fast"}
-                  onChange={() => setPlannerMode("fast")}
+                  onChange={() => {
+                    setPlannerMode("fast");
+                    const flags = defaultsForMode("fast");
+                    setSkipReview(flags.skipReview);
+                    setPlanDocs(flags.planDocs);
+                    setPlanTests(flags.planTests);
+                  }}
                   className="h-3.5 w-3.5"
                 />
                 <span className="font-medium text-foreground">Fast</span>


### PR DESCRIPTION
## Summary
- Adds a shared `defaultsForMode()` helper so planner mode drives `skipReview` / `planDocs` / `planTests` consistently across UI (AddTaskForm, TaskSettings) and API (`POST /tasks`, roadmap import).
- Full mode → `{skipReview:false, planDocs:true, planTests:true}`; Fast mode → `{skipReview:true, planDocs:false, planTests:false}`; roadmap-generated tasks force `skipReview:true`.
- Centralizes the review-stage scope rule in `subagentQuery.ts`: when `profileMode === "review"` the review/security sidecars automatically get a system-prompt append restricting them to the current task's diff. No longer depends on editing each `.claude/agents/*.md` file.
- Fixes a latent AddTaskForm reset bug (reset set `plannerMode` to `full` while initial was `fast`).

## Test plan
- [x] `npm run ai:validate` passes (lint, build, tests, coverage)
- [x] New assertions: `POST /tasks` default matrix (fast/full/explicit-false), roadmap import `skipReview=true`
- [x] AddTaskForm: default fast flags, Full/Fast flip, reset-on-success returns to fast defaults
- [x] TaskSettings: mount preserves saved values, manual Full radio flips flags, PATCH payload carries them
- [x] Manual smoke check in UI (Kanban + task detail)