### PR TITLE
feat: universal language directive injection for AI prompts

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -135,7 +135,7 @@ Keys:
 
 - `artifacts` — BCP-47-ish language code. Values are validated against a conservative
   `^[a-z]{2,3}(?:[-_][a-z0-9]{2,8})*$` pattern after trim+lowercase (both `-` and `_` are
-  accepted as subtag separators, so `en-US` and `en_GB` parse identically); tags that fail the
+  accepted as subtag separators, so `en-US` and `en_US` parse identically); tags that fail the
   pattern (typos, non-ASCII strings) silently fall back to the default `en` rather than being
   embedded raw in the system directive. Any regional tag whose primary subtag is `en` (`en-US`,
   `en_GB`, …) is also treated as a no-op. Any other valid tag appends a short system directive
@@ -386,7 +386,7 @@ The config is editable via the **Global Settings** dialog in the web UI (gear ic
 | Key               | Default | Options                                                                                                                                                                                                                       |
 | ----------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `ui`              | `en`    | Reserved for future UI localisation (currently informational).                                                                                                                                                                |
-| `artifacts`       | `en`    | BCP-47-ish tag, validated against `^[a-z]{2,3}(?:[-_][a-z0-9]{2,8})*$` after trim+lowercase. `-` and `_` are interchangeable separators (`en-US` == `en_GB`). Any `en*` primary subtag and invalid tags are treated as no-op. |
+| `artifacts`       | `en`    | BCP-47-ish tag, validated against `^[a-z]{2,3}(?:[-_][a-z0-9]{2,8})*$` after trim+lowercase. `-` and `_` are interchangeable separators (`en-US` == `en_US`). Any `en*` primary subtag and invalid tags are treated as no-op. |
 | `technical_terms` | `keep`  | `keep`, `translate`                                                                                                                                                                                                           |
 
 **`paths`** — custom paths for AI Factory artifacts (relative to project root):

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,12 +146,13 @@ Keys:
   of those tokens where a good equivalent exists.
 - `ui` — reserved for future UI-side localisation; currently informational only.
 
-The directive is appended to `execution.systemPromptAppend` — never to `prompt` — so resume
-sessions, slash commands, and agent definitions continue to work unchanged. Existing appends
-(project-scope, review-diff-scope) are preserved verbatim and placed BEFORE the language
-directive so scope rules keep their emphasis.
+Injection is uniform at the registry layer: the directive is written to
+`execution.systemPromptAppend` (never to `input.prompt`), so resume sessions, slash commands,
+and agent definitions continue to work unchanged. Existing appends (project-scope,
+review-diff-scope) are preserved verbatim and placed BEFORE the language directive so scope
+rules keep their emphasis.
 
-Transport delivery matrix (how each adapter surfaces `systemPromptAppend` to the model):
+How each adapter then delivers that append block to the model depends on the transport:
 
 | Adapter    | SDK                          | CLI                      | API            |
 | ---------- | ---------------------------- | ------------------------ | -------------- |
@@ -161,8 +162,10 @@ Transport delivery matrix (how each adapter surfaces `systemPromptAppend` to the
 | OpenCode   | n/a                          | n/a                      | system message |
 
 The Codex SDK/CLI paths do not expose a dedicated system-prompt slot, so the adapter prepends
-the append block to the user prompt separated by a blank line. This keeps the registry-level
-injection guaranteed to reach the model on every Codex transport, matching the API path.
+the append block to the user prompt separated by a blank line. That happens inside the
+adapter, after the registry has set `systemPromptAppend` — the caller and the registry never
+mutate `input.prompt` themselves. This keeps the registry-level injection guaranteed to reach
+the model on every Codex transport, matching the API path.
 
 To disable: leave `artifacts: en` (the default).
 
@@ -378,13 +381,13 @@ The config is editable via the **Global Settings** dialog in the web UI (gear ic
 
 ### Sections
 
-**`language`** — controls AI-generated content language:
+**`language`** — controls AI-generated content language. See [Project Language](#project-language) for the full directive contract, validation rules, and per-transport delivery matrix:
 
-| Key               | Default | Options                                                    |
-| ----------------- | ------- | ---------------------------------------------------------- |
-| `ui`              | `en`    | `en`, `ru`, `de`, `fr`, `es`, `zh`, `ja`, `ko`, `pt`, `it` |
-| `artifacts`       | `en`    | Same as `ui`                                               |
-| `technical_terms` | `keep`  | `keep`, `translate`                                        |
+| Key               | Default | Options                                                                                                                                                                                                                       |
+| ----------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ui`              | `en`    | Reserved for future UI localisation (currently informational).                                                                                                                                                                |
+| `artifacts`       | `en`    | BCP-47-ish tag, validated against `^[a-z]{2,3}(?:[-_][a-z0-9]{2,8})*$` after trim+lowercase. `-` and `_` are interchangeable separators (`en-US` == `en_GB`). Any `en*` primary subtag and invalid tags are treated as no-op. |
+| `technical_terms` | `keep`  | `keep`, `translate`                                                                                                                                                                                                           |
 
 **`paths`** — custom paths for AI Factory artifacts (relative to project root):
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -134,11 +134,12 @@ language:
 Keys:
 
 - `artifacts` — BCP-47-ish language code. Values are validated against a conservative
-  `^[a-z]{2,3}(-[a-z0-9]{2,8})*$` pattern after trim+lowercase; tags that fail the pattern
-  (typos, non-ASCII strings) silently fall back to the default `en` rather than being embedded
-  raw in the system directive. Any regional tag whose primary subtag is `en` (`en-US`, `en_GB`,
-  …) is also treated as a no-op. Any other valid tag appends a short system directive asking
-  the model to write artifacts in that language.
+  `^[a-z]{2,3}(?:[-_][a-z0-9]{2,8})*$` pattern after trim+lowercase (both `-` and `_` are
+  accepted as subtag separators, so `en-US` and `en_GB` parse identically); tags that fail the
+  pattern (typos, non-ASCII strings) silently fall back to the default `en` rather than being
+  embedded raw in the system directive. Any regional tag whose primary subtag is `en` (`en-US`,
+  `en_GB`, …) is also treated as a no-op. Any other valid tag appends a short system directive
+  asking the model to write artifacts in that language.
 - `technical_terms` — `keep` (default) instructs the model to leave identifiers, API/function
   names, file paths, CLI flags, environment variables, code snippets, and log/error strings in
   English even when the rest of the text is translated. `translate` allows natural translation

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -133,9 +133,12 @@ language:
 
 Keys:
 
-- `artifacts` — BCP-47-ish language code. `en` (or unset) leaves prompts untouched so the model
-  uses its native default. Any other value appends a short system directive asking the model to
-  write artifacts in that language.
+- `artifacts` — BCP-47-ish language code. Values are validated against a conservative
+  `^[a-z]{2,3}(-[a-z0-9]{2,8})*$` pattern after trim+lowercase; tags that fail the pattern
+  (typos, non-ASCII strings) silently fall back to the default `en` rather than being embedded
+  raw in the system directive. Any regional tag whose primary subtag is `en` (`en-US`, `en_GB`,
+  …) is also treated as a no-op. Any other valid tag appends a short system directive asking
+  the model to write artifacts in that language.
 - `technical_terms` — `keep` (default) instructs the model to leave identifiers, API/function
   names, file paths, CLI flags, environment variables, code snippets, and log/error strings in
   English even when the rest of the text is translated. `translate` allows natural translation
@@ -146,6 +149,19 @@ The directive is appended to `execution.systemPromptAppend` — never to `prompt
 sessions, slash commands, and agent definitions continue to work unchanged. Existing appends
 (project-scope, review-diff-scope) are preserved verbatim and placed BEFORE the language
 directive so scope rules keep their emphasis.
+
+Transport delivery matrix (how each adapter surfaces `systemPromptAppend` to the model):
+
+| Adapter    | SDK                          | CLI                      | API            |
+| ---------- | ---------------------------- | ------------------------ | -------------- |
+| Claude     | `options.systemPromptAppend` | `--append-system-prompt` | n/a            |
+| Codex      | prepended to user prompt     | prepended to CLI stdin   | system message |
+| OpenRouter | n/a                          | n/a                      | system message |
+| OpenCode   | n/a                          | n/a                      | system message |
+
+The Codex SDK/CLI paths do not expose a dedicated system-prompt slot, so the adapter prepends
+the append block to the user prompt separated by a blank line. This keeps the registry-level
+injection guaranteed to reach the model on every Codex transport, matching the API path.
 
 To disable: leave `artifacts: en` (the default).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -114,6 +114,41 @@ Only non-secret fields are persisted (`baseUrl`, `apiKeyEnvVar`, headers/options
 
 For concrete profile payloads and adapter capability differences, see [Providers](providers.md).
 
+## Project Language
+
+`.ai-factory/config.yaml` carries a `language` block that controls the language AI produces for
+generated artifacts (task descriptions, plans, review notes, commit messages, roadmap items,
+chat replies). The setting is wired through a single injection point in the runtime registry
+(`packages/runtime/src/registry.ts` — `wrapAdapter`), so every call path — subagents, roadmap
+generation, fast-fix, commit generation, reviewGate, chat — picks it up automatically across
+all transports (SDK/CLI/API).
+
+```yaml
+# .ai-factory/config.yaml
+language:
+  ui: en # reserved for future UI localisation (currently informational)
+  artifacts: ru # language for AI-produced artifacts; "en" (default) disables injection
+  technical_terms: keep # "keep" or "translate"
+```
+
+Keys:
+
+- `artifacts` — BCP-47-ish language code. `en` (or unset) leaves prompts untouched so the model
+  uses its native default. Any other value appends a short system directive asking the model to
+  write artifacts in that language.
+- `technical_terms` — `keep` (default) instructs the model to leave identifiers, API/function
+  names, file paths, CLI flags, environment variables, code snippets, and log/error strings in
+  English even when the rest of the text is translated. `translate` allows natural translation
+  of those tokens where a good equivalent exists.
+- `ui` — reserved for future UI-side localisation; currently informational only.
+
+The directive is appended to `execution.systemPromptAppend` — never to `prompt` — so resume
+sessions, slash commands, and agent definitions continue to work unchanged. Existing appends
+(project-scope, review-diff-scope) are preserved verbatim and placed BEFORE the language
+directive so scope rules keep their emphasis.
+
+To disable: leave `artifacts: en` (the default).
+
 ## Database
 
 The database is a single SQLite file. The default path `./data/aif.sqlite` is relative to the project root.

--- a/packages/runtime/src/__tests__/codexCli.test.ts
+++ b/packages/runtime/src/__tests__/codexCli.test.ts
@@ -167,6 +167,26 @@ describe("codex cli transport", () => {
     await runPromise;
   });
 
+  it("still writes prompt to stdin on default path when the prompt collides with a generic arg token", async () => {
+    // Regression: on the default path `args` always contain generic tokens
+    // like `exec`, `--json`, or the model id. A prompt that happens to equal
+    // one of those must NOT be treated as "already embedded" — otherwise the
+    // user's prompt would never reach the CLI. Only the explicit {prompt} /
+    // --prompt placeholder signals are allowed to suppress stdin.
+    const child = createMockChildProcess();
+    spawnMock.mockReturnValueOnce(child);
+
+    const runPromise = runCodexCli(createRunInput({ prompt: "exec" }));
+
+    const { cliArgs: args } = getSpawnInvocation();
+    expect(args).toContain("exec");
+    expect(child.stdin.write).toHaveBeenCalledWith("exec");
+
+    child.stdout.emit("data", "ok");
+    child.emit("close", 0);
+    await runPromise;
+  });
+
   it("skips stdin when {prompt} placeholder is embedded inside a composite arg", async () => {
     // Guards against the edge case where `{prompt}` sits inside an arbitrary
     // flag shape (e.g. `--payload=prefix {prompt} suffix`). The substitution

--- a/packages/runtime/src/__tests__/codexCli.test.ts
+++ b/packages/runtime/src/__tests__/codexCli.test.ts
@@ -167,6 +167,38 @@ describe("codex cli transport", () => {
     await runPromise;
   });
 
+  it("skips stdin when {prompt} placeholder is embedded inside a composite arg", async () => {
+    // Guards against the edge case where `{prompt}` sits inside an arbitrary
+    // flag shape (e.g. `--payload=prefix {prompt} suffix`). The substitution
+    // consumes the literal `{prompt}` token, so the stdin suppressor must
+    // rely on a pre-substitution signal — otherwise the composed prompt would
+    // be delivered twice (once inside the arg, once via stdin).
+    const child = createMockChildProcess();
+    spawnMock.mockReturnValueOnce(child);
+
+    const runPromise = runCodexCli(
+      createRunInput({
+        execution: { systemPromptAppend: "Language policy: write in Russian." },
+        options: {
+          codexCliArgs: ["run", "--json", "--payload=prefix {prompt} suffix"],
+        },
+      }),
+    );
+
+    const { cliArgs: args } = getSpawnInvocation();
+    expect(args).toEqual([
+      "run",
+      "--json",
+      "--payload=prefix Language policy: write in Russian.\n\nImplement feature suffix",
+    ]);
+    expect(child.stdin.write).not.toHaveBeenCalled();
+
+    child.stdout.emit("data", "ok");
+    child.emit("close", 0);
+
+    await runPromise;
+  });
+
   it("uses exec resume subcommand when resume and sessionId are set", async () => {
     const child = createMockChildProcess();
     spawnMock.mockReturnValueOnce(child);

--- a/packages/runtime/src/__tests__/codexCli.test.ts
+++ b/packages/runtime/src/__tests__/codexCli.test.ts
@@ -95,6 +95,26 @@ describe("codex cli transport", () => {
     expect(result.raw).toBe("plain output");
   });
 
+  it("prepends execution.systemPromptAppend to stdin prompt (no --system-prompt CLI flag)", async () => {
+    const child = createMockChildProcess();
+    spawnMock.mockReturnValueOnce(child);
+
+    const runPromise = runCodexCli(
+      createRunInput({
+        execution: { systemPromptAppend: "Language policy: write in Russian." },
+      }),
+    );
+
+    expect(child.stdin.write).toHaveBeenCalledWith(
+      "Language policy: write in Russian.\n\nImplement feature",
+    );
+
+    child.stdout.emit("data", "plain output");
+    child.emit("close", 0);
+
+    await runPromise;
+  });
+
   it("uses exec resume subcommand when resume and sessionId are set", async () => {
     const child = createMockChildProcess();
     spawnMock.mockReturnValueOnce(child);

--- a/packages/runtime/src/__tests__/codexCli.test.ts
+++ b/packages/runtime/src/__tests__/codexCli.test.ts
@@ -115,6 +115,58 @@ describe("codex cli transport", () => {
     await runPromise;
   });
 
+  it("prepends execution.systemPromptAppend to resume stdin prompt (resume path)", async () => {
+    const child = createMockChildProcess();
+    spawnMock.mockReturnValueOnce(child);
+
+    const runPromise = runCodexCli(
+      createRunInput({
+        resume: true,
+        sessionId: "thread-resume",
+        execution: { systemPromptAppend: "Language policy: write in Russian." },
+      }),
+    );
+
+    const { cliArgs: args } = getSpawnInvocation();
+    expect(args.slice(0, 3)).toEqual(["exec", "resume", "thread-resume"]);
+    expect(child.stdin.write).toHaveBeenCalledWith(
+      "Language policy: write in Russian.\n\nImplement feature",
+    );
+
+    child.stdout.emit("data", "resumed output");
+    child.emit("close", 0);
+
+    await runPromise;
+  });
+
+  it("injects systemPromptAppend into custom codexCliArgs {prompt} placeholder and skips stdin", async () => {
+    const child = createMockChildProcess();
+    spawnMock.mockReturnValueOnce(child);
+
+    const runPromise = runCodexCli(
+      createRunInput({
+        execution: { systemPromptAppend: "Language policy: write in Russian." },
+        options: {
+          codexCliArgs: ["run", "--json", "--prompt={prompt}"],
+        },
+      }),
+    );
+
+    const { cliArgs: args } = getSpawnInvocation();
+    expect(args).toEqual([
+      "run",
+      "--json",
+      "--prompt=Language policy: write in Russian.\n\nImplement feature",
+    ]);
+    // Prompt was embedded via {prompt} → stdin must not receive it again.
+    expect(child.stdin.write).not.toHaveBeenCalled();
+
+    child.stdout.emit("data", "ok");
+    child.emit("close", 0);
+
+    await runPromise;
+  });
+
   it("uses exec resume subcommand when resume and sessionId are set", async () => {
     const child = createMockChildProcess();
     spawnMock.mockReturnValueOnce(child);

--- a/packages/runtime/src/__tests__/codexSdk.test.ts
+++ b/packages/runtime/src/__tests__/codexSdk.test.ts
@@ -477,6 +477,33 @@ describe("runCodexSdk", () => {
     );
   });
 
+  it("prepends execution.systemPromptAppend to the resumed thread's prompt", async () => {
+    mockRunStreamed.mockResolvedValue({
+      events: createMockEvents([
+        { type: "thread.started", thread_id: "thread-resume-sysappend" },
+        {
+          type: "turn.completed",
+          usage: { input_tokens: 0, output_tokens: 0, cached_input_tokens: 0 },
+        },
+      ]),
+    });
+
+    await runCodexSdk(
+      createRunInput({
+        resume: true,
+        sessionId: "thread-old",
+        prompt: "Continue feature",
+        execution: { systemPromptAppend: "Language policy: write in Russian." },
+      }),
+    );
+
+    expect(mockResumeThread).toHaveBeenCalledWith("thread-old", expect.any(Object));
+    expect(mockRunStreamed).toHaveBeenCalledWith(
+      "Language policy: write in Russian.\n\nContinue feature",
+      expect.any(Object),
+    );
+  });
+
   it("leaves the prompt untouched when systemPromptAppend is absent", async () => {
     mockRunStreamed.mockResolvedValue({
       events: createMockEvents([

--- a/packages/runtime/src/__tests__/codexSdk.test.ts
+++ b/packages/runtime/src/__tests__/codexSdk.test.ts
@@ -453,6 +453,46 @@ describe("runCodexSdk", () => {
     expect(constructorOptions.env?.npm_config_registry).toBeUndefined();
   });
 
+  it("prepends execution.systemPromptAppend to the user prompt (no native system slot on Thread)", async () => {
+    mockRunStreamed.mockResolvedValue({
+      events: createMockEvents([
+        { type: "thread.started", thread_id: "thread-sysappend" },
+        {
+          type: "turn.completed",
+          usage: { input_tokens: 0, output_tokens: 0, cached_input_tokens: 0 },
+        },
+      ]),
+    });
+
+    await runCodexSdk(
+      createRunInput({
+        prompt: "Implement feature",
+        execution: { systemPromptAppend: "Language policy: write in Russian." },
+      }),
+    );
+
+    expect(mockRunStreamed).toHaveBeenCalledWith(
+      "Language policy: write in Russian.\n\nImplement feature",
+      expect.any(Object),
+    );
+  });
+
+  it("leaves the prompt untouched when systemPromptAppend is absent", async () => {
+    mockRunStreamed.mockResolvedValue({
+      events: createMockEvents([
+        { type: "thread.started", thread_id: "thread-no-sysappend" },
+        {
+          type: "turn.completed",
+          usage: { input_tokens: 0, output_tokens: 0, cached_input_tokens: 0 },
+        },
+      ]),
+    });
+
+    await runCodexSdk(createRunInput({ prompt: "Implement feature" }));
+
+    expect(mockRunStreamed).toHaveBeenCalledWith("Implement feature", expect.any(Object));
+  });
+
   it("warns and falls back to stable defaults when thread permission overrides are invalid", async () => {
     const logger = {
       debug: vi.fn(),

--- a/packages/runtime/src/__tests__/languagePolicy.test.ts
+++ b/packages/runtime/src/__tests__/languagePolicy.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { buildLanguageDirective } from "../languagePolicy.js";
+
+describe("buildLanguageDirective", () => {
+  it("returns empty string for artifacts=en", () => {
+    expect(buildLanguageDirective({ artifacts: "en", technicalTerms: "keep" })).toBe("");
+  });
+
+  it("returns empty string for undefined artifacts", () => {
+    expect(buildLanguageDirective({ artifacts: undefined, technicalTerms: "keep" })).toBe("");
+  });
+
+  it("returns empty string for null artifacts", () => {
+    expect(buildLanguageDirective({ artifacts: null, technicalTerms: "keep" })).toBe("");
+  });
+
+  it("returns empty string for whitespace-only artifacts", () => {
+    expect(buildLanguageDirective({ artifacts: "   ", technicalTerms: "keep" })).toBe("");
+  });
+
+  it("includes Russian language and keep-identifiers rule when artifacts=ru & technical_terms=keep", () => {
+    const out = buildLanguageDirective({ artifacts: "ru", technicalTerms: "keep" });
+    expect(out).toContain("Russian");
+    expect(out).toContain("русском");
+    expect(out).toContain("identifiers");
+    expect(out).toContain("file paths");
+    expect(out).toContain("CLI flags");
+  });
+
+  it("omits keep-identifiers rule when technical_terms=translate", () => {
+    const out = buildLanguageDirective({ artifacts: "fr", technicalTerms: "translate" });
+    expect(out).toContain("French");
+    expect(out).not.toContain("Keep technical tokens in English");
+    expect(out).toContain("translated where a natural equivalent");
+  });
+
+  it("resolves uppercase codes case-insensitively", () => {
+    const out = buildLanguageDirective({ artifacts: "RU", technicalTerms: "keep" });
+    expect(out).toContain("Russian");
+  });
+
+  it("handles BCP-47-style region subtags by using the primary code", () => {
+    const out = buildLanguageDirective({ artifacts: "pt-BR", technicalTerms: "keep" });
+    expect(out).toContain("Portuguese");
+  });
+
+  it("falls back to the raw code when the language is not in the lookup table", () => {
+    const out = buildLanguageDirective({ artifacts: "eo", technicalTerms: "keep" });
+    // Empty directive would only happen for en/unset; unknown codes still produce a directive.
+    expect(out).toContain("eo");
+    expect(out).toContain("Language policy");
+  });
+});

--- a/packages/runtime/src/__tests__/languagePolicy.test.ts
+++ b/packages/runtime/src/__tests__/languagePolicy.test.ts
@@ -44,6 +44,14 @@ describe("buildLanguageDirective", () => {
     expect(out).toContain("Portuguese");
   });
 
+  it("treats en-US as a no-op (primary subtag check)", () => {
+    expect(buildLanguageDirective({ artifacts: "en-US", technicalTerms: "keep" })).toBe("");
+  });
+
+  it("treats en_GB as a no-op (primary subtag check, underscore separator)", () => {
+    expect(buildLanguageDirective({ artifacts: "en_GB", technicalTerms: "keep" })).toBe("");
+  });
+
   it("falls back to the raw code when the language is not in the lookup table", () => {
     const out = buildLanguageDirective({ artifacts: "eo", technicalTerms: "keep" });
     // Empty directive would only happen for en/unset; unknown codes still produce a directive.

--- a/packages/runtime/src/__tests__/registry.test.ts
+++ b/packages/runtime/src/__tests__/registry.test.ts
@@ -586,3 +586,137 @@ describe("runtime error classes", () => {
     expect(load.code).toBe("RUNTIME_MODULE_LOAD_ERROR");
   });
 });
+
+describe("Language directive injection", () => {
+  async function setupTempProject(languageBlock: string | null): Promise<string> {
+    const { mkdtempSync, mkdirSync, writeFileSync } = await import("node:fs");
+    const root = mkdtempSync(join(tmpdir(), "registry-lang-test-"));
+    mkdirSync(join(root, ".ai-factory"), { recursive: true });
+    if (languageBlock !== null) {
+      writeFileSync(join(root, ".ai-factory", "config.yaml"), languageBlock);
+    }
+    const { clearProjectConfigCache } = await import("@aif/shared");
+    clearProjectConfigCache();
+    return root;
+  }
+
+  function createCapturingAdapter(): {
+    adapter: RuntimeAdapter;
+    captured: { run: string | undefined; resume: string | undefined };
+  } {
+    const captured = {
+      run: undefined as string | undefined,
+      resume: undefined as string | undefined,
+    };
+    const adapter: RuntimeAdapter = {
+      descriptor: {
+        id: "capture",
+        providerId: "capture-provider",
+        displayName: "Capture",
+        capabilities: { ...DEFAULT_RUNTIME_CAPABILITIES, supportsResume: true },
+      },
+      async run(input) {
+        captured.run = input.execution?.systemPromptAppend;
+        return { outputText: "ok", usage: null };
+      },
+      async resume(input) {
+        captured.resume = input.execution?.systemPromptAppend;
+        return { outputText: "ok", usage: null };
+      },
+    };
+    return { adapter, captured };
+  }
+
+  function buildRunInput(projectRoot: string | undefined, existingAppend?: string) {
+    return {
+      runtimeId: "capture",
+      providerId: "capture-provider",
+      profileId: null,
+      workflowKind: "test",
+      transport: "sdk" as const,
+      prompt: "hello",
+      projectRoot,
+      execution: existingAppend ? { systemPromptAppend: existingAppend } : undefined,
+      usageContext: TEST_USAGE_CONTEXT,
+    };
+  }
+
+  it("appends directive to systemPromptAppend when artifacts=ru", async () => {
+    const root = await setupTempProject("language:\n  artifacts: ru\n");
+    const { adapter, captured } = createCapturingAdapter();
+    const registry = createRuntimeRegistry({ builtInAdapters: [adapter] });
+    const wrapped = registry.resolveRuntime("capture");
+
+    await wrapped.run(buildRunInput(root, "PROJECT SCOPE RULE"));
+
+    expect(captured.run).toBeDefined();
+    expect(captured.run).toMatch(/^PROJECT SCOPE RULE\n\n/);
+    expect(captured.run).toContain("Russian");
+    expect(captured.run).toContain("identifiers");
+  });
+
+  it("injects directive with no existing systemPromptAppend", async () => {
+    const root = await setupTempProject("language:\n  artifacts: ru\n");
+    const { adapter, captured } = createCapturingAdapter();
+    const registry = createRuntimeRegistry({ builtInAdapters: [adapter] });
+    const wrapped = registry.resolveRuntime("capture");
+
+    await wrapped.run(buildRunInput(root));
+
+    expect(captured.run).toBeDefined();
+    expect(captured.run).toContain("Russian");
+    expect(captured.run).not.toMatch(/^\n\n/);
+  });
+
+  it("does not modify systemPromptAppend when artifacts=en", async () => {
+    const root = await setupTempProject("language:\n  artifacts: en\n");
+    const { adapter, captured } = createCapturingAdapter();
+    const registry = createRuntimeRegistry({ builtInAdapters: [adapter] });
+    const wrapped = registry.resolveRuntime("capture");
+
+    await wrapped.run(buildRunInput(root, "SCOPE RULE"));
+
+    expect(captured.run).toBe("SCOPE RULE");
+  });
+
+  it("skips injection when projectRoot is missing", async () => {
+    const { adapter, captured } = createCapturingAdapter();
+    const registry = createRuntimeRegistry({ builtInAdapters: [adapter] });
+    const wrapped = registry.resolveRuntime("capture");
+
+    await wrapped.run(buildRunInput(undefined, "SCOPE"));
+
+    expect(captured.run).toBe("SCOPE");
+  });
+
+  it("also injects on resume()", async () => {
+    const root = await setupTempProject("language:\n  artifacts: ru\n");
+    const { adapter, captured } = createCapturingAdapter();
+    const registry = createRuntimeRegistry({ builtInAdapters: [adapter] });
+    const wrapped = registry.resolveRuntime("capture");
+
+    await wrapped.resume!({ ...buildRunInput(root, "S"), sessionId: "sid-1" });
+
+    expect(captured.resume).toBeDefined();
+    expect(captured.resume).toContain("Russian");
+    expect(captured.resume).toMatch(/^S\n\n/);
+  });
+
+  it("does not throw and logs WARN when config read fails", async () => {
+    // Point projectRoot at a path where config.yaml exists but is unreadable
+    // garbage — YAML.parse will blow up and we should swallow + warn.
+    const root = await setupTempProject(":::not yaml::\n  - [");
+    const { adapter, captured } = createCapturingAdapter();
+    const logger = { debug: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const registry = createRuntimeRegistry({ logger, builtInAdapters: [adapter] });
+    const wrapped = registry.resolveRuntime("capture");
+
+    await expect(wrapped.run(buildRunInput(root, "EXISTING"))).resolves.toBeDefined();
+
+    expect(captured.run).toBe("EXISTING");
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ runtimeId: "capture" }),
+      expect.stringContaining("skipping language directive"),
+    );
+  });
+});

--- a/packages/runtime/src/adapters/codex/cli.ts
+++ b/packages/runtime/src/adapters/codex/cli.ts
@@ -705,7 +705,13 @@ function runCodexCliAttempt(
     // Ignore broken-pipe errors — the child may exit before stdin is fully written
   });
   if (shouldWritePromptToStdin(args, input.prompt)) {
-    child.stdin!.write(input.prompt);
+    // The Codex CLI consumes a single prompt blob from stdin with no separate
+    // system-prompt flag, so `execution.systemPromptAppend` (carrying the
+    // registry's language directive among other cross-cutting appends) is
+    // prepended to the user prompt to keep parity with the API transport.
+    const systemAppend = execution?.systemPromptAppend?.trim();
+    const composedPrompt = systemAppend ? `${systemAppend}\n\n${input.prompt}` : input.prompt;
+    child.stdin!.write(composedPrompt);
   }
   child.stdin!.end();
 

--- a/packages/runtime/src/adapters/codex/cli.ts
+++ b/packages/runtime/src/adapters/codex/cli.ts
@@ -127,14 +127,23 @@ function readStringArray(value: unknown): string[] | null {
   return parsed.length > 0 ? parsed : null;
 }
 
-function normalizeCliArgs(input: RuntimeRunInput, logger?: CodexCliLogger): string[] {
+function normalizeCliArgs(
+  input: RuntimeRunInput,
+  effectivePrompt: string,
+  logger?: CodexCliLogger,
+): string[] {
   const options = asRecord(input.options);
   const configured = readStringArray(options.codexCliArgs);
 
-  // Custom args — apply template substitutions
+  // Custom args — apply template substitutions.
+  //
+  // `effectivePrompt` already carries `execution.systemPromptAppend`
+  // prepended by `composePrompt()` so the registry's language directive
+  // (and any other cross-cutting append) reaches the model via the
+  // `{prompt}` placeholder too — not only through the default stdin path.
   if (configured) {
     return configured.map((arg) => {
-      if (arg.includes("{prompt}")) return arg.replaceAll("{prompt}", input.prompt);
+      if (arg.includes("{prompt}")) return arg.replaceAll("{prompt}", effectivePrompt);
       if (arg.includes("{model}")) return arg.replaceAll("{model}", input.model ?? "");
       if (arg.includes("{session_id}"))
         return arg.replaceAll("{session_id}", input.sessionId ?? "");
@@ -621,6 +630,22 @@ function finalizeCodexResult(
   };
 }
 
+/**
+ * Compose the prompt that actually reaches the model: `systemPromptAppend`
+ * (registry-injected language directive + any other cross-cutting appends)
+ * prepended to `input.prompt`, separated by a blank line.
+ *
+ * The Codex CLI has no dedicated system-prompt slot, so this is the only way
+ * to deliver `execution.systemPromptAppend` to the model. Computing it once
+ * at the top of the run and threading it through both template substitution
+ * and stdin write keeps delivery guarantees uniform across the default path
+ * AND custom `codexCliArgs` escape hatches that use `{prompt}`.
+ */
+function composePrompt(input: RuntimeRunInput): string {
+  const append = input.execution?.systemPromptAppend?.trim();
+  return append ? `${append}\n\n${input.prompt}` : input.prompt;
+}
+
 function shouldWritePromptToStdin(args: string[], prompt: string): boolean {
   if (prompt && args.includes(prompt)) {
     return false;
@@ -647,6 +672,7 @@ function runCodexCliAttempt(
   cliPath: string,
   args: string[],
   env: Record<string, string>,
+  composedPrompt: string,
   logger?: CodexCliLogger,
 ): Promise<{ result: RuntimeRunResult; startTimedOut: boolean }> {
   const execution = input.execution;
@@ -704,13 +730,12 @@ function runCodexCliAttempt(
   child.stdin!.on("error", () => {
     // Ignore broken-pipe errors — the child may exit before stdin is fully written
   });
-  if (shouldWritePromptToStdin(args, input.prompt)) {
-    // The Codex CLI consumes a single prompt blob from stdin with no separate
-    // system-prompt flag, so `execution.systemPromptAppend` (carrying the
-    // registry's language directive among other cross-cutting appends) is
-    // prepended to the user prompt to keep parity with the API transport.
-    const systemAppend = execution?.systemPromptAppend?.trim();
-    const composedPrompt = systemAppend ? `${systemAppend}\n\n${input.prompt}` : input.prompt;
+  // `composedPrompt` already includes `execution.systemPromptAppend`
+  // prepended to the user prompt (see `composePrompt()`). When custom
+  // `codexCliArgs` embed the prompt via `{prompt}` or `--prompt`, the same
+  // value was substituted into `args`, so `shouldWritePromptToStdin()` skips
+  // stdin here to avoid sending the prompt twice.
+  if (shouldWritePromptToStdin(args, composedPrompt)) {
     child.stdin!.write(composedPrompt);
   }
   child.stdin!.end();
@@ -775,7 +800,12 @@ export async function runCodexCli(
   logger?: CodexCliLogger,
 ): Promise<RuntimeRunResult> {
   const cliPath = resolveCliPath(input);
-  const args = normalizeCliArgs(input, logger);
+  // Compose once so the same prompt (systemPromptAppend + user prompt) is
+  // used for both template substitution in `codexCliArgs` and the stdin
+  // fallback — otherwise a custom `--prompt={prompt}` would silently drop
+  // the language directive the registry attached via `systemPromptAppend`.
+  const composedPrompt = composePrompt(input);
+  const args = normalizeCliArgs(input, composedPrompt, logger);
   const options = asRecord(input.options);
   const apiKeyEnvVar =
     typeof options.apiKeyEnvVar === "string" ? options.apiKeyEnvVar : "OPENAI_API_KEY";
@@ -815,7 +845,14 @@ export async function runCodexCli(
     "Starting Codex CLI run",
   );
 
-  const { result, startTimedOut } = await runCodexCliAttempt(input, cliPath, args, env, logger);
+  const { result, startTimedOut } = await runCodexCliAttempt(
+    input,
+    cliPath,
+    args,
+    env,
+    composedPrompt,
+    logger,
+  );
 
   if (startTimedOut) {
     const retryDelayMs = resolveRetryDelay(input.execution ?? {});
@@ -825,7 +862,7 @@ export async function runCodexCli(
     );
     await sleepMs(retryDelayMs);
 
-    const retry = await runCodexCliAttempt(input, cliPath, args, env, logger);
+    const retry = await runCodexCliAttempt(input, cliPath, args, env, composedPrompt, logger);
     if (retry.startTimedOut) {
       throw makeProcessStartTimeoutError(input.execution?.startTimeoutMs ?? 0);
     }

--- a/packages/runtime/src/adapters/codex/cli.ts
+++ b/packages/runtime/src/adapters/codex/cli.ts
@@ -127,11 +127,23 @@ function readStringArray(value: unknown): string[] | null {
   return parsed.length > 0 ? parsed : null;
 }
 
+interface NormalizedCliArgs {
+  args: string[];
+  /**
+   * True when the configured custom `codexCliArgs` embedded the prompt via a
+   * `{prompt}` placeholder anywhere in any arg (including composite shapes
+   * like `--payload=prefix {prompt} suffix`). Tracked pre-substitution — the
+   * literal `{prompt}` token is gone from `args` after `normalizeCliArgs()`
+   * returns, so the flag is the only reliable signal for the stdin suppressor.
+   */
+  usesPromptPlaceholder: boolean;
+}
+
 function normalizeCliArgs(
   input: RuntimeRunInput,
   effectivePrompt: string,
   logger?: CodexCliLogger,
-): string[] {
+): NormalizedCliArgs {
   const options = asRecord(input.options);
   const configured = readStringArray(options.codexCliArgs);
 
@@ -142,13 +154,18 @@ function normalizeCliArgs(
   // (and any other cross-cutting append) reaches the model via the
   // `{prompt}` placeholder too — not only through the default stdin path.
   if (configured) {
-    return configured.map((arg) => {
-      if (arg.includes("{prompt}")) return arg.replaceAll("{prompt}", effectivePrompt);
+    let usesPromptPlaceholder = false;
+    const args = configured.map((arg) => {
+      if (arg.includes("{prompt}")) {
+        usesPromptPlaceholder = true;
+        return arg.replaceAll("{prompt}", effectivePrompt);
+      }
       if (arg.includes("{model}")) return arg.replaceAll("{model}", input.model ?? "");
       if (arg.includes("{session_id}"))
         return arg.replaceAll("{session_id}", input.sessionId ?? "");
       return arg;
     });
+    return { args, usesPromptPlaceholder };
   }
 
   // Default args — resume session or fresh exec
@@ -185,7 +202,7 @@ function normalizeCliArgs(
   args.push("-c", `approval_policy="${approvalPolicy}"`);
   args.push("-c", `sandbox_mode="${sandboxMode}"`);
 
-  return args;
+  return { args, usesPromptPlaceholder: false };
 }
 
 const ALLOWED_ENV_PREFIXES = [
@@ -646,13 +663,19 @@ function composePrompt(input: RuntimeRunInput): string {
   return append ? `${append}\n\n${input.prompt}` : input.prompt;
 }
 
-function shouldWritePromptToStdin(args: string[], prompt: string): boolean {
-  if (prompt && args.includes(prompt)) {
-    return false;
-  }
-  return !args.some(
-    (arg) => arg.includes("{prompt}") || arg === "--prompt" || arg.startsWith("--prompt="),
-  );
+function shouldWritePromptToStdin(
+  args: string[],
+  prompt: string,
+  usesPromptPlaceholder: boolean,
+): boolean {
+  // Any custom arg that embedded `{prompt}` already carries the composed
+  // prompt after substitution — including composite shapes like
+  // `--payload=prefix {prompt} suffix` that neither the literal-equality nor
+  // `--prompt`/`--prompt=*` checks below would catch. `usesPromptPlaceholder`
+  // captures that signal pre-substitution, so we can suppress stdin uniformly.
+  if (usesPromptPlaceholder) return false;
+  if (prompt && args.includes(prompt)) return false;
+  return !args.some((arg) => arg === "--prompt" || arg.startsWith("--prompt="));
 }
 
 function spawnCodexProcess(
@@ -673,6 +696,7 @@ function runCodexCliAttempt(
   args: string[],
   env: Record<string, string>,
   composedPrompt: string,
+  usesPromptPlaceholder: boolean,
   logger?: CodexCliLogger,
 ): Promise<{ result: RuntimeRunResult; startTimedOut: boolean }> {
   const execution = input.execution;
@@ -735,7 +759,7 @@ function runCodexCliAttempt(
   // `codexCliArgs` embed the prompt via `{prompt}` or `--prompt`, the same
   // value was substituted into `args`, so `shouldWritePromptToStdin()` skips
   // stdin here to avoid sending the prompt twice.
-  if (shouldWritePromptToStdin(args, composedPrompt)) {
+  if (shouldWritePromptToStdin(args, composedPrompt, usesPromptPlaceholder)) {
     child.stdin!.write(composedPrompt);
   }
   child.stdin!.end();
@@ -805,7 +829,7 @@ export async function runCodexCli(
   // fallback — otherwise a custom `--prompt={prompt}` would silently drop
   // the language directive the registry attached via `systemPromptAppend`.
   const composedPrompt = composePrompt(input);
-  const args = normalizeCliArgs(input, composedPrompt, logger);
+  const { args, usesPromptPlaceholder } = normalizeCliArgs(input, composedPrompt, logger);
   const options = asRecord(input.options);
   const apiKeyEnvVar =
     typeof options.apiKeyEnvVar === "string" ? options.apiKeyEnvVar : "OPENAI_API_KEY";
@@ -851,6 +875,7 @@ export async function runCodexCli(
     args,
     env,
     composedPrompt,
+    usesPromptPlaceholder,
     logger,
   );
 
@@ -862,7 +887,15 @@ export async function runCodexCli(
     );
     await sleepMs(retryDelayMs);
 
-    const retry = await runCodexCliAttempt(input, cliPath, args, env, composedPrompt, logger);
+    const retry = await runCodexCliAttempt(
+      input,
+      cliPath,
+      args,
+      env,
+      composedPrompt,
+      usesPromptPlaceholder,
+      logger,
+    );
     if (retry.startTimedOut) {
       throw makeProcessStartTimeoutError(input.execution?.startTimeoutMs ?? 0);
     }

--- a/packages/runtime/src/adapters/codex/cli.ts
+++ b/packages/runtime/src/adapters/codex/cli.ts
@@ -663,18 +663,19 @@ function composePrompt(input: RuntimeRunInput): string {
   return append ? `${append}\n\n${input.prompt}` : input.prompt;
 }
 
-function shouldWritePromptToStdin(
-  args: string[],
-  prompt: string,
-  usesPromptPlaceholder: boolean,
-): boolean {
+function shouldWritePromptToStdin(args: string[], usesPromptPlaceholder: boolean): boolean {
   // Any custom arg that embedded `{prompt}` already carries the composed
   // prompt after substitution — including composite shapes like
-  // `--payload=prefix {prompt} suffix` that neither the literal-equality nor
-  // `--prompt`/`--prompt=*` checks below would catch. `usesPromptPlaceholder`
-  // captures that signal pre-substitution, so we can suppress stdin uniformly.
+  // `--payload=prefix {prompt} suffix` that the `--prompt`/`--prompt=*` check
+  // below would not catch. `usesPromptPlaceholder` captures that signal
+  // pre-substitution, so we can suppress stdin uniformly.
+  //
+  // A prior `args.includes(prompt)` branch was intentionally removed: the
+  // default-path `args` always carry generic tokens like `exec`, `--json`, or
+  // the model id, so a user prompt that happens to equal one of those would
+  // be false-positive-matched and never delivered. The placeholder flag plus
+  // the explicit `--prompt` check cover every legitimate embed path already.
   if (usesPromptPlaceholder) return false;
-  if (prompt && args.includes(prompt)) return false;
   return !args.some((arg) => arg === "--prompt" || arg.startsWith("--prompt="));
 }
 
@@ -759,7 +760,7 @@ function runCodexCliAttempt(
   // `codexCliArgs` embed the prompt via `{prompt}` or `--prompt`, the same
   // value was substituted into `args`, so `shouldWritePromptToStdin()` skips
   // stdin here to avoid sending the prompt twice.
-  if (shouldWritePromptToStdin(args, composedPrompt, usesPromptPlaceholder)) {
+  if (shouldWritePromptToStdin(args, usesPromptPlaceholder)) {
     child.stdin!.write(composedPrompt);
   }
   child.stdin!.end();

--- a/packages/runtime/src/adapters/codex/sdk.ts
+++ b/packages/runtime/src/adapters/codex/sdk.ts
@@ -487,7 +487,15 @@ async function runCodexSdkAttempt(
       ? codex.resumeThread(input.sessionId, threadOpts)
       : codex.startThread(threadOpts);
 
-  const { events } = await thread.runStreamed(input.prompt, turnOpts);
+  // The Codex SDK does not expose a dedicated system-prompt slot on
+  // ThreadOptions/TurnOptions, so `execution.systemPromptAppend` (used by the
+  // API transport via a real system message) is prepended to the user prompt
+  // instead. This keeps the registry's language-directive injection effective
+  // across every Codex transport — see packages/runtime/src/registry.ts.
+  const systemAppend = execution?.systemPromptAppend?.trim();
+  const composedPrompt = systemAppend ? `${systemAppend}\n\n${input.prompt}` : input.prompt;
+
+  const { events } = await thread.runStreamed(composedPrompt, turnOpts);
 
   // Wrap event stream with shared timeout utilities
   const abort = execution?.abortController ?? new AbortController();

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -114,6 +114,8 @@ export {
 
 export { bootstrapRuntimeRegistry, type BootstrapRuntimeRegistryOptions } from "./bootstrap.js";
 
+export { buildLanguageDirective, type LanguageDirectiveInput } from "./languagePolicy.js";
+
 export { initProject, type InitProjectOptions, type InitProjectResult } from "./projectInit.js";
 
 export { isValidTrustToken, RUNTIME_TRUST_TOKEN, type RuntimeTrustToken } from "./trust.js";

--- a/packages/runtime/src/languagePolicy.ts
+++ b/packages/runtime/src/languagePolicy.ts
@@ -1,0 +1,63 @@
+/**
+ * Language directive policy.
+ *
+ * Given the project's `language.artifacts` + `language.technical_terms` config,
+ * produce a compact system-prompt append that instructs the model to write
+ * artifacts (task descriptions, plans, review notes, commit messages, chat
+ * replies, roadmap items) in the configured language. Returns an empty string
+ * when no directive is needed (unset, empty, or `en`) so callers can safely
+ * concatenate.
+ *
+ * Pure function, no I/O, no logging — injection site lives in the runtime
+ * registry wrapper so every adapter path gets it automatically.
+ */
+
+export interface LanguageDirectiveInput {
+  artifacts: string | null | undefined;
+  technicalTerms: "keep" | "translate";
+}
+
+const LANGUAGE_NAMES: Record<string, string> = {
+  ru: "Russian (русском языке)",
+  en: "English",
+  fr: "French (français)",
+  de: "German (Deutsch)",
+  es: "Spanish (español)",
+  pt: "Portuguese (português)",
+  it: "Italian (italiano)",
+  pl: "Polish (polski)",
+  uk: "Ukrainian (українською)",
+  tr: "Turkish (Türkçe)",
+  zh: "Chinese (中文)",
+  ja: "Japanese (日本語)",
+  ko: "Korean (한국어)",
+};
+
+function resolveLanguageName(code: string): string {
+  const normalized = code.toLowerCase().split(/[-_]/, 1)[0] ?? "";
+  return LANGUAGE_NAMES[normalized] ?? code;
+}
+
+export function buildLanguageDirective(input: LanguageDirectiveInput): string {
+  const raw = (input.artifacts ?? "").trim().toLowerCase();
+  if (!raw || raw === "en") return "";
+
+  const languageName = resolveLanguageName(raw);
+  const lines = [
+    "Language policy for all produced artifacts:",
+    `- Write all generated artifacts — task descriptions, plans, review notes, commit messages, chat replies, and roadmap items — in ${languageName}.`,
+    "- Apply this to free-form prose only; it does not change the meaning of the task.",
+  ];
+
+  if (input.technicalTerms === "keep") {
+    lines.push(
+      "- Keep technical tokens in English: identifiers, API/function/class names, file paths, CLI flags, environment variables, code snippets, log strings, and error messages emitted by the code.",
+    );
+  } else {
+    lines.push(
+      "- Technical tokens may be translated where a natural equivalent exists; otherwise keep them verbatim.",
+    );
+  }
+
+  return lines.join("\n");
+}

--- a/packages/runtime/src/languagePolicy.ts
+++ b/packages/runtime/src/languagePolicy.ts
@@ -33,14 +33,22 @@ const LANGUAGE_NAMES: Record<string, string> = {
   ko: "Korean (한국어)",
 };
 
+function primarySubtag(code: string): string {
+  return code.toLowerCase().split(/[-_]/, 1)[0] ?? "";
+}
+
 function resolveLanguageName(code: string): string {
-  const normalized = code.toLowerCase().split(/[-_]/, 1)[0] ?? "";
-  return LANGUAGE_NAMES[normalized] ?? code;
+  return LANGUAGE_NAMES[primarySubtag(code)] ?? code;
 }
 
 export function buildLanguageDirective(input: LanguageDirectiveInput): string {
   const raw = (input.artifacts ?? "").trim().toLowerCase();
-  if (!raw || raw === "en") return "";
+  // No-op not only for exact `en` but for any BCP-47 tag whose primary
+  // subtag is English (`en-US`, `en_GB`, `en-x-private`, …). Without this,
+  // regional English settings would still inject a directive asking the
+  // model to "write in English", which is noise at best and misleading
+  // (since the lookup table would stringify `en-US` as the raw tag).
+  if (!raw || primarySubtag(raw) === "en") return "";
 
   const languageName = resolveLanguageName(raw);
   const lines = [

--- a/packages/runtime/src/registry.ts
+++ b/packages/runtime/src/registry.ts
@@ -1,3 +1,4 @@
+import { getProjectConfig } from "@aif/shared";
 import {
   RuntimeExecutionError,
   RuntimeModuleLoadError,
@@ -5,6 +6,7 @@ import {
   RuntimeRegistrationError,
   RuntimeResolutionError,
 } from "./errors.js";
+import { buildLanguageDirective } from "./languagePolicy.js";
 import { resolveRuntimeModuleRegistrar } from "./module.js";
 import { transformSkillCommandPrefix } from "./promptPolicy.js";
 import {
@@ -82,6 +84,66 @@ function wrapAdapter(
   function transformPrompt(input: RuntimeRunInput): RuntimeRunInput {
     if (!needsPromptTransform) return input;
     return { ...input, prompt: transformSkillCommandPrefix(input.prompt, prefix!) };
+  }
+
+  /**
+   * Inject a project-language directive into `execution.systemPromptAppend`.
+   *
+   * Covers every AI-backed call that flows through the registry — subagents,
+   * roadmap generation, commit generation, fast fix, chat, reviewGate — so the
+   * project's `language.artifacts` setting reaches the model without each call
+   * site having to remember to forward it.
+   *
+   * The directive is appended AFTER any existing `systemPromptAppend` so scope
+   * rules (project-scope, review-diff-scope) keep their visual emphasis. When
+   * `artifacts` is empty or `en`, the directive is empty and the input is
+   * returned unchanged. Failures in reading the config are swallowed (logged
+   * as WARN) because a language hint must never break `run()`.
+   */
+  function applyLanguageDirective(input: RuntimeRunInput): RuntimeRunInput {
+    const projectRoot = input.projectRoot;
+    if (!projectRoot) return input;
+
+    let directive = "";
+    try {
+      const cfg = getProjectConfig(projectRoot);
+      directive = buildLanguageDirective({
+        artifacts: cfg.language.artifacts,
+        technicalTerms: cfg.language.technical_terms,
+      });
+    } catch (error) {
+      log.warn(
+        {
+          runtimeId: adapter.descriptor.id,
+          projectRoot,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "Failed to resolve project language config — skipping language directive injection",
+      );
+      return input;
+    }
+
+    if (!directive) return input;
+
+    const existing = input.execution?.systemPromptAppend ?? "";
+    const merged = existing ? `${existing}\n\n${directive}` : directive;
+
+    log.debug(
+      {
+        runtimeId: adapter.descriptor.id,
+        projectRoot,
+        artifactsLength: merged.length,
+      },
+      "Injected project language directive into systemPromptAppend",
+    );
+
+    return {
+      ...input,
+      execution: {
+        ...input.execution,
+        systemPromptAppend: merged,
+      },
+    };
   }
 
   function recordUsage(input: RuntimeRunInput, result: RuntimeRunResult): void {
@@ -164,7 +226,7 @@ function wrapAdapter(
   }
 
   async function wrappedRun(input: RuntimeRunInput): Promise<RuntimeRunResult> {
-    const transformed = transformPrompt(input);
+    const transformed = applyLanguageDirective(transformPrompt(input));
     const result = await adapter.run(transformed);
     recordUsage(transformed, result);
     return result;
@@ -178,7 +240,9 @@ function wrapAdapter(
         `Runtime "${adapter.descriptor.id}" does not implement resume()`,
       );
     }
-    const transformed = transformPrompt(input) as RuntimeRunInput & { sessionId: string };
+    const transformed = applyLanguageDirective(transformPrompt(input)) as RuntimeRunInput & {
+      sessionId: string;
+    };
     const result = await adapter.resume(transformed);
     recordUsage(transformed, result);
     return result;

--- a/packages/shared/src/__tests__/projectConfig.test.ts
+++ b/packages/shared/src/__tests__/projectConfig.test.ts
@@ -175,6 +175,35 @@ describe("getProjectConfig", () => {
     expect(config.language.technical_terms).toBe("keep");
   });
 
+  it("falls back to default artifacts when language tag is not BCP-47 shaped", () => {
+    writeFileSync(
+      join(projectRoot, ".ai-factory", "config.yaml"),
+      'language:\n  artifacts: "not a tag"\n  ui: "русский"\n',
+    );
+    const config = getProjectConfig(projectRoot);
+    // Garbage values must not reach the directive builder verbatim.
+    expect(config.language.artifacts).toBe("en");
+    expect(config.language.ui).toBe("en");
+  });
+
+  it("accepts BCP-47 region subtags on artifacts", () => {
+    writeFileSync(
+      join(projectRoot, ".ai-factory", "config.yaml"),
+      "language:\n  artifacts: pt-BR\n",
+    );
+    const config = getProjectConfig(projectRoot);
+    expect(config.language.artifacts).toBe("pt-br");
+  });
+
+  it("normalizes technical_terms case and whitespace ('Translate' → 'translate')", () => {
+    writeFileSync(
+      join(projectRoot, ".ai-factory", "config.yaml"),
+      'language:\n  artifacts: ru\n  technical_terms: " Translate "\n',
+    );
+    const config = getProjectConfig(projectRoot);
+    expect(config.language.technical_terms).toBe("translate");
+  });
+
   it("clearProjectConfigCache invalidates cache", () => {
     writeFileSync(join(projectRoot, ".ai-factory", "config.yaml"), "paths:\n  plan: v1/PLAN.md\n");
     const first = getProjectConfig(projectRoot);

--- a/packages/shared/src/__tests__/projectConfig.test.ts
+++ b/packages/shared/src/__tests__/projectConfig.test.ts
@@ -122,6 +122,59 @@ describe("getProjectConfig", () => {
     expect(config.git.skip_push_after_commit).toBe(true);
   });
 
+  it("returns default language block when config.yaml does not exist", () => {
+    const config = getProjectConfig(projectRoot);
+    expect(config.language.ui).toBe("en");
+    expect(config.language.artifacts).toBe("en");
+    expect(config.language.technical_terms).toBe("keep");
+  });
+
+  it("returns default language block when config.yaml has no language section", () => {
+    writeFileSync(join(projectRoot, ".ai-factory", "config.yaml"), "paths:\n  plan: p.md\n");
+    const config = getProjectConfig(projectRoot);
+    expect(config.language.ui).toBe("en");
+    expect(config.language.artifacts).toBe("en");
+    expect(config.language.technical_terms).toBe("keep");
+  });
+
+  it("parses partial language block (only artifacts)", () => {
+    writeFileSync(join(projectRoot, ".ai-factory", "config.yaml"), "language:\n  artifacts: ru\n");
+    const config = getProjectConfig(projectRoot);
+    expect(config.language.ui).toBe("en");
+    expect(config.language.artifacts).toBe("ru");
+    expect(config.language.technical_terms).toBe("keep");
+  });
+
+  it("parses full language block", () => {
+    writeFileSync(
+      join(projectRoot, ".ai-factory", "config.yaml"),
+      "language:\n  ui: ru\n  artifacts: ru\n  technical_terms: translate\n",
+    );
+    const config = getProjectConfig(projectRoot);
+    expect(config.language.ui).toBe("ru");
+    expect(config.language.artifacts).toBe("ru");
+    expect(config.language.technical_terms).toBe("translate");
+  });
+
+  it("normalizes language codes to lowercase", () => {
+    writeFileSync(
+      join(projectRoot, ".ai-factory", "config.yaml"),
+      "language:\n  artifacts: RU\n  ui: Fr\n",
+    );
+    const config = getProjectConfig(projectRoot);
+    expect(config.language.artifacts).toBe("ru");
+    expect(config.language.ui).toBe("fr");
+  });
+
+  it("falls back to 'keep' for invalid technical_terms value without throwing", () => {
+    writeFileSync(
+      join(projectRoot, ".ai-factory", "config.yaml"),
+      "language:\n  artifacts: ru\n  technical_terms: nonsense\n",
+    );
+    const config = getProjectConfig(projectRoot);
+    expect(config.language.technical_terms).toBe("keep");
+  });
+
   it("clearProjectConfigCache invalidates cache", () => {
     writeFileSync(join(projectRoot, ".ai-factory", "config.yaml"), "paths:\n  plan: v1/PLAN.md\n");
     const first = getProjectConfig(projectRoot);

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -134,6 +134,7 @@ export {
   type AifProjectPaths,
   type AifProjectWorkflow,
   type AifProjectGit,
+  type AifProjectLanguage,
 } from "./projectConfig.js";
 
 // Telegram notifications

--- a/packages/shared/src/projectConfig.ts
+++ b/packages/shared/src/projectConfig.ts
@@ -108,16 +108,31 @@ const DEFAULT_LANGUAGE: AifProjectLanguage = {
   technical_terms: "keep",
 };
 
+/**
+ * Conservative BCP-47-ish tag: 2-3 letter primary subtag optionally followed
+ * by one or more `-`/`_` separated alphanumeric subtags (2-8 chars each).
+ * Catches typos and garbage values so they don't leak into the injected
+ * system directive as-is (e.g. `"ru1"` or `"русский"` would be rejected).
+ */
+const BCP47_TAG = /^[a-z]{2,3}(?:[-_][a-z0-9]{2,8})*$/;
+
+function normalizeLanguageTag(raw: unknown, fallback: string): string {
+  if (typeof raw !== "string") return fallback;
+  const trimmed = raw.trim().toLowerCase();
+  if (!trimmed) return fallback;
+  return BCP47_TAG.test(trimmed) ? trimmed : fallback;
+}
+
 function normalizeLanguage(raw: unknown): AifProjectLanguage {
   const obj = (raw ?? {}) as Partial<AifProjectLanguage>;
-  const ui =
-    typeof obj.ui === "string" && obj.ui.trim() ? obj.ui.trim().toLowerCase() : DEFAULT_LANGUAGE.ui;
-  const artifacts =
-    typeof obj.artifacts === "string" && obj.artifacts.trim()
-      ? obj.artifacts.trim().toLowerCase()
-      : DEFAULT_LANGUAGE.artifacts;
+  const ui = normalizeLanguageTag(obj.ui, DEFAULT_LANGUAGE.ui);
+  const artifacts = normalizeLanguageTag(obj.artifacts, DEFAULT_LANGUAGE.artifacts);
+  // Mirror the lenient parsing of `ui`/`artifacts` so `"Translate"` or
+  // `" translate "` don't silently revert to `keep`.
+  const technicalRaw =
+    typeof obj.technical_terms === "string" ? obj.technical_terms.trim().toLowerCase() : "";
   const technicalTerms =
-    obj.technical_terms === "translate" ? "translate" : DEFAULT_LANGUAGE.technical_terms;
+    technicalRaw === "translate" ? "translate" : DEFAULT_LANGUAGE.technical_terms;
   return { ui, artifacts, technical_terms: technicalTerms };
 }
 

--- a/packages/shared/src/projectConfig.ts
+++ b/packages/shared/src/projectConfig.ts
@@ -42,10 +42,29 @@ export interface AifProjectGit {
   skip_push_after_commit: boolean;
 }
 
+export interface AifProjectLanguage {
+  /** Locale for UI prompts (currently informational; reserved for future UI). */
+  ui: string;
+  /**
+   * Locale in which AI should produce artifacts: task descriptions, plans,
+   * review notes, commit messages, roadmap items, chat replies.
+   * BCP-47-ish language code, lowercased. "en" (default) means no directive is
+   * injected and the model picks its native default.
+   */
+  artifacts: string;
+  /**
+   * Policy for technical tokens (identifiers, API names, file paths, CLI flags,
+   * code snippets). "keep" — leave them in English even when artifacts language
+   * is non-English. "translate" — translate alongside the rest.
+   */
+  technical_terms: "keep" | "translate";
+}
+
 export interface AifProjectConfig {
   paths: AifProjectPaths;
   workflow: AifProjectWorkflow;
   git: AifProjectGit;
+  language: AifProjectLanguage;
 }
 
 const DEFAULT_PATHS: AifProjectPaths = {
@@ -83,6 +102,25 @@ const DEFAULT_GIT: AifProjectGit = {
   skip_push_after_commit: false,
 };
 
+const DEFAULT_LANGUAGE: AifProjectLanguage = {
+  ui: "en",
+  artifacts: "en",
+  technical_terms: "keep",
+};
+
+function normalizeLanguage(raw: unknown): AifProjectLanguage {
+  const obj = (raw ?? {}) as Partial<AifProjectLanguage>;
+  const ui =
+    typeof obj.ui === "string" && obj.ui.trim() ? obj.ui.trim().toLowerCase() : DEFAULT_LANGUAGE.ui;
+  const artifacts =
+    typeof obj.artifacts === "string" && obj.artifacts.trim()
+      ? obj.artifacts.trim().toLowerCase()
+      : DEFAULT_LANGUAGE.artifacts;
+  const technicalTerms =
+    obj.technical_terms === "translate" ? "translate" : DEFAULT_LANGUAGE.technical_terms;
+  return { ui, artifacts, technical_terms: technicalTerms };
+}
+
 /** Cached configs keyed by projectRoot to avoid re-reading on every call */
 const configCache = new Map<string, { config: AifProjectConfig; mtimeMs: number }>();
 
@@ -99,6 +137,7 @@ export function getProjectConfig(projectRoot: string): AifProjectConfig {
       paths: { ...DEFAULT_PATHS },
       workflow: { ...DEFAULT_WORKFLOW },
       git: { ...DEFAULT_GIT },
+      language: { ...DEFAULT_LANGUAGE },
     };
   }
 
@@ -119,6 +158,7 @@ export function getProjectConfig(projectRoot: string): AifProjectConfig {
     paths: { ...DEFAULT_PATHS, ...yamlPaths },
     workflow: { ...DEFAULT_WORKFLOW, ...yamlWorkflow },
     git: { ...DEFAULT_GIT, ...yamlGit },
+    language: normalizeLanguage(parsed?.language),
   };
 
   configCache.set(projectRoot, { config, mtimeMs: stat.mtimeMs });


### PR DESCRIPTION
## Summary

- Read `language.{artifacts,technical_terms}` from `.ai-factory/config.yaml` and inject a short directive into `execution.systemPromptAppend` inside `RuntimeRegistry.wrapAdapter()` — a single choke point that covers every AI-backed call path (subagents, roadmap generation, commit generation, fast-fix, chat, reviewGate) across all transports (SDK/CLI/API)
- Default `artifacts: en` → empty directive → zero behavioural change for existing users
- Directive is appended after existing `systemPromptAppend` so project-scope and review-diff-scope rules keep their emphasis; prompt/session/agent-definition paths are untouched

Closes #73

## Test plan

- [x] `buildLanguageDirective` unit tests (en/unset/ru/fr/case-insensitive/BCP-47/unknown code)
- [x] `projectConfig` tests for language block defaults, partial parsing, case-normalization, invalid `technical_terms` fallback
- [x] Integration tests in `registry.test.ts`: run + resume injection, missing `projectRoot` no-op, `en` no-op, malformed YAML → WARN + no throw
- [x] Lint + build green on `@aif/shared` and `@aif/runtime`
- [ ] Manual smoke test with `language.artifacts: ru` on a real task (reviewer / roadmap generation)