### PR TITLE
fix(api,web): make approve-done auto-commit reliable and observable (#75)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -360,13 +360,27 @@ The config is editable via the **Global Settings** dialog in the web UI (gear ic
 
 **`git`** — git-aware workflow settings:
 
-| Key                      | Default    | Description                        |
-| ------------------------ | ---------- | ---------------------------------- |
-| `enabled`                | `true`     | Use git-aware workflows            |
-| `base_branch`            | `main`     | Default branch for diff/review     |
-| `create_branches`        | `true`     | Auto-create feature branches       |
-| `branch_prefix`          | `feature/` | Prefix for branch names            |
-| `skip_push_after_commit` | `false`    | Skip push prompt after /aif-commit |
+| Key                      | Default    | Description                    |
+| ------------------------ | ---------- | ------------------------------ |
+| `enabled`                | `true`     | Use git-aware workflows        |
+| `base_branch`            | `main`     | Default branch for diff/review |
+| `create_branches`        | `true`     | Auto-create feature branches   |
+| `branch_prefix`          | `feature/` | Prefix for branch names        |
+| `skip_push_after_commit` | `false`    | Skip push after /aif-commit    |
+
+#### `skip_push_after_commit` semantics
+
+Controls whether the approve-done auto-commit flow (and any other `/aif-commit` run originating from the API) performs `git push` after creating the commit:
+
+- **`false` (default):** the runtime is instructed to stage everything with `git add -A`, create one conventional commit, and then run `git push` on the current branch.
+- **`true`:** the runtime creates the commit but MUST NOT push — useful when you want to review the commit locally or rely on an external push step.
+
+The setting is editable from the web UI (`Global Settings → Project config`). Because it's written into `.ai-factory/config.yaml`, it is read on every commit run — no restart required.
+
+The commit lifecycle is surfaced over WebSocket as `task:commit_started`, `task:commit_done`, and `task:commit_failed` events. The web UI subscribes to these and:
+
+- shows a toast for each event (`Creating commit…`, `Commit created`, `Commit failed: <error>`);
+- keeps the "Approve done" modal open with an inline spinner until the commit is acknowledged, so the user knows whether the commit actually ran.
 
 ### API Endpoints
 

--- a/packages/api/src/__tests__/commitGeneration.test.ts
+++ b/packages/api/src/__tests__/commitGeneration.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockRunApiRuntimeOneShot = vi.fn();
+const mockFindProjectById = vi.fn();
+const mockGetProjectConfig = vi.fn();
+
+vi.mock("../services/runtime.js", () => ({
+  runApiRuntimeOneShot: (...args: unknown[]) => mockRunApiRuntimeOneShot(...args),
+}));
+
+vi.mock("@aif/data", () => ({
+  findProjectById: (id: string) => mockFindProjectById(id),
+}));
+
+vi.mock("@aif/shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@aif/shared")>();
+  return {
+    ...actual,
+    getProjectConfig: (...args: unknown[]) => mockGetProjectConfig(...args),
+  };
+});
+
+const { runCommitQuery, buildCommitPrompt } = await import("../services/commitGeneration.js");
+
+function gitConfig(skipPush: boolean) {
+  return {
+    git: {
+      enabled: true,
+      base_branch: "main",
+      create_branches: true,
+      branch_prefix: "feature/",
+      skip_push_after_commit: skipPush,
+    },
+  };
+}
+
+describe("buildCommitPrompt", () => {
+  it("includes git add -A and push instruction when shouldPush=true", () => {
+    const prompt = buildCommitPrompt(true);
+    expect(prompt).toContain("git add -A");
+    expect(prompt).toContain("git push");
+    expect(prompt).not.toMatch(/Do NOT push/i);
+  });
+
+  it("includes git add -A and explicit no-push when shouldPush=false", () => {
+    const prompt = buildCommitPrompt(false);
+    expect(prompt).toContain("git add -A");
+    expect(prompt).toMatch(/Do NOT push/i);
+    expect(prompt).toContain("skip_push_after_commit");
+  });
+
+  it("forbids --no-verify, amend, and Co-Authored-By", () => {
+    const prompt = buildCommitPrompt(true);
+    expect(prompt).toContain("--no-verify");
+    expect(prompt).toContain("amend");
+    expect(prompt).toContain("Co-Authored-By");
+  });
+});
+
+describe("runCommitQuery", () => {
+  beforeEach(() => {
+    mockRunApiRuntimeOneShot.mockReset();
+    mockFindProjectById.mockReset();
+    mockGetProjectConfig.mockReset();
+    mockFindProjectById.mockReturnValue({ id: "p1", rootPath: "/tmp/p1" });
+  });
+
+  it("returns ok:false when project not found", async () => {
+    mockFindProjectById.mockReturnValue(undefined);
+    const res = await runCommitQuery({ projectId: "missing" });
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/Project not found/);
+    expect(mockRunApiRuntimeOneShot).not.toHaveBeenCalled();
+  });
+
+  it("sends push-enabled prompt when skip_push_after_commit=false", async () => {
+    mockGetProjectConfig.mockReturnValue(gitConfig(false));
+    mockRunApiRuntimeOneShot.mockResolvedValue({ result: { outputText: "ok" }, context: {} });
+    const res = await runCommitQuery({ projectId: "p1", taskId: "t1" });
+    expect(res.ok).toBe(true);
+    expect(mockRunApiRuntimeOneShot).toHaveBeenCalledTimes(1);
+    const callArg = mockRunApiRuntimeOneShot.mock.calls[0][0];
+    expect(callArg.workflowKind).toBe("commit");
+    expect(callArg.fallbackSlashCommand).toBe("/aif-commit");
+    expect(callArg.prompt).toContain("git add -A");
+    expect(callArg.prompt).toContain("git push");
+    expect(callArg.prompt).not.toMatch(/Do NOT push/i);
+  });
+
+  it("sends no-push prompt when skip_push_after_commit=true", async () => {
+    mockGetProjectConfig.mockReturnValue(gitConfig(true));
+    mockRunApiRuntimeOneShot.mockResolvedValue({ result: { outputText: "ok" }, context: {} });
+    const res = await runCommitQuery({ projectId: "p1" });
+    expect(res.ok).toBe(true);
+    const callArg = mockRunApiRuntimeOneShot.mock.calls[0][0];
+    expect(callArg.prompt).toMatch(/Do NOT push/i);
+    expect(callArg.prompt).not.toMatch(/\brun `git push`/);
+  });
+
+  it("returns ok:false with error message when runtime throws", async () => {
+    mockGetProjectConfig.mockReturnValue(gitConfig(false));
+    mockRunApiRuntimeOneShot.mockRejectedValue(new Error("boom"));
+    const res = await runCommitQuery({ projectId: "p1" });
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe("boom");
+  });
+});

