### PR TITLE
feat(chat): stop button to interrupt in-flight chat runs

### DIFF
--- a/packages/api/src/__tests__/chat.test.ts
+++ b/packages/api/src/__tests__/chat.test.ts
@@ -681,4 +681,50 @@ describe("chat API", () => {
       ),
     ).toBe(true);
   });
+
+  it("persists the runtime session link on abort so the next turn can resume", async () => {
+    mockAdapterRun.mockImplementation(async (input: RuntimeRunInput) => {
+      // Runtime emits the session id before the abort fires.
+      input.execution?.onEvent?.({
+        type: "system:init",
+        timestamp: new Date().toISOString(),
+        data: { sessionId: "runtime-session-preserved" },
+      });
+      await new Promise<void>((_resolve, reject) => {
+        input.execution?.abortController?.signal.addEventListener("abort", () => {
+          const err = new Error("The operation was aborted");
+          (err as Error & { name: string }).name = "AbortError";
+          reject(err);
+        });
+      });
+      return { outputText: "", sessionId: "runtime-session-preserved" };
+    });
+
+    mockUpdateChatSession.mockClear();
+
+    const conversationId = crypto.randomUUID();
+    const chatPromise = app.request("/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        projectId: "project-1",
+        message: "first turn",
+        clientId: "client-1",
+        conversationId,
+      }),
+    });
+
+    await new Promise((r) => setTimeout(r, 20));
+    await app.request(`/chat/${conversationId}/abort`, { method: "POST" });
+    const chatRes = await chatPromise;
+    expect(chatRes.status).toBe(409);
+
+    expect(
+      mockUpdateChatSession.mock.calls.some(
+        (call) =>
+          (call[1] as { runtimeSessionId?: string } | null)?.runtimeSessionId ===
+          "runtime-session-preserved",
+      ),
+    ).toBe(true);
+  });
 });

--- a/packages/api/src/__tests__/chat.test.ts
+++ b/packages/api/src/__tests__/chat.test.ts
@@ -586,4 +586,53 @@ describe("chat API", () => {
       }),
     );
   });
+
+  it("returns 404 when aborting an unknown conversation", async () => {
+    const res = await app.request("/chat/unknown-conversation-id/abort", { method: "POST" });
+    expect(res.status).toBe(404);
+  });
+
+  it("aborts an in-flight chat run and surfaces chat:error with code 'aborted'", async () => {
+    let capturedController: AbortController | undefined;
+    mockAdapterRun.mockImplementation(async (input: RuntimeRunInput) => {
+      capturedController = input.execution?.abortController;
+      // Simulate adapter honoring the AbortController by throwing AbortError
+      await new Promise<void>((_resolve, reject) => {
+        capturedController?.signal.addEventListener("abort", () => {
+          const err = new Error("The operation was aborted");
+          (err as Error & { name: string }).name = "AbortError";
+          reject(err);
+        });
+      });
+      return { outputText: "", sessionId: "runtime-session-1" };
+    });
+
+    const conversationId = crypto.randomUUID();
+    const chatPromise = app.request("/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        projectId: "project-1",
+        message: "long task",
+        clientId: "client-1",
+        conversationId,
+      }),
+    });
+
+    // Give the route a tick to register the AbortController before we abort.
+    await new Promise((r) => setTimeout(r, 20));
+    const abortRes = await app.request(`/chat/${conversationId}/abort`, { method: "POST" });
+    expect(abortRes.status).toBe(204);
+
+    const chatRes = await chatPromise;
+    expect(chatRes.status).toBe(409);
+    const body = await chatRes.json();
+    expect(body.code).toBe("aborted");
+
+    expect(
+      mockSendToClient.mock.calls.some(
+        (call) => call[1]?.type === "chat:error" && call[1].payload?.code === "aborted",
+      ),
+    ).toBe(true);
+  });
 });

--- a/packages/api/src/__tests__/chat.test.ts
+++ b/packages/api/src/__tests__/chat.test.ts
@@ -628,10 +628,56 @@ describe("chat API", () => {
     expect(chatRes.status).toBe(409);
     const body = await chatRes.json();
     expect(body.code).toBe("aborted");
+    // The response must expose the server-resolved sessionId so the client
+    // can promote a fresh "new chat" that was stopped before the happy-path
+    // onSessionResolved handshake.
+    expect(typeof body.sessionId === "string" || body.sessionId === null).toBe(true);
+    expect(body.conversationId).toBe(conversationId);
 
     expect(
       mockSendToClient.mock.calls.some(
         (call) => call[1]?.type === "chat:error" && call[1].payload?.code === "aborted",
+      ),
+    ).toBe(true);
+  });
+
+  it("persists partial streamed output when a run is aborted mid-stream", async () => {
+    mockAdapterRun.mockImplementation(async (input: RuntimeRunInput) => {
+      input.execution?.onEvent?.({
+        type: "stream:text",
+        message: "Partial reply",
+        timestamp: new Date().toISOString(),
+      });
+      await new Promise<void>((_resolve, reject) => {
+        input.execution?.abortController?.signal.addEventListener("abort", () => {
+          const err = new Error("The operation was aborted");
+          (err as Error & { name: string }).name = "AbortError";
+          reject(err);
+        });
+      });
+      return { outputText: "", sessionId: "runtime-session-2" };
+    });
+
+    const conversationId = crypto.randomUUID();
+    const chatPromise = app.request("/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        projectId: "project-1",
+        message: "long task",
+        clientId: "client-1",
+        conversationId,
+      }),
+    });
+
+    await new Promise((r) => setTimeout(r, 20));
+    await app.request(`/chat/${conversationId}/abort`, { method: "POST" });
+    const chatRes = await chatPromise;
+    expect(chatRes.status).toBe(409);
+
+    expect(
+      mockCreateChatMessage.mock.calls.some(
+        (call) => call[0]?.role === "assistant" && call[0].content === "Partial reply",
       ),
     ).toBe(true);
   });

--- a/packages/api/src/__tests__/chat.test.ts
+++ b/packages/api/src/__tests__/chat.test.ts
@@ -680,6 +680,60 @@ describe("chat API", () => {
         (call) => call[0]?.role === "assistant" && call[0].content === "Partial reply",
       ),
     ).toBe(true);
