### PR TITLE
docs(getting-started): mention non-Claude runtime credentials

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,7 +7,7 @@
 - **Docker** — Docker Desktop or compatible runtime
 - **Node.js** 22+ and **npm** 10+ — only needed if running without Docker
 - **Claude Code CLI** — only needed if running without Docker (`npm i -g @anthropic-ai/claude-code`). The Agent SDK spawns Claude Code as a subprocess, so the CLI must be installed globally
-- **Claude subscription** or Anthropic API key (for agent features)
+- **Claude subscription** or Anthropic API key (for agent features), or a Codex / OpenRouter / OpenCode credential for the corresponding runtime adapter
 
 ## Quick Start with Docker
 


### PR DESCRIPTION
## Summary
- Test PR to verify CI workflows (build, lint, tests, mcpunit, security-audit).
- Tiny docs tweak: prerequisites now mention Codex / OpenRouter / OpenCode credentials alongside Claude.

## Test plan
- [ ] build.yml passes
- [ ] lint.yml passes
- [ ] tests.yml passes
- [ ] mcpunit.yml passes
- [ ] security-audit.yml passes