### PR TITLE
fix: preserve project runtime defaults on update

### DIFF
--- a/packages/api/src/__tests__/projects.test.ts
+++ b/packages/api/src/__tests__/projects.test.ts
@@ -393,6 +393,92 @@ describe("projects API", () => {
     expect(refetched.defaultReviewRuntimeProfileId).toBe("profile-review");
   });
 
+  it("preserves project runtime defaults when update payload omits them", async () => {
+    testDb.current
+      .insert(runtimeProfiles)
+      .values([
+        {
+          id: "profile-task",
+          projectId: null,
+          name: "Task Profile",
+          runtimeId: "claude",
+          providerId: "anthropic",
+          enabled: true,
+        },
+        {
+          id: "profile-plan",
+          projectId: null,
+          name: "Plan Profile",
+          runtimeId: "claude",
+          providerId: "anthropic",
+          enabled: true,
+        },
+        {
+          id: "profile-review",
+          projectId: null,
+          name: "Review Profile",
+          runtimeId: "claude",
+          providerId: "anthropic",
+          enabled: true,
+        },
+        {
+          id: "profile-chat",
+          projectId: null,
+          name: "Chat Profile",
+          runtimeId: "claude",
+          providerId: "anthropic",
+          enabled: true,
+        },
+      ])
+      .run();
+
+    const createRes = await app.request("/projects", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Runtime Defaults",
+        rootPath: "/tmp/runtime-defaults-project",
+        defaultTaskRuntimeProfileId: "profile-task",
+        defaultPlanRuntimeProfileId: "profile-plan",
+        defaultReviewRuntimeProfileId: "profile-review",
+        defaultChatRuntimeProfileId: "profile-chat",
+      }),
+    });
+    expect(createRes.status).toBe(201);
+    const created = await createRes.json();
+
+    const updateRes = await app.request(`/projects/${created.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Runtime Defaults Renamed",
+        rootPath: "/tmp/runtime-defaults-project-renamed",
+      }),
+    });
+    expect(updateRes.status).toBe(200);
+    const updated = await updateRes.json();
+    expect(updated.defaultTaskRuntimeProfileId).toBe("profile-task");
+    expect(updated.defaultPlanRuntimeProfileId).toBe("profile-plan");
+    expect(updated.defaultReviewRuntimeProfileId).toBe("profile-review");
+    expect(updated.defaultChatRuntimeProfileId).toBe("profile-chat");
+
+    const clearRes = await app.request(`/projects/${created.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Runtime Defaults Renamed",
+        rootPath: "/tmp/runtime-defaults-project-renamed",
+        defaultPlanRuntimeProfileId: null,
+      }),
+    });
+    expect(clearRes.status).toBe(200);
+    const cleared = await clearRes.json();
+    expect(cleared.defaultTaskRuntimeProfileId).toBe("profile-task");
+    expect(cleared.defaultPlanRuntimeProfileId).toBeNull();
+    expect(cleared.defaultReviewRuntimeProfileId).toBe("profile-review");
+    expect(cleared.defaultChatRuntimeProfileId).toBe("profile-chat");
+  });
+
   it("rejects foreign project-owned runtime profile defaults on update", async () => {
     testDb.current
       .insert(runtimeProfiles)

--- a/packages/data/src/__tests__/index.test.ts
+++ b/packages/data/src/__tests__/index.test.ts
@@ -384,6 +384,33 @@ describe("data layer", () => {
       expect(updated!.rootPath).toBe("/tmp/updated");
     });
 
+    it("updateProject preserves omitted runtime defaults and clears explicit nulls", () => {
+      const p = createProject({
+        name: "P",
+        rootPath: "/tmp/p",
+        defaultTaskRuntimeProfileId: "task-profile",
+        defaultPlanRuntimeProfileId: "plan-profile",
+        defaultReviewRuntimeProfileId: "review-profile",
+        defaultChatRuntimeProfileId: "chat-profile",
+      });
+
+      const renamed = updateProject(p!.id, { name: "Renamed", rootPath: "/tmp/renamed" });
+      expect(renamed!.defaultTaskRuntimeProfileId).toBe("task-profile");
+      expect(renamed!.defaultPlanRuntimeProfileId).toBe("plan-profile");
+      expect(renamed!.defaultReviewRuntimeProfileId).toBe("review-profile");
+      expect(renamed!.defaultChatRuntimeProfileId).toBe("chat-profile");
+
+      const cleared = updateProject(p!.id, {
+        name: "Renamed",
+        rootPath: "/tmp/renamed",
+        defaultPlanRuntimeProfileId: null,
+      });
+      expect(cleared!.defaultTaskRuntimeProfileId).toBe("task-profile");
+      expect(cleared!.defaultPlanRuntimeProfileId).toBeNull();
+      expect(cleared!.defaultReviewRuntimeProfileId).toBe("review-profile");
+      expect(cleared!.defaultChatRuntimeProfileId).toBe("chat-profile");
+    });
+
     it("deleteProject removes project", () => {
       const p = createProject({ name: "Del", rootPath: "/tmp/del" });
       deleteProject(p!.id);

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -1098,32 +1098,42 @@ export function updateProject(
     defaultChatRuntimeProfileId?: string | null;
   },
 ): ProjectRow | undefined {
+  const patch: Partial<ProjectRow> = {
+    name: input.name,
+    rootPath: input.rootPath,
+    plannerMaxBudgetUsd: input.plannerMaxBudgetUsd ?? null,
+    planCheckerMaxBudgetUsd: input.planCheckerMaxBudgetUsd ?? null,
+    implementerMaxBudgetUsd: input.implementerMaxBudgetUsd ?? null,
+    reviewSidecarMaxBudgetUsd: input.reviewSidecarMaxBudgetUsd ?? null,
+    parallelEnabled: input.parallelEnabled ?? false,
+    updatedAt: new Date().toISOString(),
+  };
+  if (input.defaultTaskRuntimeProfileId !== undefined) {
+    patch.defaultTaskRuntimeProfileId = input.defaultTaskRuntimeProfileId;
+  }
+  if (input.defaultPlanRuntimeProfileId !== undefined) {
+    patch.defaultPlanRuntimeProfileId = input.defaultPlanRuntimeProfileId;
+  }
+  if (input.defaultReviewRuntimeProfileId !== undefined) {
+    patch.defaultReviewRuntimeProfileId = input.defaultReviewRuntimeProfileId;
+  }
+  if (input.defaultChatRuntimeProfileId !== undefined) {
+    patch.defaultChatRuntimeProfileId = input.defaultChatRuntimeProfileId;
+  }
+
   log.debug(
     {
       projectId: id,
-      defaultTaskRuntimeProfileId: input.defaultTaskRuntimeProfileId ?? null,
-      defaultPlanRuntimeProfileId: input.defaultPlanRuntimeProfileId ?? null,
-      defaultReviewRuntimeProfileId: input.defaultReviewRuntimeProfileId ?? null,
-      defaultChatRuntimeProfileId: input.defaultChatRuntimeProfileId ?? null,
+      defaultTaskRuntimeProfileId: patch.defaultTaskRuntimeProfileId ?? null,
+      defaultPlanRuntimeProfileId: patch.defaultPlanRuntimeProfileId ?? null,
+      defaultReviewRuntimeProfileId: patch.defaultReviewRuntimeProfileId ?? null,
+      defaultChatRuntimeProfileId: patch.defaultChatRuntimeProfileId ?? null,
     },
     "Updating project runtime defaults",
   );
   getDb()
     .update(projects)
-    .set({
-      name: input.name,
-      rootPath: input.rootPath,
-      plannerMaxBudgetUsd: input.plannerMaxBudgetUsd ?? null,
-      planCheckerMaxBudgetUsd: input.planCheckerMaxBudgetUsd ?? null,
-      implementerMaxBudgetUsd: input.implementerMaxBudgetUsd ?? null,
-      reviewSidecarMaxBudgetUsd: input.reviewSidecarMaxBudgetUsd ?? null,
-      parallelEnabled: input.parallelEnabled ?? false,
-      defaultTaskRuntimeProfileId: input.defaultTaskRuntimeProfileId ?? null,
-      defaultPlanRuntimeProfileId: input.defaultPlanRuntimeProfileId ?? null,
-      defaultReviewRuntimeProfileId: input.defaultReviewRuntimeProfileId ?? null,
-      defaultChatRuntimeProfileId: input.defaultChatRuntimeProfileId ?? null,
-      updatedAt: new Date().toISOString(),
-    })
+    .set(patch)
     .where(eq(projects.id, id))
     .run();
   return findProjectById(id);


### PR DESCRIPTION
## Summary

Fixes a project update bug where saving unrelated project settings could clear project-level runtime defaults for task, plan, review, and chat.

The issue happened because `PUT /projects/:id` accepted optional `default*RuntimeProfileId` fields, but the data layer treated omitted fields as `null`.

## Reproduction

1. Configure project runtime defaults for task, plan, review, and chat.
2. Edit the project settings without changing runtime defaults, for example project name, budgets, parallel mode, or auto-queue related settings.
3. Save the project.
4. Runtime defaults are cleared and effective runtime resolution falls back unexpectedly.

## Changes

- Preserve existing project runtime defaults when update payload omits them.
- Keep explicit `null` behavior for intentionally clearing a runtime default.
- Add regression coverage for the data layer and projects API.

## AI Model

Which AI model was used to generate or assist with this code?

- [ ] Claude Opus 4.6
- [ ] Claude Sonnet 4.6
- [ ] Claude Haiku 4.5
- [x] Other: gpt-5.5
- [ ] No AI used

## Test Plan

- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Documentation updated (if applicable)
- [x] Manually verified the change works as expected