+
+    // The 409 body must surface the partial reply so no-WS clients can render
+    // what was saved server-side without a round-trip to load messages.
+    const body = await chatRes.json();
+    expect(body.assistantMessage).toBe("Partial reply");
+  });
+
+  it("returns saved attachments in the 409 abort response", async () => {
+    mockPersistAttachments.mockResolvedValue([
+      {
+        name: "spec.md",
+        mimeType: "text/markdown",
+        size: 10,
+        path: "storage/chat/s1/spec.md",
+      },
+    ]);
+    mockAdapterRun.mockImplementation(async (input: RuntimeRunInput) => {
+      await new Promise<void>((_resolve, reject) => {
+        input.execution?.abortController?.signal.addEventListener("abort", () => {
+          const err = new Error("The operation was aborted");
+          (err as Error & { name: string }).name = "AbortError";
+          reject(err);
+        });
+      });
+      return { outputText: "", sessionId: "runtime-session-3" };
+    });
+
+    const conversationId = crypto.randomUUID();
+    const chatPromise = app.request("/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        projectId: "project-1",
+        message: "review this",
+        clientId: "client-1",
+        conversationId,
+        attachments: [{ name: "spec.md", mimeType: "text/markdown", size: 10, content: "hi" }],
+      }),
+    });
+
+    await new Promise((r) => setTimeout(r, 20));
+    await app.request(`/chat/${conversationId}/abort`, { method: "POST" });
+    const chatRes = await chatPromise;
+    expect(chatRes.status).toBe(409);
+
+    const body = await chatRes.json();
+    expect(body.attachments).toEqual([
+      {
+        name: "spec.md",
+        mimeType: "text/markdown",
+        size: 10,
+        path: "storage/chat/s1/spec.md",
+      },
+    ]);
   });
 
   it("persists the runtime session link on abort so the next turn can resume", async () => {

--- a/packages/api/src/__tests__/chat.test.ts
+++ b/packages/api/src/__tests__/chat.test.ts
@@ -596,6 +596,11 @@ describe("chat API", () => {
     let capturedController: AbortController | undefined;
     mockAdapterRun.mockImplementation(async (input: RuntimeRunInput) => {
       capturedController = input.execution?.abortController;
+      if (capturedController?.signal.aborted) {
+        const err = new Error("The operation was aborted");
+        (err as Error & { name: string }).name = "AbortError";
+        throw err;
+      }
       // Simulate adapter honoring the AbortController by throwing AbortError
       await new Promise<void>((_resolve, reject) => {
         capturedController?.signal.addEventListener("abort", () => {
@@ -605,6 +610,31 @@ describe("chat API", () => {
         });
       });
       return { outputText: "", sessionId: "runtime-session-1" };
+    });
+    let releaseRuntimeResolutionGate = () => {};
+    const runtimeResolutionGate = new Promise<void>((resolve) => {
+      releaseRuntimeResolutionGate = () => resolve();
+    });
+    mockResolveApiRuntimeContext.mockImplementationOnce(async () => {
+      await runtimeResolutionGate;
+      return {
+        project: { id: "project-1", rootPath: "/tmp/project-1" },
+        adapter: runtimeAdapter,
+        resolvedProfile: {
+          source: "project_default",
+          profileId: "profile-1",
+          runtimeId: "claude",
+          providerId: "anthropic",
+          transport: "sdk",
+          model: null,
+          baseUrl: null,
+          apiKey: null,
+          apiKeyEnvVar: null,
+          headers: {},
+          options: {},
+        },
+        selectionSource: "project_default",
+      };
     });
 
     const conversationId = crypto.randomUUID();
@@ -619,10 +649,26 @@ describe("chat API", () => {
       }),
     });
 
-    // Give the route a tick to register the AbortController before we abort.
-    await new Promise((r) => setTimeout(r, 20));
-    const abortRes = await app.request(`/chat/${conversationId}/abort`, { method: "POST" });
+    // Let the route start and block on runtime resolution; at this point the
+    // AbortController should already be registered but chatSession auto-create
+    // has not run yet.
+    await Promise.resolve();
+    let abortRes: Response | null = null;
+    for (let i = 0; i < 50; i += 1) {
+      const attempt = await app.request(`/chat/${conversationId}/abort`, { method: "POST" });
+      if (attempt.status === 204) {
+        abortRes = attempt;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 1));
+    }
+    if (!abortRes) {
+      abortRes = await app.request(`/chat/${conversationId}/abort`, { method: "POST" });
+    }
     expect(abortRes.status).toBe(204);
+    expect(mockCreateChatSession).not.toHaveBeenCalled();
+
+    releaseRuntimeResolutionGate();
 
     const chatRes = await chatPromise;
     expect(chatRes.status).toBe(409);

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -729,103 +729,120 @@ chatRouter.post("/", jsonValidator(chatRequestSchema), async (c) => {
   let { sessionId: inputSessionId } = body;
   const env = getEnv();
 
-  const project = findProjectById(projectId);
-  if (!project) {
-    return c.json({ error: "Project not found" }, 404);
-  }
-
-  // Resolve currently open task for context injection
-  let currentTask: Task | null = null;
-  if (taskId) {
-    const row = findTaskById(taskId);
-    if (row) currentTask = toTaskResponse(row);
-  }
-
-  const systemAppend = buildContextAppend(project.name, currentTask);
-  const runtimeResolution = await resolveChatRuntimeAdapter(projectId, message, systemAppend);
-  const runtimeContext = runtimeResolution.context;
-  const adapter = runtimeContext.adapter;
-  const runtimeId = runtimeContext.resolvedProfile.runtimeId;
-  const runtimeProfileId = runtimeContext.resolvedProfile.profileId;
-  const runtimeProviderId = runtimeContext.resolvedProfile.providerId;
-
-  // Resolve or auto-create a chat session
-  let chatSessionId = inputSessionId ?? null;
-  const incomingVirtual = chatSessionId ? parseVirtualRuntimeSessionId(chatSessionId) : null;
-
-  // External runtime sessions are virtual — create a DB session linked to the runtime session
-  if (incomingVirtual) {
-    const autoTitle = message.slice(0, 80);
-    const session = createChatSession({
-      projectId,
-      title: autoTitle,
-      runtimeProfileId,
-      runtimeSessionId: incomingVirtual.sessionId,
-    });
-    if (session) {
-      chatSessionId = session.id;
-      updateChatSession(session.id, {
-        runtimeProfileId,
-        runtimeSessionId: incomingVirtual.sessionId,
-      });
-      broadcast({ type: "chat:session_created", payload: toChatSessionResponse(session) });
-    } else {
-      chatSessionId = null;
-    }
-  } else if (chatSessionId) {
-    const existing = findChatSessionById(chatSessionId);
-    if (!existing) {
-      log.debug("Provided sessionId=%s not found, will auto-create", chatSessionId);
-      chatSessionId = null;
-    }
-  }
-
-  if (!chatSessionId) {
-    const autoTitle = message.slice(0, 80);
-    const session = createChatSession({
-      projectId,
-      title: autoTitle,
-      runtimeProfileId,
-    });
-    chatSessionId = session?.id ?? null;
-    if (session) {
-      broadcast({ type: "chat:session_created", payload: toChatSessionResponse(session) });
-    }
-  }
-
+  // Register the AbortController BEFORE any slow work (project lookup, runtime
+  // resolution, session auto-create). This closes the window where an early
+  // Stop click from the client would hit `/abort` with a 404 because the
+  // controller wasn't registered yet, letting the `/chat` request continue
+  // running. If `.abort()` fires before `adapter.run()` is reached, the
+  // already-aborted signal propagates into the run and trips the catch below.
   const chatConversationId = conversationId ?? crypto.randomUUID();
   const abortController = new AbortController();
   activeChatRuns.set(chatConversationId, abortController);
+
+  let chatSessionId: string | null = null;
+  let runtimeId: string | undefined;
+  let runtimeProfileId: string | null | undefined;
+  let runtimeProviderId: string | undefined;
   // Hoisted so the abort branch can persist any partial streamed output.
   let fullAssistantResponse = "";
-  log.info(
-    {
-      projectId,
-      clientId: clientId ?? null,
-      conversationId: chatConversationId,
-      sessionId: chatSessionId,
-      runtimeId,
-      runtimeProfileId,
-      runtimeProviderId,
-      logNamespace: API_RUNTIME_LOG,
-      explore,
-      taskId,
-    },
-    "INFO [api-runtime] Chat request started",
-  );
-
-  const dbSession = chatSessionId ? findChatSessionById(chatSessionId) : null;
-  const resumeRuntimeSessionId =
-    dbSession?.runtimeSessionId ?? dbSession?.agentSessionId ?? undefined;
-
-  if (chatSessionId && !attachments?.length) {
-    createChatMessage({ sessionId: chatSessionId, role: "user", content: message });
-  }
-  if (chatSessionId) {
-    updateChatSessionTimestamp(chatSessionId);
-  }
+  // Captured from the runtime `system:init` event so the abort branch can
+  // link the DB chat session to the runtime session even when the run never
+  // completed. Without this, aborting the first turn of a fresh chat would
+  // break runtime continuity — the next turn would have no resume context.
+  let runtimeSessionIdFromEvents: string | null = null;
 
   try {
+    const project = findProjectById(projectId);
+    if (!project) {
+      return c.json({ error: "Project not found" }, 404);
+    }
+
+    // Resolve currently open task for context injection
+    let currentTask: Task | null = null;
+    if (taskId) {
+      const row = findTaskById(taskId);
+      if (row) currentTask = toTaskResponse(row);
+    }
+
+    const systemAppend = buildContextAppend(project.name, currentTask);
+    const runtimeResolution = await resolveChatRuntimeAdapter(projectId, message, systemAppend);
+    const runtimeContext = runtimeResolution.context;
+    const adapter = runtimeContext.adapter;
+    runtimeId = runtimeContext.resolvedProfile.runtimeId;
+    runtimeProfileId = runtimeContext.resolvedProfile.profileId;
+    runtimeProviderId = runtimeContext.resolvedProfile.providerId;
+
+    // Resolve or auto-create a chat session
+    chatSessionId = inputSessionId ?? null;
+    const incomingVirtual = chatSessionId ? parseVirtualRuntimeSessionId(chatSessionId) : null;
+
+    // External runtime sessions are virtual — create a DB session linked to the runtime session
+    if (incomingVirtual) {
+      const autoTitle = message.slice(0, 80);
+      const session = createChatSession({
+        projectId,
+        title: autoTitle,
+        runtimeProfileId,
+        runtimeSessionId: incomingVirtual.sessionId,
+      });
+      if (session) {
+        chatSessionId = session.id;
+        updateChatSession(session.id, {
+          runtimeProfileId,
+          runtimeSessionId: incomingVirtual.sessionId,
+        });
+        broadcast({ type: "chat:session_created", payload: toChatSessionResponse(session) });
+      } else {
+        chatSessionId = null;
+      }
+    } else if (chatSessionId) {
+      const existing = findChatSessionById(chatSessionId);
+      if (!existing) {
+        log.debug("Provided sessionId=%s not found, will auto-create", chatSessionId);
+        chatSessionId = null;
+      }
+    }
+
+    if (!chatSessionId) {
+      const autoTitle = message.slice(0, 80);
+      const session = createChatSession({
+        projectId,
+        title: autoTitle,
+        runtimeProfileId,
+      });
+      chatSessionId = session?.id ?? null;
+      if (session) {
+        broadcast({ type: "chat:session_created", payload: toChatSessionResponse(session) });
+      }
+    }
+
+    log.info(
+      {
+        projectId,
+        clientId: clientId ?? null,
+        conversationId: chatConversationId,
+        sessionId: chatSessionId,
+        runtimeId,
+        runtimeProfileId,
+        runtimeProviderId,
+        logNamespace: API_RUNTIME_LOG,
+        explore,
+        taskId,
+      },
+      "INFO [api-runtime] Chat request started",
+    );
+
+    const dbSession = chatSessionId ? findChatSessionById(chatSessionId) : null;
+    const resumeRuntimeSessionId =
+      dbSession?.runtimeSessionId ?? dbSession?.agentSessionId ?? undefined;
+
+    if (chatSessionId && !attachments?.length) {
+      createChatMessage({ sessionId: chatSessionId, role: "user", content: message });
+    }
+    if (chatSessionId) {
+      updateChatSessionTimestamp(chatSessionId);
+    }
+
     // Persist file attachments to disk and build prompt with paths
     let prompt = explore ? `/aif-explore ${message}` : message;
     let savedAttachments: ChatMessageAttachment[] | undefined;
@@ -877,6 +894,19 @@ chatRouter.post("/", jsonValidator(chatRequestSchema), async (c) => {
 
       if (event.type === "tool:summary" && event.message) {
         sendToken(`\n\n> ${event.message}\n\n`);
+        return;
+      }
+
+      // Capture the runtime session id as soon as the adapter emits it, so
+      // the abort branch can persist a DB→runtime session link even when
+      // adapter.run() never resolves. Without this, aborting the first turn
+      // of a fresh chat would leave the DB session without runtimeSessionId
+      // and the next turn would dispatch with no resume context.
+      if (event.type === "system:init" && event.data) {
+        const sid = event.data.sessionId;
+        if (typeof sid === "string" && sid) {
+          runtimeSessionIdFromEvents = sid;
+        }
       }
     };
 
@@ -1029,12 +1059,22 @@ chatRouter.post("/", jsonValidator(chatRequestSchema), async (c) => {
         createChatMessage({ sessionId: chatSessionId, role: "assistant", content: partial });
         updateChatSessionTimestamp(chatSessionId);
       }
+      // Link the DB chat session to the runtime session the adapter started
+      // before we aborted, so the next turn can resume instead of starting
+      // a brand-new runtime thread and losing continuity.
+      if (chatSessionId && runtimeSessionIdFromEvents) {
+        updateChatSession(chatSessionId, {
+          runtimeProfileId: runtimeProfileId ?? null,
+          runtimeSessionId: runtimeSessionIdFromEvents,
+        });
+      }
       log.info(
         {
           runtimeId,
           runtimeProfileId,
           conversationId: chatConversationId,
           partial: partial.length,
+          runtimeSessionId: runtimeSessionIdFromEvents,
         },
         "INFO [chat-route] Chat run aborted",
       );

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -750,6 +750,10 @@ chatRouter.post("/", jsonValidator(chatRequestSchema), async (c) => {
   // completed. Without this, aborting the first turn of a fresh chat would
   // break runtime continuity — the next turn would have no resume context.
   let runtimeSessionIdFromEvents: string | null = null;
+  // Hoisted so the abort branch can surface server-resolved attachment paths
+  // to the client — without this, an aborted run with uploads would leave the
+  // user bubble with a path-less chip until the session is reopened.
+  let savedAttachments: ChatMessageAttachment[] | undefined;
 
   try {
     const project = findProjectById(projectId);
@@ -845,7 +849,6 @@ chatRouter.post("/", jsonValidator(chatRequestSchema), async (c) => {
 
     // Persist file attachments to disk and build prompt with paths
     let prompt = explore ? `/aif-explore ${message}` : message;
-    let savedAttachments: ChatMessageAttachment[] | undefined;
     if (attachments?.length && chatSessionId) {
       const persisted = await persistAttachments(attachments, {
         projectRoot: project.rootPath,
@@ -1100,6 +1103,13 @@ chatRouter.post("/", jsonValidator(chatRequestSchema), async (c) => {
           code: "aborted",
           conversationId: chatConversationId,
           sessionId: chatSessionId,
+          // Expose the partial assistant reply so clients without an active
+          // WebSocket can render what was saved server-side. Mirrors the
+          // success path's `assistantMessage`.
+          assistantMessage: partial.length > 0 ? partial : null,
+          // Echo server-resolved attachments so the optimistic user bubble
+          // can upgrade its chips with download paths even on abort.
+          ...(savedAttachments?.length ? { attachments: savedAttachments } : {}),
         },
         409,
       );

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -796,6 +796,8 @@ chatRouter.post("/", jsonValidator(chatRequestSchema), async (c) => {
   const chatConversationId = conversationId ?? crypto.randomUUID();
   const abortController = new AbortController();
   activeChatRuns.set(chatConversationId, abortController);
+  // Hoisted so the abort branch can persist any partial streamed output.
+  let fullAssistantResponse = "";
   log.info(
     {
       projectId,
@@ -854,7 +856,6 @@ chatRouter.post("/", jsonValidator(chatRequestSchema), async (c) => {
     }
 
     const bypassPermissions = env.AGENT_BYPASS_PERMISSIONS;
-    let fullAssistantResponse = "";
     let hasStreamedTokens = false;
 
     const sendToken = (text: string) => {
@@ -1020,8 +1021,21 @@ chatRouter.post("/", jsonValidator(chatRequestSchema), async (c) => {
   } catch (err) {
     const aborted = abortController.signal.aborted || isAbortError(err);
     if (aborted) {
+      // Persist any tokens streamed before the abort so the partial assistant
+      // reply survives reload. Without this, a fresh session stopped mid-stream
+      // would lose visible output.
+      const partial = fullAssistantResponse.trim();
+      if (chatSessionId && partial) {
+        createChatMessage({ sessionId: chatSessionId, role: "assistant", content: partial });
+        updateChatSessionTimestamp(chatSessionId);
+      }
       log.info(
-        { runtimeId, runtimeProfileId, conversationId: chatConversationId },
+        {
+          runtimeId,
+          runtimeProfileId,
+          conversationId: chatConversationId,
+          partial: partial.length,
+        },
         "INFO [chat-route] Chat run aborted",
       );
       const abortedEvent: WsEvent = {
@@ -1040,7 +1054,15 @@ chatRouter.post("/", jsonValidator(chatRequestSchema), async (c) => {
         sendToClient(clientId, abortedEvent);
         sendToClient(clientId, doneEvent);
       }
-      return c.json({ error: "Chat run aborted by user", code: "aborted" }, 409);
+      return c.json(
+        {
+          error: "Chat run aborted by user",
+          code: "aborted",
+          conversationId: chatConversationId,
+          sessionId: chatSessionId,
+        },
+        409,
+      );
     }
 
     log.error(

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -156,6 +156,15 @@ function runtimeSourceFromTransport(transport: string): "cli" | "agent" {
   return transport === RuntimeTransport.CLI ? "cli" : "agent";
 }
 
+function isAbortError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const asError = err as { name?: string; code?: string; cause?: unknown };
+  if (asError.name === "AbortError") return true;
+  if (asError.code === "ABORT_ERR") return true;
+  if (asError.cause) return isAbortError(asError.cause);
+  return false;
+}
+
 function classifyChatError(err: unknown): {
   status: 429 | 500;
   code: string;
@@ -321,6 +330,16 @@ async function getAdapterForRuntimeId(runtimeId: string): Promise<RuntimeAdapter
 }
 
 export const chatRouter = new Hono();
+
+/**
+ * Per-conversation AbortController registry. Populated before dispatching the
+ * runtime `run`/`resume` call and cleared in the route's finally block.
+ * The `/:conversationId/abort` endpoint looks up the controller and calls
+ * `.abort()`, which propagates through the Claude adapter (AbortController on
+ * SDK query options, `kill()` on the CLI spawn) and surfaces to the client as
+ * `chat:error` with code `"aborted"`.
+ */
+const activeChatRuns = new Map<string, AbortController>();
 
 // ── Session CRUD ───────────────────────────────────────────
 
@@ -687,6 +706,23 @@ chatRouter.get("/sessions/:sessionId/attachments/:filename", async (c) => {
 });
 
 // POST /chat
+// POST /chat/:conversationId/abort — interrupt an in-flight chat run.
+chatRouter.post("/:conversationId/abort", async (c) => {
+  const conversationId = c.req.param("conversationId");
+  const controller = activeChatRuns.get(conversationId);
+  if (!controller) {
+    log.debug(
+      { conversationId },
+      "DEBUG [chat-route] abort requested for unknown or completed conversation",
+    );
+    return c.json({ error: "Conversation not found or already completed" }, 404);
+  }
+  controller.abort();
+  activeChatRuns.delete(conversationId);
+  log.info({ conversationId }, "INFO [chat-route] Chat run aborted by user");
+  return c.body(null, 204);
+});
+
 chatRouter.post("/", jsonValidator(chatRequestSchema), async (c) => {
   const body = c.req.valid("json") as ChatRequestPayload;
   const { projectId, message, clientId, conversationId, explore, taskId, attachments } = body;
@@ -758,6 +794,8 @@ chatRouter.post("/", jsonValidator(chatRequestSchema), async (c) => {
   }
 
   const chatConversationId = conversationId ?? crypto.randomUUID();
+  const abortController = new AbortController();
+  activeChatRuns.set(chatConversationId, abortController);
   log.info(
     {
       projectId,
@@ -880,6 +918,7 @@ chatRouter.post("/", jsonValidator(chatRequestSchema), async (c) => {
         onEvent: onRuntimeEvent,
         systemPromptAppend: systemAppend,
         bypassPermissions,
+        abortController,
         environment: {
           HANDOFF_MODE: "1",
           ...(taskId ? { HANDOFF_TASK_ID: taskId } : {}),
@@ -979,6 +1018,31 @@ chatRouter.post("/", jsonValidator(chatRequestSchema), async (c) => {
       ...(savedAttachments?.length ? { attachments: savedAttachments } : {}),
     });
   } catch (err) {
+    const aborted = abortController.signal.aborted || isAbortError(err);
+    if (aborted) {
+      log.info(
+        { runtimeId, runtimeProfileId, conversationId: chatConversationId },
+        "INFO [chat-route] Chat run aborted",
+      );
+      const abortedEvent: WsEvent = {
+        type: "chat:error",
+        payload: {
+          conversationId: chatConversationId,
+          message: "Chat run aborted by user",
+          code: "aborted",
+        },
+      };
+      const doneEvent: WsEvent = {
+        type: "chat:done",
+        payload: { conversationId: chatConversationId },
+      };
+      if (clientId) {
+        sendToClient(clientId, abortedEvent);
+        sendToClient(clientId, doneEvent);
+      }
+      return c.json({ error: "Chat run aborted by user", code: "aborted" }, 409);
+    }
+
     log.error(
       { err, runtimeId, runtimeProfileId, runtimeProviderId, conversationId: chatConversationId },
       "Chat request failed",
@@ -1006,5 +1070,7 @@ chatRouter.post("/", jsonValidator(chatRequestSchema), async (c) => {
     }
 
     return c.json({ error: classified.message, code: classified.code }, classified.status);
+  } finally {
+    activeChatRuns.delete(chatConversationId);
   }
 });

--- a/packages/runtime/src/__tests__/codexModelDiscoveryProcess.test.ts
+++ b/packages/runtime/src/__tests__/codexModelDiscoveryProcess.test.ts
@@ -130,12 +130,30 @@ describe("codex model discovery process helpers", () => {
   });
 
   it("reserves a loopback port that can be bound immediately afterwards", async () => {
-    const port = await reservePort();
+    let port: number;
+    try {
+      port = await reservePort();
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException)?.code;
+      // Some sandboxed CI/runtime environments disallow opening local sockets.
+      // In that case the behavior is environment-constrained, not a reservePort bug.
+      if (code === "EPERM" || code === "EACCES") {
+        return;
+      }
+      throw error;
+    }
     expect(port).toBeGreaterThan(0);
 
     await new Promise<void>((resolve, reject) => {
       const server = createServer();
-      server.once("error", reject);
+      server.once("error", (error) => {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code === "EPERM" || code === "EACCES") {
+          resolve();
+          return;
+        }
+        reject(error);
+      });
       server.listen(port, "127.0.0.1", () => {
         server.close((error) => {
           if (error) {

--- a/packages/web/src/__tests__/useChat.test.ts
+++ b/packages/web/src/__tests__/useChat.test.ts
@@ -478,6 +478,131 @@ describe("useChat", () => {
     expect(handleSessionResolved).toHaveBeenCalledWith("sess-new-1");
   });
 
+  it("does not clear Stop or show Stopped on session B when session A's run aborts in the background", async () => {
+    // Stream A: resolvable by us, simulates A's HTTP settling after user switches away
+    let rejectA: ((reason?: unknown) => void) | null = null;
+    mockSendChatMessage.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectA = reject;
+        }),
+    );
+    // Stream B: pending forever for this test
+    let resolveB: ((v: { conversationId: string; sessionId: string }) => void) | null = null;
+    mockSendChatMessage.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveB = resolve;
+        }),
+    );
+
+    const { result, rerender } = renderHook(
+      ({ sid }: { sid: string | null }) => useChat("p-1", sid),
+      { initialProps: { sid: "sess-A" as string | null } },
+    );
+
+    // Kick off stream for A
+    let sendAPromise: Promise<void>;
+    act(() => {
+      sendAPromise = result.current.sendMessage("A");
+    });
+    await waitFor(() => expect(mockSendChatMessage).toHaveBeenCalledTimes(1));
+    const convA = mockSendChatMessage.mock.calls[0][0].conversationId as string;
+
+    // Switch to B and kick off its stream
+    await act(async () => {
+      rerender({ sid: "sess-B" });
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    let sendBPromise: Promise<void>;
+    act(() => {
+      sendBPromise = result.current.sendMessage("B");
+    });
+    await waitFor(() => expect(mockSendChatMessage).toHaveBeenCalledTimes(2));
+
+    // While the user is still viewing B, A's HTTP request aborts with 409.
+    await act(async () => {
+      rejectA!(
+        new ApiError("Chat run aborted by user", 409, {
+          code: "aborted",
+          sessionId: "sess-A",
+          conversationId: convA,
+          assistantMessage: null,
+        }),
+      );
+      await sendAPromise;
+    });
+
+    // B is still streaming — Stop must stay, no "Stopped" banner must appear.
+    expect(result.current.isStreaming).toBe(true);
+    expect(result.current.chatErrorCode).toBeNull();
+
+    // Clean up
+    await act(async () => {
+      resolveB?.({ conversationId: "conv-B", sessionId: "sess-B" });
+      await sendBPromise;
+    });
+  });
+
+  it("appends the partial assistant reply from the 409 abort body when no WS tokens arrived", async () => {
+    mockGetWsClientId.mockReturnValue(null);
+    mockSendChatMessage.mockRejectedValueOnce(
+      new ApiError("Chat run aborted by user", 409, {
+        code: "aborted",
+        sessionId: "sess-partial-1",
+        conversationId: "conv-partial-1",
+        assistantMessage: "half-written answer",
+      }),
+    );
+
+    const { result } = renderHook(() => useChat("p-1"));
+
+    await act(async () => {
+      await result.current.sendMessage("question");
+    });
+
+    expect(result.current.messages).toEqual([
+      { role: "user", content: "question" },
+      { role: "assistant", content: "half-written answer" },
+    ]);
+    expect(result.current.chatErrorCode).toBe("aborted");
+    expect(result.current.isStreaming).toBe(false);
+  });
+
+  it("upgrades user message attachments from the 409 abort body", async () => {
+    mockSendChatMessage.mockRejectedValueOnce(
+      new ApiError("Chat run aborted by user", 409, {
+        code: "aborted",
+        sessionId: "sess-att-1",
+        conversationId: "conv-att-1",
+        attachments: [
+          {
+            name: "plan.md",
+            mimeType: "text/markdown",
+            size: 12,
+            path: "storage/chat/s1/plan.md",
+          },
+        ],
+      }),
+    );
+
+    const { result } = renderHook(() => useChat("p-1"));
+
+    await act(async () => {
+      await result.current.sendMessage("take a look", [
+        { name: "plan.md", mimeType: "text/markdown", size: 12, content: "hello" },
+      ]);
+    });
+
+    const userMessage = result.current.messages.find((m) => m.role === "user");
+    expect(userMessage?.attachments?.[0]).toEqual(
+      expect.objectContaining({
+        name: "plan.md",
+        path: "storage/chat/s1/plan.md",
+      }),
+    );
+  });
+
   it("toggles explore mode", () => {
     const { result } = renderHook(() => useChat("p-1"));
 

--- a/packages/web/src/__tests__/useChat.test.ts
+++ b/packages/web/src/__tests__/useChat.test.ts
@@ -3,13 +3,27 @@ import { renderHook, act, waitFor } from "@testing-library/react";
 
 const mockSendChatMessage = vi.fn();
 const mockGetChatSessionMessages = vi.fn();
+const mockAbortChat = vi.fn();
 const mockGetWsClientId = vi.fn();
 const WS_CLIENT_ID_WAIT_TIMEOUT_MS = 500;
 
+class ApiError extends Error {
+  status: number;
+  data?: unknown;
+  constructor(message: string, status: number, data?: unknown) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.data = data;
+  }
+}
+
 vi.mock("@/lib/api", () => ({
+  ApiError,
   api: {
     sendChatMessage: (...args: unknown[]) => mockSendChatMessage(...args),
     getChatSessionMessages: (...args: unknown[]) => mockGetChatSessionMessages(...args),
+    abortChat: (...args: unknown[]) => mockAbortChat(...args),
   },
 }));
 
@@ -23,6 +37,8 @@ describe("useChat", () => {
   beforeEach(() => {
     mockSendChatMessage.mockReset();
     mockGetChatSessionMessages.mockReset();
+    mockAbortChat.mockReset();
+    mockAbortChat.mockResolvedValue(undefined);
     mockGetWsClientId.mockReset();
     mockGetWsClientId.mockReturnValue("test-client-id");
     mockSendChatMessage.mockResolvedValue({ conversationId: "conv-1", sessionId: "sess-1" });
@@ -376,6 +392,90 @@ describe("useChat", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("abort targets the currently viewed session when multiple streams are in flight", async () => {
+    // Stream A: pending on session "sess-A"
+    let resolveA: ((v: { conversationId: string; sessionId: string }) => void) | null = null;
+    mockSendChatMessage.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveA = resolve;
+        }),
+    );
+    // Stream B: pending on session "sess-B"
+    let resolveB: ((v: { conversationId: string; sessionId: string }) => void) | null = null;
+    mockSendChatMessage.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveB = resolve;
+        }),
+    );
+
+    // Hook A bound to session A; Hook B to session B — they share the abort registry
+    // via activeStreamsRef only within one hook instance, so simulate the real scenario
+    // with a single hook switching its viewed session.
+    const { result, rerender } = renderHook(
+      ({ sid }: { sid: string | null }) => useChat("p-1", sid),
+      { initialProps: { sid: "sess-A" as string | null } },
+    );
+
+    // Start stream for session A
+    let sendAPromise: Promise<void>;
+    act(() => {
+      sendAPromise = result.current.sendMessage("A");
+    });
+    await waitFor(() => expect(mockSendChatMessage).toHaveBeenCalledTimes(1));
+    const convA = mockSendChatMessage.mock.calls[0][0].conversationId as string;
+
+    // Switch to session B — wait for the effect to clear isStreaming — then send
+    await act(async () => {
+      rerender({ sid: "sess-B" });
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    let sendBPromise: Promise<void>;
+    act(() => {
+      sendBPromise = result.current.sendMessage("B");
+    });
+    await waitFor(() => expect(mockSendChatMessage).toHaveBeenCalledTimes(2));
+    const convB = mockSendChatMessage.mock.calls[1][0].conversationId as string;
+
+    // Switch back to A and hit Stop — must abort A's conversation, not B's
+    rerender({ sid: "sess-A" });
+    await act(async () => {
+      await result.current.abortStream();
+    });
+
+    expect(mockAbortChat).toHaveBeenCalledTimes(1);
+    expect(mockAbortChat).toHaveBeenCalledWith(convA);
+    expect(convA).not.toBe(convB);
+
+    // Clean up pending promises
+    await act(async () => {
+      resolveA?.({ conversationId: convA, sessionId: "sess-A" });
+      resolveB?.({ conversationId: convB, sessionId: "sess-B" });
+      await sendAPromise;
+      await sendBPromise;
+    });
+  });
+
+  it("resolves the active session when aborting the first message in a new chat", async () => {
+    const handleSessionResolved = vi.fn();
+    mockSendChatMessage.mockRejectedValueOnce(
+      new ApiError("Chat run aborted by user", 409, {
+        code: "aborted",
+        sessionId: "sess-new-1",
+        conversationId: "conv-new-1",
+      }),
+    );
+
+    const { result } = renderHook(() => useChat("p-1", null, null, handleSessionResolved));
+
+    await act(async () => {
+      await result.current.sendMessage("Hello");
+    });
+
+    expect(handleSessionResolved).toHaveBeenCalledWith("sess-new-1");
   });
 
   it("toggles explore mode", () => {

--- a/packages/web/src/__tests__/useChat.test.ts
+++ b/packages/web/src/__tests__/useChat.test.ts
@@ -603,6 +603,68 @@ describe("useChat", () => {
     );
   });
 
+  it("upgrades user message attachments when chat:error races ahead of the 409 abort body", async () => {
+    let rejectSend: ((reason?: unknown) => void) | null = null;
+    mockSendChatMessage.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectSend = reject;
+        }),
+    );
+
+    const { result } = renderHook(() => useChat("p-1"));
+
+    let sendPromise: Promise<void>;
+    act(() => {
+      sendPromise = result.current.sendMessage("take a look", [
+        { name: "plan.md", mimeType: "text/markdown", size: 12, content: "hello" },
+      ]);
+    });
+    await waitFor(() => expect(mockSendChatMessage).toHaveBeenCalledTimes(1));
+
+    const conversationId = mockSendChatMessage.mock.calls[0][0].conversationId as string;
+
+    // WS `chat:error` with code=aborted arrives first — this clears the
+    // in-flight stream state before the HTTP 409 lands.
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("chat:error", {
+          detail: { conversationId, message: "Chat run aborted by user", code: "aborted" },
+        }),
+      );
+    });
+
+    // Then the HTTP request rejects with a 409 carrying server-resolved
+    // attachment paths. The bubble must still pick them up.
+    await act(async () => {
+      rejectSend!(
+        new ApiError("Chat run aborted by user", 409, {
+          code: "aborted",
+          sessionId: "sess-race-1",
+          conversationId,
+          attachments: [
+            {
+              name: "plan.md",
+              mimeType: "text/markdown",
+              size: 12,
+              path: "storage/chat/s1/plan.md",
+            },
+          ],
+        }),
+      );
+      await sendPromise;
+    });
+
+    const userMessage = result.current.messages.find((m) => m.role === "user");
+    expect(userMessage?.attachments?.[0]).toEqual(
+      expect.objectContaining({
+        name: "plan.md",
+        path: "storage/chat/s1/plan.md",
+      }),
+    );
+    expect(result.current.chatErrorCode).toBe("aborted");
+  });
+
   it("toggles explore mode", () => {
     const { result } = renderHook(() => useChat("p-1"));
 

--- a/packages/web/src/__tests__/useChat.test.ts
+++ b/packages/web/src/__tests__/useChat.test.ts
@@ -478,6 +478,26 @@ describe("useChat", () => {
     expect(handleSessionResolved).toHaveBeenCalledWith("sess-new-1");
   });
 
+  it("rolls back the optimistic first message when abort returns without sessionId", async () => {
+    mockSendChatMessage.mockRejectedValueOnce(
+      new ApiError("Chat run aborted by user", 409, {
+        code: "aborted",
+        sessionId: null,
+        conversationId: "conv-new-orphan-1",
+      }),
+    );
+
+    const { result } = renderHook(() => useChat("p-1"));
+
+    await act(async () => {
+      await result.current.sendMessage("Hello");
+    });
+
+    expect(result.current.messages).toEqual([]);
+    expect(result.current.chatErrorCode).toBe("aborted");
+    expect(result.current.isStreaming).toBe(false);
+  });
+
   it("does not clear Stop or show Stopped on session B when session A's run aborts in the background", async () => {
     // Stream A: resolvable by us, simulates A's HTTP settling after user switches away
     let rejectA: ((reason?: unknown) => void) | null = null;
@@ -663,6 +683,53 @@ describe("useChat", () => {
       }),
     );
     expect(result.current.chatErrorCode).toBe("aborted");
+  });
+
+  it("appends assistantMessage when chat:error races ahead of the 409 abort body", async () => {
+    let rejectSend: ((reason?: unknown) => void) | null = null;
+    mockSendChatMessage.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectSend = reject;
+        }),
+    );
+
+    const { result } = renderHook(() => useChat("p-1"));
+
+    let sendPromise: Promise<void>;
+    act(() => {
+      sendPromise = result.current.sendMessage("question");
+    });
+    await waitFor(() => expect(mockSendChatMessage).toHaveBeenCalledTimes(1));
+
+    const conversationId = mockSendChatMessage.mock.calls[0][0].conversationId as string;
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("chat:error", {
+          detail: { conversationId, message: "Chat run aborted by user", code: "aborted" },
+        }),
+      );
+    });
+
+    await act(async () => {
+      rejectSend!(
+        new ApiError("Chat run aborted by user", 409, {
+          code: "aborted",
+          sessionId: "sess-race-assistant-1",
+          conversationId,
+          assistantMessage: "half-written answer",
+        }),
+      );
+      await sendPromise;
+    });
+
+    expect(result.current.messages).toEqual([
+      { role: "user", content: "question" },
+      { role: "assistant", content: "half-written answer" },
+    ]);
+    expect(result.current.chatErrorCode).toBe("aborted");
+    expect(result.current.isStreaming).toBe(false);
   });
 
   it("toggles explore mode", () => {

--- a/packages/web/src/components/chat/ChatPanel.tsx
+++ b/packages/web/src/components/chat/ChatPanel.tsx
@@ -320,6 +320,18 @@ export function ChatPanel({
               </div>
             </div>
           )}
+          {chatErrorCode === "aborted" && (
+            <div className="px-3 pb-2">
+              <div className="rounded border border-muted-foreground/30 bg-muted/40 p-2">
+                <Badge variant="outline" className="border-muted-foreground/50">
+                  Stopped
+                </Badge>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Chat run was stopped. Any partial reply above has been saved.
+                </p>
+              </div>
+            </div>
+          )}
           {chatErrorCode === "CHAT_USAGE_LIMIT" && (
             <div className="px-3 pb-2">
               <div className="rounded border border-amber-500/50 bg-amber-500/15 p-2">

--- a/packages/web/src/components/chat/ChatPanel.tsx
+++ b/packages/web/src/components/chat/ChatPanel.tsx
@@ -18,6 +18,7 @@ import {
   PanelLeftOpen,
   Paperclip,
   AlertTriangle,
+  Square,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
@@ -71,6 +72,7 @@ export function ChatPanel({
     explore,
     setExplore,
     sendMessage,
+    abortStream,
     clearMessages,
     newSession,
   } = useChat(projectId, activeSessionId, taskId, setActiveSessionId);
@@ -413,14 +415,25 @@ export function ChatPanel({
             rows={1}
             className="max-h-32 min-h-[2.25rem] flex-1 resize-none bg-secondary/50"
           />
-          <Button
-            onClick={handleSend}
-            disabled={!input.trim() || isStreaming}
-            aria-label="Send message"
-            className="h-auto self-stretch w-9 shrink-0 rounded px-0"
-          >
-            <Send className="h-4 w-4 shrink-0" />
-          </Button>
+          {isStreaming ? (
+            <Button
+              onClick={() => void abortStream()}
+              aria-label="Stop generation"
+              variant="destructive"
+              className="h-auto self-stretch w-9 shrink-0 rounded px-0"
+            >
+              <Square className="h-4 w-4 shrink-0" />
+            </Button>
+          ) : (
+            <Button
+              onClick={handleSend}
+              disabled={!input.trim()}
+              aria-label="Send message"
+              className="h-auto self-stretch w-9 shrink-0 rounded px-0"
+            >
+              <Send className="h-4 w-4 shrink-0" />
+            </Button>
+          )}
         </div>
       </div>
     </div>

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -222,10 +222,18 @@ export function useChat(
       if (isCurrentStream(streamKey)) {
         setIsStreaming(false);
         setChatErrorCode(code ?? null);
-        setMessages((prev) => [
-          ...prev,
-          { role: "assistant", content: message || "Chat request failed" },
-        ]);
+        // User-initiated aborts surface as a banner via chatErrorCode, not a
+        // phantom assistant bubble. The bubble was misleading because only
+        // partial streamed text (if any) is persisted to DB — the "Chat run
+        // aborted by user" text disappeared after reload, and the partial
+        // reply took its place. Any partial assistant content is already
+        // visible in the transcript via handleToken.
+        if (code !== "aborted") {
+          setMessages((prev) => [
+            ...prev,
+            { role: "assistant", content: message || "Chat request failed" },
+          ]);
+        }
       }
     };
 
@@ -436,7 +444,14 @@ export function useChat(
         sessionStreamsRef.current.delete(activeStreamKey);
         setIsStreaming(false);
         const wsHandled = handledErrorConversationsRef.current.has(newConversationId);
-        if (!errorHandled && !wsHandled) {
+        const isAbortedError =
+          err instanceof ApiError &&
+          err.status === 409 &&
+          (err.data as { code?: string } | null)?.code === "aborted";
+        if (isAbortedError) {
+          // Abort is surfaced via the banner only — no phantom bubble.
+          setChatErrorCode("aborted");
+        } else if (!errorHandled && !wsHandled) {
           const message =
             err instanceof Error ? err.message : "Failed to get a response. Please try again.";
           setChatErrorCode(null);

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -491,20 +491,28 @@ export function useChat(
         // into React state for the viewed session.
         let patchedUserAttachments: ChatMessageAttachment[] | undefined;
         let appendedPartialAssistant: string | null = null;
-        if (isAbortedError && state) {
+        if (isAbortedError) {
           if (abortData?.attachments?.length) {
             const resolvedAttachments = abortData.attachments;
-            state.messages = state.messages.map((m) =>
-              m.role === "user" &&
-              m.content === userMessage.content &&
-              m.attachments &&
-              !m.attachments[0]?.path
-                ? { ...m, attachments: resolvedAttachments }
-                : m,
-            );
+            // Patch in-flight stream state only when it survived the WS race —
+            // needed so a later session switch restores the upgraded chips.
+            if (state) {
+              state.messages = state.messages.map((m) =>
+                m.role === "user" &&
+                m.content === userMessage.content &&
+                m.attachments &&
+                !m.attachments[0]?.path
+                  ? { ...m, attachments: resolvedAttachments }
+                  : m,
+              );
+            }
+            // Always mirror to React state: if WS `chat:error` raced ahead and
+            // cleared the stream state, the bubble would otherwise stay without
+            // its download link until the user reloads the session.
             patchedUserAttachments = resolvedAttachments;
           }
           if (
+            state &&
             !hasAccumulatedTokens &&
             typeof abortData?.assistantMessage === "string" &&
             abortData.assistantMessage.trim().length > 0

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -7,7 +7,7 @@ import type {
   ChatDonePayload,
   ChatErrorPayload,
 } from "@aif/shared/browser";
-import { api } from "@/lib/api";
+import { api, ApiError } from "@/lib/api";
 import { getWsClientId } from "./useWebSocket";
 
 interface SessionStreamState {
@@ -49,8 +49,6 @@ export function useChat(
   const [chatErrorCode, setChatErrorCode] = useState<string | null>(null);
   const currentSessionIdRef = useRef<string | null>(null);
 
-  // Conversation id of the most recently dispatched message — used by abortStream().
-  const currentConversationIdRef = useRef<string | null>(null);
   // Per-session streaming state: conversationId → streamKey (sessionId or conversationId)
   const activeStreamsRef = useRef<Map<string, string>>(new Map());
   // Per-session stream data: streamKey → state
@@ -277,7 +275,6 @@ export function useChat(
       const newMessages = forceNewSession ? [userMessage] : [...messages, userMessage];
 
       // Register active stream
-      currentConversationIdRef.current = newConversationId;
       if (!effectiveSessionId) {
         conversationIdForNoSession.current = newConversationId;
       }
@@ -410,6 +407,29 @@ export function useChat(
       } catch (err) {
         console.error("[useChat] Failed to send message:", err);
         clearConversationTimers(newConversationId);
+        // If the server aborted the run but already created a DB session, promote it
+        // so the fresh "new chat" doesn't lose its thread in the sidebar.
+        if (err instanceof ApiError && err.status === 409) {
+          const data = err.data as { code?: string; sessionId?: string | null } | null;
+          if (data?.code === "aborted" && data.sessionId) {
+            const resolvedId = data.sessionId;
+            currentSessionIdRef.current = resolvedId;
+            if (streamKey !== resolvedId) {
+              const state = sessionStreamsRef.current.get(streamKey);
+              if (state) {
+                sessionStreamsRef.current.delete(streamKey);
+                sessionStreamsRef.current.set(resolvedId, state);
+              }
+              activeStreamsRef.current.set(newConversationId, resolvedId);
+            }
+            if (resolvedId !== effectiveSessionId) {
+              onSessionResolved?.(resolvedId);
+            }
+            window.dispatchEvent(
+              new CustomEvent("chat:session_created", { detail: { id: resolvedId } }),
+            );
+          }
+        }
         const activeStreamKey = activeStreamsRef.current.get(newConversationId) ?? streamKey;
         activeStreamsRef.current.delete(newConversationId);
         const errorHandled = sessionStreamsRef.current.get(activeStreamKey)?.errorHandled ?? false;
@@ -438,9 +458,20 @@ export function useChat(
   );
 
   const abortStream = useCallback(async () => {
-    const conversationId = currentConversationIdRef.current;
+    // Pick the conversation whose streamKey matches the currently viewed session
+    // (or the pending new-chat conversation), so switching sessions while
+    // multiple runs are in flight doesn't abort the wrong one.
+    const targetKey = currentSessionIdRef.current ?? conversationIdForNoSession.current;
+    if (!targetKey) return;
+    let conversationId: string | null = null;
+    for (const [convId, streamKey] of activeStreamsRef.current) {
+      if (streamKey === targetKey) {
+        conversationId = convId;
+        break;
+      }
+    }
     if (!conversationId) return;
-    console.debug("[useChat] aborting conversation %s", conversationId);
+    console.debug("[useChat] aborting conversation %s (key=%s)", conversationId, targetKey);
     try {
       await api.abortChat(conversationId);
     } catch (err) {

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -94,6 +94,18 @@ export function useChat(
     return false;
   }, []);
 
+  // True when `streamKey` belongs to the session the user is currently viewing.
+  // Any `setIsStreaming` / `setChatErrorCode` / `setMessages` call that ends a
+  // run must be gated by this — otherwise a background session terminating
+  // would wipe the Stop button / banner / transcript of an unrelated session
+  // the user has already switched to.
+  const isCurrentStream = useCallback((streamKey: string) => {
+    return (
+      currentSessionIdRef.current === streamKey ||
+      (!currentSessionIdRef.current && streamKey === conversationIdForNoSession.current)
+    );
+  }, []);
+
   const prevSessionIdRef = useRef<string | null>(null);
   // Load messages when sessionId changes
   useEffect(() => {
@@ -156,11 +168,6 @@ export function useChat(
 
   // Listen for chat stream events dispatched by useWebSocket
   useEffect(() => {
-    // Check if a stream belongs to the currently viewed session
-    const isCurrentStream = (streamKey: string) =>
-      currentSessionIdRef.current === streamKey ||
-      (!currentSessionIdRef.current && streamKey === conversationIdForNoSession.current);
-
     const handleToken = (e: Event) => {
       const { conversationId, token } = (e as CustomEvent<ChatStreamTokenPayload>).detail;
       const streamKey = activeStreamsRef.current.get(conversationId);
@@ -246,7 +253,7 @@ export function useChat(
       window.removeEventListener("chat:error", handleError);
       clearAllConversationTimers();
     };
-  }, [clearAllConversationTimers, clearConversationTimers]);
+  }, [clearAllConversationTimers, clearConversationTimers, isCurrentStream]);
 
   const sendMessage = useCallback(
     async (text: string, attachments?: ChatAttachment[], forceNewSession?: boolean) => {
@@ -319,41 +326,53 @@ export function useChat(
         });
 
         if (result.sessionId) {
-          currentSessionIdRef.current = result.sessionId;
-
-          if (streamKey !== result.sessionId) {
+          const resolvedId = result.sessionId;
+          // Move stream-scoped state to the resolved key regardless of which
+          // session the user is viewing — WS events still need to match.
+          if (streamKey !== resolvedId) {
             const state = sessionStreamsRef.current.get(streamKey);
             if (state) {
               sessionStreamsRef.current.delete(streamKey);
-              sessionStreamsRef.current.set(result.sessionId, state);
+              sessionStreamsRef.current.set(resolvedId, state);
             }
-            activeStreamsRef.current.set(newConversationId, result.sessionId);
+            activeStreamsRef.current.set(newConversationId, resolvedId);
           }
 
-          if (result.sessionId !== effectiveSessionId) {
-            onSessionResolved?.(result.sessionId);
+          // Only rebind the viewed session to the resolved id when the user is
+          // still on this stream. Otherwise a background run finishing would
+          // silently yank their view back to the originating session.
+          if (isCurrentStream(streamKey)) {
+            currentSessionIdRef.current = resolvedId;
+            if (resolvedId !== effectiveSessionId) {
+              onSessionResolved?.(resolvedId);
+            }
           }
+          // Sidebar notification is view-agnostic.
           window.dispatchEvent(
-            new CustomEvent("chat:session_created", { detail: { id: result.sessionId } }),
+            new CustomEvent("chat:session_created", { detail: { id: resolvedId } }),
           );
         }
 
         // Update user message attachments with server-resolved paths (for download links)
         if (result.attachments?.length) {
-          setMessages((prev) =>
-            prev.map((m) => (m === userMessage ? { ...m, attachments: result.attachments } : m)),
-          );
+          const resolvedAttachments = result.attachments;
           const activeStreamKey = activeStreamsRef.current.get(newConversationId) ?? streamKey;
           const state = sessionStreamsRef.current.get(activeStreamKey);
           if (state) {
-            // Also update in-flight stream state
+            // Also update in-flight stream state so restoring the session
+            // after a switch-away keeps the upgraded attachments.
             state.messages = state.messages.map((m) =>
               m.role === "user" &&
               m.content === userMessage.content &&
               m.attachments &&
               !m.attachments[0]?.path
-                ? { ...m, attachments: result.attachments }
+                ? { ...m, attachments: resolvedAttachments }
                 : m,
+            );
+          }
+          if (isCurrentStream(activeStreamKey)) {
+            setMessages((prev) =>
+              prev.map((m) => (m === userMessage ? { ...m, attachments: resolvedAttachments } : m)),
             );
           }
         }
@@ -384,10 +403,15 @@ export function useChat(
             );
             clearConversationTimers(newConversationId);
             state.messages = [...state.messages, { role: "assistant", content: assistantMessage }];
-            setMessages(state.messages);
             activeStreamsRef.current.delete(newConversationId);
             sessionStreamsRef.current.delete(activeStreamKey);
-            setIsStreaming(false);
+            // Only mutate UI state when the viewed session owns this stream.
+            // Otherwise a background session finishing would set the active
+            // session's transcript to someone else's messages.
+            if (isCurrentStream(activeStreamKey)) {
+              setMessages(state.messages);
+              setIsStreaming(false);
+            }
           }, 100);
           fallbackTimersRef.current.set(newConversationId, fallbackTimer);
         }
@@ -409,53 +433,119 @@ export function useChat(
           clearConversationTimers(newConversationId);
           activeStreamsRef.current.delete(newConversationId);
           sessionStreamsRef.current.delete(activeStreamKey);
-          setIsStreaming(false);
+          if (isCurrentStream(activeStreamKey)) {
+            setIsStreaming(false);
+          }
         }, 500);
         forcedStopTimersRef.current.set(newConversationId, forcedStopTimer);
       } catch (err) {
         console.error("[useChat] Failed to send message:", err);
         clearConversationTimers(newConversationId);
-        // If the server aborted the run but already created a DB session, promote it
-        // so the fresh "new chat" doesn't lose its thread in the sidebar.
-        if (err instanceof ApiError && err.status === 409) {
-          const data = err.data as { code?: string; sessionId?: string | null } | null;
-          if (data?.code === "aborted" && data.sessionId) {
-            const resolvedId = data.sessionId;
-            currentSessionIdRef.current = resolvedId;
-            if (streamKey !== resolvedId) {
-              const state = sessionStreamsRef.current.get(streamKey);
-              if (state) {
-                sessionStreamsRef.current.delete(streamKey);
-                sessionStreamsRef.current.set(resolvedId, state);
-              }
-              activeStreamsRef.current.set(newConversationId, resolvedId);
+
+        const abortData =
+          err instanceof ApiError && err.status === 409
+            ? (err.data as {
+                code?: string;
+                sessionId?: string | null;
+                assistantMessage?: string | null;
+                attachments?: ChatMessageAttachment[];
+              } | null)
+            : null;
+        const isAbortedError = abortData?.code === "aborted";
+
+        // If the server aborted the run but already created a DB session, promote
+        // it so the fresh "new chat" doesn't lose its thread in the sidebar.
+        // Only switch the viewed session when the user is still on this stream —
+        // otherwise a background abort would yank them away from the session
+        // they're currently reading.
+        if (isAbortedError && abortData?.sessionId) {
+          const resolvedId = abortData.sessionId;
+          const shouldPromoteView = isCurrentStream(streamKey);
+          if (streamKey !== resolvedId) {
+            const state = sessionStreamsRef.current.get(streamKey);
+            if (state) {
+              sessionStreamsRef.current.delete(streamKey);
+              sessionStreamsRef.current.set(resolvedId, state);
             }
+            activeStreamsRef.current.set(newConversationId, resolvedId);
+          }
+          if (shouldPromoteView) {
+            currentSessionIdRef.current = resolvedId;
             if (resolvedId !== effectiveSessionId) {
               onSessionResolved?.(resolvedId);
             }
-            window.dispatchEvent(
-              new CustomEvent("chat:session_created", { detail: { id: resolvedId } }),
+          }
+          // Sidebar update is view-agnostic — always surface the new session.
+          window.dispatchEvent(
+            new CustomEvent("chat:session_created", { detail: { id: resolvedId } }),
+          );
+        }
+
+        const activeStreamKey = activeStreamsRef.current.get(newConversationId) ?? streamKey;
+        const state = sessionStreamsRef.current.get(activeStreamKey);
+        const errorHandled = state?.errorHandled ?? false;
+        const hasAccumulatedTokens = (state?.accumulator.length ?? 0) > 0;
+
+        // On abort, apply server-resolved data to the stream-scoped state before
+        // deleting it. Guards below then decide whether to mirror the changes
+        // into React state for the viewed session.
+        let patchedUserAttachments: ChatMessageAttachment[] | undefined;
+        let appendedPartialAssistant: string | null = null;
+        if (isAbortedError && state) {
+          if (abortData?.attachments?.length) {
+            const resolvedAttachments = abortData.attachments;
+            state.messages = state.messages.map((m) =>
+              m.role === "user" &&
+              m.content === userMessage.content &&
+              m.attachments &&
+              !m.attachments[0]?.path
+                ? { ...m, attachments: resolvedAttachments }
+                : m,
             );
+            patchedUserAttachments = resolvedAttachments;
+          }
+          if (
+            !hasAccumulatedTokens &&
+            typeof abortData?.assistantMessage === "string" &&
+            abortData.assistantMessage.trim().length > 0
+          ) {
+            appendedPartialAssistant = abortData.assistantMessage;
+            state.messages = [
+              ...state.messages,
+              { role: "assistant", content: appendedPartialAssistant },
+            ];
           }
         }
-        const activeStreamKey = activeStreamsRef.current.get(newConversationId) ?? streamKey;
+
         activeStreamsRef.current.delete(newConversationId);
-        const errorHandled = sessionStreamsRef.current.get(activeStreamKey)?.errorHandled ?? false;
         sessionStreamsRef.current.delete(activeStreamKey);
-        setIsStreaming(false);
+
         const wsHandled = handledErrorConversationsRef.current.has(newConversationId);
-        const isAbortedError =
-          err instanceof ApiError &&
-          err.status === 409 &&
-          (err.data as { code?: string } | null)?.code === "aborted";
-        if (isAbortedError) {
-          // Abort is surfaced via the banner only — no phantom bubble.
-          setChatErrorCode("aborted");
-        } else if (!errorHandled && !wsHandled) {
-          const message =
-            err instanceof Error ? err.message : "Failed to get a response. Please try again.";
-          setChatErrorCode(null);
-          setMessages((prev) => [...prev, { role: "assistant", content: message }]);
+        // All UI state mutations below end the run for the viewed session —
+        // gate them on isCurrentStream so a background conversation terminating
+        // can't hide Stop / flip the banner / inject messages into session B
+        // while the user is watching it.
+        if (isCurrentStream(activeStreamKey)) {
+          if (patchedUserAttachments) {
+            const resolved = patchedUserAttachments;
+            setMessages((prev) =>
+              prev.map((m) => (m === userMessage ? { ...m, attachments: resolved } : m)),
+            );
+          }
+          if (appendedPartialAssistant) {
+            const partial = appendedPartialAssistant;
+            setMessages((prev) => [...prev, { role: "assistant", content: partial }]);
+          }
+          setIsStreaming(false);
+          if (isAbortedError) {
+            // Abort is surfaced via the banner only — no phantom bubble.
+            setChatErrorCode("aborted");
+          } else if (!errorHandled && !wsHandled) {
+            const message =
+              err instanceof Error ? err.message : "Failed to get a response. Please try again.";
+            setChatErrorCode(null);
+            setMessages((prev) => [...prev, { role: "assistant", content: message }]);
+          }
         }
         handledErrorConversationsRef.current.delete(newConversationId);
       }
@@ -469,6 +559,7 @@ export function useChat(
       taskId,
       onSessionResolved,
       clearConversationTimers,
+      isCurrentStream,
     ],
   );
 

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -49,6 +49,8 @@ export function useChat(
   const [chatErrorCode, setChatErrorCode] = useState<string | null>(null);
   const currentSessionIdRef = useRef<string | null>(null);
 
+  // Conversation id of the most recently dispatched message — used by abortStream().
+  const currentConversationIdRef = useRef<string | null>(null);
   // Per-session streaming state: conversationId → streamKey (sessionId or conversationId)
   const activeStreamsRef = useRef<Map<string, string>>(new Map());
   // Per-session stream data: streamKey → state
@@ -275,6 +277,7 @@ export function useChat(
       const newMessages = forceNewSession ? [userMessage] : [...messages, userMessage];
 
       // Register active stream
+      currentConversationIdRef.current = newConversationId;
       if (!effectiveSessionId) {
         conversationIdForNoSession.current = newConversationId;
       }
@@ -434,6 +437,17 @@ export function useChat(
     ],
   );
 
+  const abortStream = useCallback(async () => {
+    const conversationId = currentConversationIdRef.current;
+    if (!conversationId) return;
+    console.debug("[useChat] aborting conversation %s", conversationId);
+    try {
+      await api.abortChat(conversationId);
+    } catch (err) {
+      console.warn("[useChat] abort request failed", err);
+    }
+  }, []);
+
   const clearMessages = useCallback(() => {
     setMessages([]);
     setChatErrorCode(null);
@@ -452,6 +466,7 @@ export function useChat(
     explore,
     setExplore,
     sendMessage,
+    abortStream,
     clearMessages,
     newSession,
   };

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -485,6 +485,8 @@ export function useChat(
         const state = sessionStreamsRef.current.get(activeStreamKey);
         const errorHandled = state?.errorHandled ?? false;
         const hasAccumulatedTokens = (state?.accumulator.length ?? 0) > 0;
+        const shouldRollbackOptimisticFirstTurn =
+          isAbortedError && !abortData?.sessionId && !effectiveSessionId;
 
         // On abort, apply server-resolved data to the stream-scoped state before
         // deleting it. Guards below then decide whether to mirror the changes
@@ -512,16 +514,16 @@ export function useChat(
             patchedUserAttachments = resolvedAttachments;
           }
           if (
-            state &&
-            !hasAccumulatedTokens &&
             typeof abortData?.assistantMessage === "string" &&
             abortData.assistantMessage.trim().length > 0
           ) {
             appendedPartialAssistant = abortData.assistantMessage;
-            state.messages = [
-              ...state.messages,
-              { role: "assistant", content: appendedPartialAssistant },
-            ];
+            if (state && !hasAccumulatedTokens) {
+              state.messages = [
+                ...state.messages,
+                { role: "assistant", content: appendedPartialAssistant },
+              ];
+            }
           }
         }
 
@@ -534,15 +536,26 @@ export function useChat(
         // can't hide Stop / flip the banner / inject messages into session B
         // while the user is watching it.
         if (isCurrentStream(activeStreamKey)) {
-          if (patchedUserAttachments) {
-            const resolved = patchedUserAttachments;
-            setMessages((prev) =>
-              prev.map((m) => (m === userMessage ? { ...m, attachments: resolved } : m)),
-            );
-          }
-          if (appendedPartialAssistant) {
-            const partial = appendedPartialAssistant;
-            setMessages((prev) => [...prev, { role: "assistant", content: partial }]);
+          if (shouldRollbackOptimisticFirstTurn) {
+            // First message in a brand-new chat was never persisted server-side.
+            // Roll back the optimistic bubble to avoid an orphan transcript.
+            setMessages([]);
+            conversationIdForNoSession.current = null;
+          } else {
+            if (patchedUserAttachments) {
+              const resolved = patchedUserAttachments;
+              setMessages((prev) =>
+                prev.map((m) => (m === userMessage ? { ...m, attachments: resolved } : m)),
+              );
+            }
+            if (appendedPartialAssistant) {
+              const partial = appendedPartialAssistant;
+              setMessages((prev) =>
+                prev.some((m) => m.role === "assistant" && m.content === partial)
+                  ? prev
+                  : [...prev, { role: "assistant", content: partial }],
+              );
+            }
           }
           setIsStreaming(false);
           if (isAbortedError) {

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -22,10 +22,12 @@ import type {
 
 export class ApiError extends Error {
   status: number;
-  constructor(message: string, status: number) {
+  data?: unknown;
+  constructor(message: string, status: number, data?: unknown) {
     super(message);
     this.name = "ApiError";
     this.status = status;
+    this.data = data;
   }
 }
 
@@ -147,7 +149,7 @@ async function request<T>(
         message = firstFieldError[0] ?? null;
       }
     }
-    throw new ApiError(message ?? `HTTP ${res.status}`, res.status);
+    throw new ApiError(message ?? `HTTP ${res.status}`, res.status, body);
   }
 
   return res.json();

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -403,6 +403,14 @@ export const api = {
     );
   },
 
+  async abortChat(conversationId: string): Promise<void> {
+    console.debug("[api] POST /chat/%s/abort", conversationId);
+    const res = await fetch(`${API_PREFIX}/chat/${conversationId}/abort`, { method: "POST" });
+    if (!res.ok && res.status !== 404) {
+      throw new Error(`Failed to abort chat: ${res.status}`);
+    }
+  },
+
   // Chat Sessions
   listChatSessions(projectId: string): Promise<ChatSession[]> {
     console.debug("[api] GET /chat/sessions projectId=%s", projectId);


### PR DESCRIPTION
## Summary

- Adds a Stop button to the chat input that replaces Send while a run is streaming. Clicking it aborts the underlying runtime call and unwinds the request cleanly.
- Backend keeps a `conversationId → AbortController` map, exposes `POST /chat/:conversationId/abort`, and classifies the thrown `AbortError` so aborted runs emit `chat:error` with code `"aborted"` (HTTP 409) instead of being reported as failures.
- Frontend hook exposes `abortStream()`, `ChatPanel` renders the Stop button (Square icon, destructive variant — composition of existing UI primitives, no new ones).

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test` — 232 API tests pass, including two new ones (404 for unknown conversation, full round-trip aborting an in-flight run)
- [x] `npm run format`
- [x] `npm run ai:validate`
- [ ] Manual verification: start a long run, press Stop, confirm the stream ends immediately and the UI reflects the aborted state.

## Notes

- Independent of #77 (AskUserQuestion rendering) — no conflicts.
- Honors `AbortController` on both Claude transports: SDK forwards the signal to `query()`, CLI kills the spawn.