--- a/packages/api/src/__tests__/tasks.test.ts
+++ b/packages/api/src/__tests__/tasks.test.ts
@@ -1415,7 +1415,49 @@ describe("tasks API", () => {
       expect(mockRunApiRuntimeOneShot).toHaveBeenCalled();
       const callArgs =
         mockRunApiRuntimeOneShot.mock.calls[mockRunApiRuntimeOneShot.mock.calls.length - 1][0];
-      expect(callArgs.prompt).toBe("/aif-commit");
+      expect(callArgs.workflowKind).toBe("commit");
+      expect(callArgs.fallbackSlashCommand).toBe("/aif-commit");
+      expect(callArgs.prompt).toContain("git add -A");
+
+      const { broadcast } = await import("../ws.js");
+      const types = (
+        broadcast as unknown as { mock: { calls: Array<[{ type: string }]> } }
+      ).mock.calls.map((c) => c[0].type);
+      expect(types).toContain("task:commit_started");
+      expect(types).toContain("task:commit_done");
+    });
+
+    it("should broadcast task:commit_failed when runtime throws", async () => {
+      const db = testDb.current;
+      insertTestProject(db);
+      db.insert(tasks)
+        .values({
+          id: "ev-commit-fail",
+          projectId: "test-project",
+          title: "Done commit fail",
+          status: "done",
+        })
+        .run();
+
+      mockRunApiRuntimeOneShot.mockClear();
+      mockRunApiRuntimeOneShot.mockRejectedValueOnce(new Error("runtime boom"));
+      const { broadcast } = await import("../ws.js");
+      (broadcast as unknown as { mockClear: () => void }).mockClear();
+
+      const res = await app.request("/tasks/ev-commit-fail/events", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ event: "approve_done", commitOnApprove: true }),
+      });
+      expect(res.status).toBe(200);
+      await new Promise((r) => setTimeout(r, 200));
+
+      const calls = (
+        broadcast as unknown as { mock: { calls: Array<[{ type: string; payload: unknown }]> } }
+      ).mock.calls;
+      const failed = calls.find((c) => c[0].type === "task:commit_failed");
+      expect(failed).toBeDefined();
+      expect((failed![0].payload as { error?: string }).error).toBe("runtime boom");
     });
 
     it("should not fire /aif-commit query when commitOnApprove is not set", async () => {

--- a/packages/api/src/routes/tasks.ts
+++ b/packages/api/src/routes/tasks.ts
@@ -436,10 +436,34 @@ tasksRouter.post("/:id/events", jsonValidator(taskEventSchema), async (c) => {
       broadcast({ type: "agent:wake", payload: { id: handled.task.id } });
     }
 
-    // Fire-and-forget: run /aif-commit when approved with commit checkbox
+    // Fire-and-forget: run /aif-commit when approved with commit checkbox.
+    // Broadcast lifecycle over WS so the UI can show a spinner/toast and the
+    // approve modal does not close without feedback.
     if (event === "approve_done" && commitOnApprove) {
-      const { runCommitQuery } = await import("../services/commitGeneration.js");
-      void runCommitQuery(handled.task.projectId);
+      const taskId = handled.task.id;
+      const projectId = handled.task.projectId;
+      log.info({ taskId, projectId }, "Approve-done commit flow started");
+      broadcast({
+        type: "task:commit_started",
+        payload: { taskId, projectId, status: "started" },
+      });
+      void (async () => {
+        const { runCommitQuery } = await import("../services/commitGeneration.js");
+        const result = await runCommitQuery({ projectId, taskId });
+        if (result.ok) {
+          log.info({ taskId, projectId }, "Approve-done commit flow succeeded");
+          broadcast({
+            type: "task:commit_done",
+            payload: { taskId, projectId, status: "done" },
+          });
+        } else {
+          log.error({ taskId, projectId, error: result.error }, "Approve-done commit flow failed");
+          broadcast({
+            type: "task:commit_failed",
+            payload: { taskId, projectId, status: "failed", error: result.error },
+          });
+        }
+      })();
     }
 
     return c.json(toTaskRouteResponse(handled.task));

--- a/packages/api/src/services/commitGeneration.ts
+++ b/packages/api/src/services/commitGeneration.ts
@@ -1,4 +1,4 @@
-import { logger } from "@aif/shared";
+import { getProjectConfig, logger } from "@aif/shared";
 import { findProjectById } from "@aif/data";
 import { UsageSource } from "@aif/runtime";
 import { runApiRuntimeOneShot } from "./runtime.js";
@@ -10,33 +10,103 @@ const PROJECT_SCOPE_APPEND =
   "Do not inspect or modify files in the orchestrator monorepo or in parent/sibling directories " +
   "unless the user explicitly asks for that path. Avoid broad discovery outside the current project root.";
 
+export interface RunCommitQueryResult {
+  ok: boolean;
+  error?: string;
+}
+
+export interface RunCommitQueryInput {
+  projectId: string;
+  taskId?: string | null;
+}
+
 /**
- * Fire-and-forget: run `/aif-commit` via shared runtime in the project root.
- * Logs errors but never throws — caller should not await or depend on success.
+ * Build the explicit instruction prompt for the commit run.
+ *
+ * Background: the previous implementation sent the bare string `"/aif-commit"`
+ * as the prompt, relying on Claude Code to resolve it as a slash command /
+ * skill. In `-p` (print) mode that resolution is unreliable — the model would
+ * often respond with text and never actually run `git commit`. This prompt
+ * spells the full procedure out in English so ANY runtime adapter can execute
+ * it. We still pass the slash command as a fallback hint for adapters that DO
+ * support skill resolution.
  */
-export async function runCommitQuery(projectId: string): Promise<void> {
+export function buildCommitPrompt(shouldPush: boolean): string {
+  const pushLine = shouldPush
+    ? "5. After committing, run `git push` on the current branch. Do not force-push."
+    : "5. Do NOT push. The project is configured with `git.skip_push_after_commit: true` — commit only.";
+
+  return [
+    "You are running the aif-commit workflow. Follow these steps exactly:",
+    "",
+    "1. Run `git status` to see the current working tree.",
+    "2. Stage ALL changes, including untracked files: run `git add -A` from the project root.",
+    "3. Analyze the staged diff (`git diff --cached`) and draft ONE conventional commit message (feat/fix/chore/docs/refactor/test/perf, optional scope, short subject, body if helpful).",
+    "4. Create the commit with `git commit -m ...`. Create exactly one commit. Do not amend.",
+    pushLine,
+    "",
+    "Hard rules:",
+    "- Never skip git hooks (no --no-verify).",
+    "- Never rewrite history (no rebase, no reset --hard, no amend).",
+    "- Never add the `Co-Authored-By` trailer.",
+    "- If there are no changes to commit after `git add -A`, report that and stop — do NOT create an empty commit.",
+  ].join("\n");
+}
+
+/**
+ * Fire-and-forget entry point: run the commit workflow via the shared runtime
+ * in the project root. Returns a structured result so the caller can broadcast
+ * success/failure over WS. Never throws.
+ */
+export async function runCommitQuery(input: RunCommitQueryInput): Promise<RunCommitQueryResult> {
+  const { projectId, taskId = null } = input;
   const project = findProjectById(projectId);
   if (!project) {
-    log.error({ projectId }, "Project not found for commit generation");
-    return;
+    const msg = `Project not found: ${projectId}`;
+    log.error({ projectId }, msg);
+    return { ok: false, error: msg };
   }
 
+  const { git } = getProjectConfig(project.rootPath);
+  const shouldPush = git.enabled && !git.skip_push_after_commit;
+  const prompt = buildCommitPrompt(shouldPush);
+
   log.info(
-    { projectId, projectRoot: project.rootPath },
-    "Starting /aif-commit via runtime adapter",
+    {
+      projectId,
+      taskId,
+      projectRoot: project.rootPath,
+      skipPushAfterCommit: git.skip_push_after_commit,
+      shouldPush,
+      promptLength: prompt.length,
+    },
+    "Starting commit runtime run",
   );
 
   try {
-    await runApiRuntimeOneShot({
+    const { result } = await runApiRuntimeOneShot({
       projectId,
       projectRoot: project.rootPath,
-      prompt: "/aif-commit",
+      taskId,
+      prompt,
       workflowKind: "commit",
+      fallbackSlashCommand: "/aif-commit",
       systemPromptAppend: PROJECT_SCOPE_APPEND,
       usageContext: { source: UsageSource.COMMIT },
     });
-    log.info({ projectId }, "/aif-commit completed successfully");
+    log.info(
+      {
+        projectId,
+        taskId,
+        shouldPush,
+        outputPreview: result.outputText?.slice(0, 200) ?? "",
+      },
+      "Commit runtime run completed successfully",
+    );
+    return { ok: true };
   } catch (err) {
-    log.error({ err, projectId }, "/aif-commit runtime error");
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err, projectId, taskId }, "Commit runtime error");
+    return { ok: false, error: message };
   }
 }

--- a/packages/api/src/services/runtime.ts
+++ b/packages/api/src/services/runtime.ts
@@ -247,6 +247,13 @@ export async function runApiRuntimeOneShot(input: {
   includePartialMessages?: boolean;
   maxTurns?: number;
   /**
+   * Hint for adapters that support slash-command / skill resolution (e.g.
+   * Claude Code CLI). Passed through to the workflow spec so compatible
+   * adapters can invoke the named skill instead of relying on the prompt
+   * text alone. Adapters that do not support it ignore this field.
+   */
+  fallbackSlashCommand?: string;
+  /**
    * Scope metadata for usage tracking. Callers must pick one `UsageSource`
    * value identifying the logical flow (fast-fix, commit, roadmap-*, ...).
    * `projectId` is always included automatically; `taskId` is added when the
@@ -264,6 +271,7 @@ export async function runApiRuntimeOneShot(input: {
     requiredCapabilities: input.requiredCapabilities ?? [],
     sessionReusePolicy: "never",
     systemPromptAppend: input.systemPromptAppend,
+    fallbackSlashCommand: input.fallbackSlashCommand,
   });
 
   const context = await resolveApiRuntimeContext({

--- a/packages/shared/src/__tests__/projectConfig.test.ts
+++ b/packages/shared/src/__tests__/projectConfig.test.ts
@@ -80,6 +80,48 @@ describe("getProjectConfig", () => {
     expect(config.workflow.verify_mode).toBe("normal");
   });
 
+  it("returns default git section when config.yaml does not exist", () => {
+    const config = getProjectConfig(projectRoot);
+    expect(config.git.enabled).toBe(true);
+    expect(config.git.base_branch).toBe("main");
+    expect(config.git.create_branches).toBe(true);
+    expect(config.git.branch_prefix).toBe("feature/");
+    expect(config.git.skip_push_after_commit).toBe(false);
+  });
+
+  it("overrides git.skip_push_after_commit=true from config.yaml", () => {
+    writeFileSync(
+      join(projectRoot, ".ai-factory", "config.yaml"),
+      "git:\n  skip_push_after_commit: true\n",
+    );
+    const config = getProjectConfig(projectRoot);
+    expect(config.git.skip_push_after_commit).toBe(true);
+    // Other git defaults preserved
+    expect(config.git.enabled).toBe(true);
+    expect(config.git.base_branch).toBe("main");
+  });
+
+  it("overrides full git section from config.yaml", () => {
+    writeFileSync(
+      join(projectRoot, ".ai-factory", "config.yaml"),
+      [
+        "git:",
+        "  enabled: false",
+        "  base_branch: develop",
+        "  create_branches: false",
+        "  branch_prefix: feat/",
+        "  skip_push_after_commit: true",
+        "",
+      ].join("\n"),
+    );
+    const config = getProjectConfig(projectRoot);
+    expect(config.git.enabled).toBe(false);
+    expect(config.git.base_branch).toBe("develop");
+    expect(config.git.create_branches).toBe(false);
+    expect(config.git.branch_prefix).toBe("feat/");
+    expect(config.git.skip_push_after_commit).toBe(true);
+  });
+
   it("clearProjectConfigCache invalidates cache", () => {
     writeFileSync(join(projectRoot, ".ai-factory", "config.yaml"), "paths:\n  plan: v1/PLAN.md\n");
     const first = getProjectConfig(projectRoot);

--- a/packages/shared/src/browser.ts
+++ b/packages/shared/src/browser.ts
@@ -25,6 +25,7 @@ export {
   type WsEvent,
   type RoadmapCompletePayload,
   type RoadmapErrorPayload,
+  type TaskCommitPayload,
   type ChatMessage,
   type ChatMessageAttachment,
   type ChatAttachment,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -133,6 +133,7 @@ export {
   type AifProjectConfig,
   type AifProjectPaths,
   type AifProjectWorkflow,
+  type AifProjectGit,
 } from "./projectConfig.js";
 
 // Telegram notifications

--- a/packages/shared/src/projectConfig.ts
+++ b/packages/shared/src/projectConfig.ts
@@ -29,9 +29,23 @@ export interface AifProjectWorkflow {
   verify_mode: "strict" | "normal" | "lenient";
 }
 
+export interface AifProjectGit {
+  enabled: boolean;
+  base_branch: string;
+  create_branches: boolean;
+  branch_prefix: string;
+  /**
+   * When true, `/aif-commit` (and approve-done auto-commit flow) must create a
+   * commit but NOT push. When false (default), also push to the current branch
+   * after committing. Surfaced in the web settings UI.
+   */
+  skip_push_after_commit: boolean;
+}
+
 export interface AifProjectConfig {
   paths: AifProjectPaths;
   workflow: AifProjectWorkflow;
+  git: AifProjectGit;
 }
 
 const DEFAULT_PATHS: AifProjectPaths = {
@@ -61,6 +75,14 @@ const DEFAULT_WORKFLOW: AifProjectWorkflow = {
   verify_mode: "normal",
 };
 
+const DEFAULT_GIT: AifProjectGit = {
+  enabled: true,
+  base_branch: "main",
+  create_branches: true,
+  branch_prefix: "feature/",
+  skip_push_after_commit: false,
+};
+
 /** Cached configs keyed by projectRoot to avoid re-reading on every call */
 const configCache = new Map<string, { config: AifProjectConfig; mtimeMs: number }>();
 
@@ -73,7 +95,11 @@ export function getProjectConfig(projectRoot: string): AifProjectConfig {
   const configPath = join(projectRoot, ".ai-factory", "config.yaml");
 
   if (!existsSync(configPath)) {
-    return { paths: { ...DEFAULT_PATHS }, workflow: { ...DEFAULT_WORKFLOW } };
+    return {
+      paths: { ...DEFAULT_PATHS },
+      workflow: { ...DEFAULT_WORKFLOW },
+      git: { ...DEFAULT_GIT },
+    };
   }
 
   const stat = statSync(configPath);
@@ -87,10 +113,12 @@ export function getProjectConfig(projectRoot: string): AifProjectConfig {
 
   const yamlPaths = (parsed?.paths ?? {}) as Partial<AifProjectPaths>;
   const yamlWorkflow = (parsed?.workflow ?? {}) as Partial<AifProjectWorkflow>;
+  const yamlGit = (parsed?.git ?? {}) as Partial<AifProjectGit>;
 
   const config: AifProjectConfig = {
     paths: { ...DEFAULT_PATHS, ...yamlPaths },
     workflow: { ...DEFAULT_WORKFLOW, ...yamlWorkflow },
+    git: { ...DEFAULT_GIT, ...yamlGit },
   };
 
   configCache.set(projectRoot, { config, mtimeMs: stat.mtimeMs });

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -258,7 +258,10 @@ export type WsEventType =
   | "task:activity"
   | "task:scheduled_fired"
   | "project:auto_queue_mode_changed"
-  | "project:auto_queue_advanced";
+  | "project:auto_queue_advanced"
+  | "task:commit_started"
+  | "task:commit_done"
+  | "task:commit_failed";
 
 export interface RoadmapCompletePayload {
   projectId: string;
@@ -276,6 +279,18 @@ export interface RoadmapErrorPayload {
   code: string;
 }
 
+/**
+ * Emitted when the "create commit" checkbox is used on approve-done, to
+ * surface the lifecycle of the fire-and-forget `/aif-commit` run to the UI.
+ * `status` is redundant with `type` but makes the payload self-describing.
+ */
+export interface TaskCommitPayload {
+  taskId: string;
+  projectId: string;
+  status: "started" | "done" | "failed";
+  error?: string;
+}
+
 export interface WsEvent {
   type: WsEventType;
   payload:
@@ -287,7 +302,8 @@ export interface WsEvent {
     | ChatStreamTokenPayload
     | ChatDonePayload
     | ChatErrorPayload
-    | ChatSession;
+    | ChatSession
+    | TaskCommitPayload;
 }
 
 export const RuntimeTransport = {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -5,6 +5,7 @@ import { Board } from "./components/kanban/Board";
 import { TaskDetail } from "./components/task/TaskDetail";
 import { CommandPalette } from "./components/layout/CommandPalette";
 import { useWebSocket } from "./hooks/useWebSocket";
+import { useCommitToasts } from "./hooks/useCommitToasts";
 import { useProjects } from "./hooks/useProjects";
 import { useTasks } from "./hooks/useTasks";
 import { useTheme } from "./hooks/useTheme";
@@ -30,6 +31,7 @@ const queryClient = new QueryClient({
 
 function AppContent() {
   useWebSocket();
+  useCommitToasts();
   const { theme, toggleTheme } = useTheme();
   const { data: projects } = useProjects();
   const [project, setProject] = useState<Project | null>(null);

--- a/packages/web/src/__tests__/TaskDetail.test.tsx
+++ b/packages/web/src/__tests__/TaskDetail.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { Task } from "@aif/shared/browser";
 
@@ -334,21 +334,72 @@ describe("TaskDetail", () => {
     expect(screen.getByText("MANUAL REVIEW")).toBeDefined();
   });
 
-  it("should confirm approve_done and send deletePlanFile=false by default", () => {
+  it("confirms approve_done without commit closes the modal immediately", () => {
     const onClose = vi.fn();
     render(<TaskDetail taskId="detail-done" onClose={onClose} />, { wrapper: Wrapper });
 
     fireEvent.click(screen.getByRole("button", { name: "Approve" }));
     expect(screen.getByText("Approve done task?")).toBeDefined();
+
+    // Uncheck the commit box so the modal closes synchronously (legacy path).
+    const checkboxes = screen.getAllByRole("checkbox");
+    fireEvent.click(checkboxes[1]); // commit checkbox
     fireEvent.click(screen.getAllByRole("button", { name: "Approve" })[1]);
 
     expect(mutateTaskEvent).toHaveBeenCalledWith({
       id: "detail-done",
       event: "approve_done",
       deletePlanFile: false,
-      commitOnApprove: true,
+      commitOnApprove: false,
     });
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it("keeps modal open while commit is pending and closes on WS commit_done", () => {
+    const onClose = vi.fn();
+    render(<TaskDetail taskId="detail-done" onClose={onClose} />, { wrapper: Wrapper });
+
+    fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+    fireEvent.click(screen.getAllByRole("button", { name: "Approve" })[1]);
+
+    // Mutation fires with commit=true (default).
+    expect(mutateTaskEvent).toHaveBeenCalledWith({
+      id: "detail-done",
+      event: "approve_done",
+      deletePlanFile: false,
+      commitOnApprove: true,
+    });
+    // Modal stays open; onClose not called yet.
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByText(/Running \/aif-commit/)).toBeDefined();
+
+    // Simulate WS ack for this task → modal closes.
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("task:commit_done", {
+          detail: { taskId: "detail-done", projectId: "p1", status: "done" },
+        }),
+      );
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("keeps modal open on WS commit_failed so user can see the error", () => {
+    const onClose = vi.fn();
+    render(<TaskDetail taskId="detail-done" onClose={onClose} />, { wrapper: Wrapper });
+
+    fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+    fireEvent.click(screen.getAllByRole("button", { name: "Approve" })[1]);
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("task:commit_failed", {
+          detail: { taskId: "detail-done", projectId: "p1", status: "failed", error: "nope" },
+        }),
+      );
+    });
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.queryByText(/Running \/aif-commit/)).toBeNull();
   });
 
   it("should send deletePlanFile=true when checkbox is selected in approve confirmation", () => {
@@ -359,13 +410,14 @@ describe("TaskDetail", () => {
     expect(screen.getByText("Delete plan file (FIX_PLAN.md)")).toBeDefined();
     const checkboxes = screen.getAllByRole("checkbox");
     fireEvent.click(checkboxes[0]); // delete plan file checkbox
+    fireEvent.click(checkboxes[1]); // commit checkbox (uncheck) to close modal synchronously
     fireEvent.click(screen.getAllByRole("button", { name: "Approve" })[1]);
 
     expect(mutateTaskEvent).toHaveBeenCalledWith({
       id: "detail-done-fix",
       event: "approve_done",
       deletePlanFile: true,
-      commitOnApprove: true,
+      commitOnApprove: false,
     });
     expect(onClose).toHaveBeenCalled();
   });

--- a/packages/web/src/components/task/TaskDetail.tsx
+++ b/packages/web/src/components/task/TaskDetail.tsx
@@ -18,6 +18,7 @@ import { Section } from "./Section";
 import { useTaskDetailActions } from "./useTaskDetailActions";
 import { AlertBox } from "@/components/ui/alert-box";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Spinner } from "@/components/ui/spinner";
 
 interface TaskDetailProps {
   taskId: string | null;
@@ -254,7 +255,12 @@ export function TaskDetail({ taskId, onClose }: TaskDetailProps) {
       </Dialog>
       <Dialog
         open={actions.showApproveDoneConfirm}
-        onOpenChange={actions.setShowApproveDoneConfirm}
+        onOpenChange={(next) => {
+          // Block dismissing the modal while a commit is in flight so the
+          // user waits for the WS ack (commit_done / commit_failed).
+          if (!next && actions.commitPending) return;
+          actions.setShowApproveDoneConfirm(next);
+        }}
       >
         <DialogContent>
           <DialogHeader>
@@ -267,6 +273,7 @@ export function TaskDetail({ taskId, onClose }: TaskDetailProps) {
             <Checkbox
               checked={actions.deletePlanOnApprove}
               onChange={(event) => actions.setDeletePlanOnApprove(event.target.checked)}
+              disabled={actions.commitPending}
             />
             Delete plan file ({task?.isFix ? "FIX_PLAN.md" : "PLAN.md"})
           </label>
@@ -274,13 +281,21 @@ export function TaskDetail({ taskId, onClose }: TaskDetailProps) {
             <Checkbox
               checked={actions.commitOnApprove}
               onChange={(event) => actions.setCommitOnApprove(event.target.checked)}
+              disabled={actions.commitPending}
             />
             Create commit (/aif-commit)
           </label>
+          {actions.commitPending && (
+            <div className="mt-3 flex items-center gap-2 text-xs text-muted-foreground">
+              <Spinner size="sm" />
+              <span>Running /aif-commit… waiting for server ack.</span>
+            </div>
+          )}
           <div className="mt-4 flex justify-end gap-2">
             <Button
               variant="ghost"
               size="sm"
+              disabled={actions.commitPending}
               onClick={() => {
                 actions.setShowApproveDoneConfirm(false);
                 actions.setDeletePlanOnApprove(false);
@@ -289,8 +304,15 @@ export function TaskDetail({ taskId, onClose }: TaskDetailProps) {
             >
               Cancel
             </Button>
-            <Button size="sm" onClick={actions.handleApproveDone}>
-              Approve
+            <Button size="sm" onClick={actions.handleApproveDone} disabled={actions.commitPending}>
+              {actions.commitPending ? (
+                <span className="flex items-center gap-2">
+                  <Spinner size="sm" />
+                  Committing…
+                </span>
+              ) : (
+                "Approve"
+              )}
             </Button>
           </div>
         </DialogContent>

--- a/packages/web/src/components/task/useTaskDetailActions.ts
+++ b/packages/web/src/components/task/useTaskDetailActions.ts
@@ -259,6 +259,40 @@ export function useTaskDetailActions(task: Task | undefined, onClose: () => void
   const [showApproveDoneConfirm, setShowApproveDoneConfirm] = useState(false);
   const [deletePlanOnApprove, setDeletePlanOnApprove] = useState(false);
   const [commitOnApprove, setCommitOnApprove] = useState(true);
+  // When the user asks for a commit on approve, the server runs `/aif-commit`
+  // as a fire-and-forget background task and broadcasts the result over WS.
+  // We keep the modal open with a spinner until the WS ack arrives, so the
+  // user sees whether the commit actually happened (issue #75).
+  const [commitPending, setCommitPending] = useState(false);
+
+  useEffect(() => {
+    if (!commitPending || !task) return;
+    const matchesTask = (e: Event): boolean => {
+      const detail = (e as CustomEvent<{ taskId?: string }>).detail;
+      return detail?.taskId === task.id;
+    };
+    const onDone = (e: Event) => {
+      if (!matchesTask(e)) return;
+      console.debug("[approve-done] commit done for", task.id);
+      setCommitPending(false);
+      setShowApproveDoneConfirm(false);
+      setDeletePlanOnApprove(false);
+      setCommitOnApprove(true);
+      onClose();
+    };
+    const onFailed = (e: Event) => {
+      if (!matchesTask(e)) return;
+      console.debug("[approve-done] commit failed for", task.id);
+      // Keep modal open so the user sees the error toast and can retry.
+      setCommitPending(false);
+    };
+    window.addEventListener("task:commit_done", onDone);
+    window.addEventListener("task:commit_failed", onFailed);
+    return () => {
+      window.removeEventListener("task:commit_done", onDone);
+      window.removeEventListener("task:commit_failed", onFailed);
+    };
+  }, [commitPending, task, onClose]);
 
   const handleApproveDone = () => {
     if (!task) return;
@@ -268,6 +302,12 @@ export function useTaskDetailActions(task: Task | undefined, onClose: () => void
       deletePlanFile: deletePlanOnApprove,
       commitOnApprove,
     });
+    if (commitOnApprove) {
+      // Wait for WS ack — do NOT close the modal yet.
+      console.debug("[approve-done] awaiting commit WS ack for", task.id);
+      setCommitPending(true);
+      return;
+    }
     setShowApproveDoneConfirm(false);
     setDeletePlanOnApprove(false);
     setCommitOnApprove(true);
@@ -347,6 +387,7 @@ export function useTaskDetailActions(task: Task | undefined, onClose: () => void
     setDeletePlanOnApprove,
     commitOnApprove,
     setCommitOnApprove,
+    commitPending,
     handleApproveDone,
     // action buttons
     handleActionClick,

--- a/packages/web/src/hooks/useCommitToasts.ts
+++ b/packages/web/src/hooks/useCommitToasts.ts
@@ -1,0 +1,62 @@
+import { useEffect, useRef } from "react";
+import { useToast } from "@/components/ui/toast";
+import type { TaskCommitPayload } from "@aif/shared/browser";
+
+// Dedupe window for (taskId, type) pairs. StrictMode double-mount, transient
+// dual WS connections during reconnect, and server re-broadcasts can all
+// deliver the same commit event more than once. 2s is long enough to swallow
+// those, short enough that a genuine repeat (e.g. second manual approve) still
+// produces a fresh toast.
+const DEDUPE_WINDOW_MS = 2000;
+
+/**
+ * Global listener for `task:commit_*` WS events. Mounts once (in <App/>) and
+ * converts the event stream into toasts so the user always gets feedback on
+ * the approve-done auto-commit flow — regardless of whether the task detail
+ * modal is open.
+ */
+export function useCommitToasts() {
+  const { toast } = useToast();
+  const lastSeenRef = useRef<Map<string, number>>(new Map());
+
+  useEffect(() => {
+    const seen = lastSeenRef.current;
+    const shouldSkip = (type: string, taskId: string | undefined): boolean => {
+      const key = `${type}:${taskId ?? "unknown"}`;
+      const now = Date.now();
+      const prev = seen.get(key);
+      if (prev && now - prev < DEDUPE_WINDOW_MS) return true;
+      seen.set(key, now);
+      return false;
+    };
+
+    const onStarted = (e: Event) => {
+      const detail = (e as CustomEvent<TaskCommitPayload>).detail;
+      if (shouldSkip("started", detail?.taskId)) return;
+      console.debug("[commit-toast] started", detail);
+      toast("Creating commit…", "info", 6000);
+    };
+    const onDone = (e: Event) => {
+      const detail = (e as CustomEvent<TaskCommitPayload>).detail;
+      if (shouldSkip("done", detail?.taskId)) return;
+      console.debug("[commit-toast] done", detail);
+      toast("Commit created", "success", 4000);
+    };
+    const onFailed = (e: Event) => {
+      const detail = (e as CustomEvent<TaskCommitPayload>).detail;
+      if (shouldSkip("failed", detail?.taskId)) return;
+      console.debug("[commit-toast] failed", detail);
+      toast(`Commit failed: ${detail?.error ?? "unknown error"}`, "error", 8000);
+    };
+
+    window.addEventListener("task:commit_started", onStarted);
+    window.addEventListener("task:commit_done", onDone);
+    window.addEventListener("task:commit_failed", onFailed);
+
+    return () => {
+      window.removeEventListener("task:commit_started", onStarted);
+      window.removeEventListener("task:commit_done", onDone);
+      window.removeEventListener("task:commit_failed", onFailed);
+    };
+  }, [toast]);
+}

--- a/packages/web/src/hooks/useWebSocket.ts
+++ b/packages/web/src/hooks/useWebSocket.ts
@@ -118,6 +118,18 @@ export function useWebSocket() {
         return;
       }
 
+      // Commit lifecycle (approve-done auto-commit): surface to any listener
+      // via custom DOM events; global toast + modal spinner subscribe to these.
+      if (
+        raw.type === "task:commit_started" ||
+        raw.type === "task:commit_done" ||
+        raw.type === "task:commit_failed"
+      ) {
+        console.debug("[ws] commit event:", raw.type, raw.payload);
+        window.dispatchEvent(new CustomEvent(raw.type, { detail: raw.payload }));
+        return;
+      }
+
       const data = raw as unknown as WsEvent;
 
       if (data.type === "task:moved" && isTaskPayload(data.payload)) {


### PR DESCRIPTION
## Summary

Fixes #75 — approving a Done task with the "create commit" checkbox transitioned to Verified but no commit was actually created, and the modal closed without any feedback.

- Replace the bare `"/aif-commit"` prompt sent to the runtime with an explicit English instruction: `git add -A` (incl. untracked), one conventional commit, and `git push` unless `git.skip_push_after_commit=true`. Slash command kept as a fallback hint for adapters that resolve skills.
- Parse the `git` section (incl. `skip_push_after_commit`) in `@aif/shared` `projectConfig` so the API honors the web settings toggle. Default when no config: `false` (i.e. push enabled).
- Add WS events `task:commit_started | commit_done | commit_failed` + `TaskCommitPayload`. The tasks route broadcasts them around the fire-and-forget commit run.
- Web: global `useCommitToasts` hook surfaces lifecycle as toasts; the approve-done modal now stays open with a spinner until the WS ack arrives (closes on `commit_done`, stays open on `commit_failed` so the error toast is visible).
- Dedupe commit toasts inside a 2s window to absorb React StrictMode / WS reconnect / server re-broadcast duplicates.

## Test plan

- [x] `npm run ai:validate` (lint + tests + build) — all 7 packages green
- [x] New tests: shared `projectConfig` git section (3), api `commitGeneration` (7), api tasks route WS broadcast started/done/failed (2), web TaskDetail modal pending/done/failed (3)
- [ ] Manual: in a project with `skip_push_after_commit=false`, approve a Done task with the checkbox → toast "Creating commit…", modal stays open with spinner, then "Commit created" toast and modal closes; verify a real commit + push landed in the project repo
- [ ] Manual: flip `skip_push_after_commit=true` in web settings → repeat → commit lands, no push
- [ ] Manual: simulate failure (e.g. dirty submodule) → "Commit failed: …" toast, modal stays open