### PR TITLE
fix(shared): resolve git base branch from origin head

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -463,6 +463,16 @@ The config is editable via the **Global Settings** dialog in the web UI (gear ic
 | `skip_push_after_commit` | `false`    | Skip push after /aif-commit                     |
 | `strict_base_update`     | `false`    | Hard-fail if `git pull --ff-only` of base fails |
 
+When `config.yaml` is absent, Handoff treats the base branch as repository
+discovery: it first checks the branch pointed to by `refs/remotes/origin/HEAD`,
+creating a same-named local branch from `origin/<branch>` when only the remote
+ref exists, with upstream tracking when Git can infer the remote relationship,
+then falls back to the legacy `master` branch, and only then to the built-in
+`main` default. When `base_branch` is explicitly configured and still points to
+the default `main`, but the local repository does not have `main`, Handoff uses
+the same `origin/HEAD` then `master` fallback. Explicit non-default base
+branches are strict: if you set `base_branch: develop`, that branch must exist.
+
 #### `skip_push_after_commit` semantics
 
 Controls whether the approve-done auto-commit flow (and any other `/aif-commit` run originating from the API) performs `git push` after creating the commit:

--- a/packages/shared/src/__tests__/gitIsolation.test.ts
+++ b/packages/shared/src/__tests__/gitIsolation.test.ts
@@ -233,6 +233,93 @@ describe("gitIsolation", () => {
   );
 
   it(
+    "falls back to master when the default main base is missing",
+    () => {
+      initRepo(projectRoot);
+      git(projectRoot, ["branch", "-M", "master"]);
+      writeConfig(projectRoot, "git:\n  base_branch: main\n  branch_prefix: feature/\n");
+
+      const result = ensureFeatureBranch({
+        projectRoot,
+        taskId: "task-master",
+        title: "Master default",
+      });
+
+      expect(result.action).toBe("created");
+      expect(result.branchName).toBe("feature/master-default-taskma");
+      expect(getCurrentBranch(projectRoot)).toBe("feature/master-default-taskma");
+    },
+    GIT_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "falls back to origin HEAD before legacy master when the default main base is missing",
+    () => {
+      initRepo(projectRoot);
+      git(projectRoot, ["checkout", "-b", "2.x"]);
+      writeFileSync(join(projectRoot, "release.txt"), "2.x\n");
+      git(projectRoot, ["add", "release.txt"]);
+      git(projectRoot, ["commit", "-m", "release branch"]);
+      git(projectRoot, ["update-ref", "refs/remotes/origin/2.x", "2.x"]);
+      git(projectRoot, ["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/2.x"]);
+      git(projectRoot, ["checkout", "-b", "master"]);
+      writeFileSync(join(projectRoot, "master.txt"), "master\n");
+      git(projectRoot, ["add", "master.txt"]);
+      git(projectRoot, ["commit", "-m", "master branch"]);
+      git(projectRoot, ["branch", "-D", "main"]);
+      git(projectRoot, ["branch", "-D", "2.x"]);
+      writeConfig(projectRoot, "git:\n  base_branch: main\n  branch_prefix: feature/\n");
+
+      const result = ensureFeatureBranch({
+        projectRoot,
+        taskId: "task-origin",
+        title: "Origin default",
+      });
+
+      expect(result.action).toBe("created");
+      expect(result.branchName).toBe("feature/origin-default-taskor");
+      if (!result.branchName) throw new Error("expected branch name");
+      expect(getCurrentBranch(projectRoot)).toBe("feature/origin-default-taskor");
+      const branchHead = git(projectRoot, ["rev-parse", result.branchName]);
+      const expectedHead = git(projectRoot, ["rev-parse", "refs/remotes/origin/2.x"]);
+      expect(branchHead).toBe(expectedHead);
+      expect(branchExists(projectRoot, "2.x")).toBe(true);
+    },
+    GIT_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "uses origin HEAD before local main when project config is absent",
+    () => {
+      initRepo(projectRoot);
+      git(projectRoot, ["checkout", "-b", "2.x"]);
+      writeFileSync(join(projectRoot, "release.txt"), "2.x\n");
+      git(projectRoot, ["add", "release.txt"]);
+      git(projectRoot, ["commit", "-m", "release branch"]);
+      git(projectRoot, ["checkout", "main"]);
+      git(projectRoot, ["update-ref", "refs/remotes/origin/2.x", "2.x"]);
+      git(projectRoot, ["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/2.x"]);
+      git(projectRoot, ["branch", "-D", "2.x"]);
+
+      const result = ensureFeatureBranch({
+        projectRoot,
+        taskId: "task-no-config",
+        title: "No config",
+      });
+
+      expect(result.action).toBe("created");
+      expect(result.branchName).toBe("feature/no-config-taskno");
+      if (!result.branchName) throw new Error("expected branch name");
+      expect(getCurrentBranch(projectRoot)).toBe("feature/no-config-taskno");
+      const branchHead = git(projectRoot, ["rev-parse", result.branchName]);
+      const expectedHead = git(projectRoot, ["rev-parse", "refs/remotes/origin/2.x"]);
+      expect(branchHead).toBe(expectedHead);
+      expect(branchExists(projectRoot, "2.x")).toBe(true);
+    },
+    GIT_TEST_TIMEOUT_MS,
+  );
+
+  it(
     "returns switched when already on the task branch",
     () => {
       initRepo(projectRoot);

--- a/packages/shared/src/gitIsolation.ts
+++ b/packages/shared/src/gitIsolation.ts
@@ -129,6 +129,30 @@ export function branchExists(projectRoot: string, branchName: string): boolean {
   return status === 0;
 }
 
+function remoteBranchExists(projectRoot: string, branchName: string): boolean {
+  const { status } = runGit(
+    projectRoot,
+    ["show-ref", "--verify", "--quiet", `refs/remotes/origin/${branchName}`],
+    { ignoreExit: true },
+  );
+  return status === 0;
+}
+
+function getOriginHeadBranch(projectRoot: string): string | null {
+  const { stdout, status } = runGit(
+    projectRoot,
+    ["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"],
+    {
+      ignoreExit: true,
+    },
+  );
+  if (status !== 0 || !stdout) return null;
+  const prefix = "refs/remotes/origin/";
+  if (!stdout.startsWith(prefix)) return null;
+  const branchName = stdout.slice(prefix.length).trim();
+  return branchName || null;
+}
+
 export function workingTreeClean(projectRoot: string): boolean {
   const { stdout, status } = runGit(projectRoot, ["status", "--porcelain"], { ignoreExit: true });
   return status === 0 && stdout.length === 0;
@@ -208,6 +232,93 @@ function resolveGitConfig(projectRoot: string): AifProjectGit {
   return getProjectConfig(projectRoot).git;
 }
 
+function hasProjectConfigFile(projectRoot: string): boolean {
+  return existsSync(join(projectRoot, ".ai-factory", "config.yaml"));
+}
+
+interface ResolvedBaseBranch {
+  branchName: string;
+  createFromRemote: boolean;
+}
+
+function resolveOriginHeadBaseBranch(projectRoot: string): ResolvedBaseBranch | null {
+  const originHeadBranch = getOriginHeadBranch(projectRoot);
+  if (!originHeadBranch) return null;
+  if (branchExists(projectRoot, originHeadBranch)) {
+    return { branchName: originHeadBranch, createFromRemote: false };
+  }
+  if (remoteBranchExists(projectRoot, originHeadBranch)) {
+    return { branchName: originHeadBranch, createFromRemote: true };
+  }
+  return null;
+}
+
+function resolveGitDefaultBaseBranch(
+  projectRoot: string,
+  fallbackBase: string,
+): ResolvedBaseBranch {
+  const originHeadBase = resolveOriginHeadBaseBranch(projectRoot);
+  if (originHeadBase) {
+    log.warn(
+      {
+        projectRoot,
+        configuredBase: fallbackBase,
+        resolvedBase: originHeadBase.branchName,
+        source: "origin/HEAD",
+        createFromRemote: originHeadBase.createFromRemote,
+      },
+      "No project git base branch is configured; using origin default branch",
+    );
+    return originHeadBase;
+  }
+  if (branchExists(projectRoot, "master")) {
+    log.warn(
+      { projectRoot, configuredBase: fallbackBase, resolvedBase: "master" },
+      "No project git base branch is configured; using legacy master branch",
+    );
+    return { branchName: "master", createFromRemote: false };
+  }
+  return { branchName: fallbackBase, createFromRemote: false };
+}
+
+function resolveBaseBranch(
+  projectRoot: string,
+  configuredBase: string,
+  configFileExists: boolean,
+): ResolvedBaseBranch {
+  if (!configFileExists) {
+    return resolveGitDefaultBaseBranch(projectRoot, configuredBase);
+  }
+  if (branchExists(projectRoot, configuredBase)) {
+    return { branchName: configuredBase, createFromRemote: false };
+  }
+  if (configuredBase !== "main") {
+    return { branchName: configuredBase, createFromRemote: false };
+  }
+  const originHeadBase = resolveOriginHeadBaseBranch(projectRoot);
+  if (originHeadBase) {
+    log.warn(
+      {
+        projectRoot,
+        configuredBase,
+        resolvedBase: originHeadBase.branchName,
+        source: "origin/HEAD",
+        createFromRemote: originHeadBase.createFromRemote,
+      },
+      "Configured base branch is missing; falling back to origin default branch",
+    );
+    return originHeadBase;
+  }
+  if (branchExists(projectRoot, "master")) {
+    log.warn(
+      { projectRoot, configuredBase, resolvedBase: "master" },
+      "Configured base branch is missing; falling back to legacy master branch",
+    );
+    return { branchName: "master", createFromRemote: false };
+  }
+  return { branchName: configuredBase, createFromRemote: false };
+}
+
 export function projectUsesSharedBranchIsolation(projectRoot: string): boolean {
   const config = resolveGitConfig(projectRoot);
   return config.enabled && config.create_branches && isGitRepo(projectRoot);
@@ -271,27 +382,61 @@ export function ensureFeatureBranch(input: EnsureFeatureBranchInput): EnsureFeat
   // Step 1: ensure HEAD is on the base branch. We need it both as the
   // create-from-target for `git checkout -b` and as the target of the pull
   // policy below.
-  if (current !== config.base_branch) {
-    if (!branchExists(projectRoot, config.base_branch)) {
-      throw new BranchIsolationError(
-        "base_branch_unavailable",
-        `Base branch ${config.base_branch} does not exist in ${projectRoot}. Cannot create ${branchName} from a known base.`,
+  const resolvedBaseBranch = resolveBaseBranch(
+    projectRoot,
+    config.base_branch,
+    hasProjectConfigFile(projectRoot),
+  );
+  const baseBranch = resolvedBaseBranch.branchName;
+  if (current !== baseBranch) {
+    if (!branchExists(projectRoot, baseBranch)) {
+      if (!resolvedBaseBranch.createFromRemote) {
+        throw new BranchIsolationError(
+          "base_branch_unavailable",
+          `Base branch ${config.base_branch} does not exist in ${projectRoot}. Cannot create ${branchName} from a known base.`,
+          projectRoot,
+          branchName,
+        );
+      }
+      validateBranchName(projectRoot, baseBranch);
+      const { status: trackStatus, stderr: trackErr } = runGit(
         projectRoot,
-        branchName,
+        ["checkout", "--track", "-b", baseBranch, `origin/${baseBranch}`],
+        { ignoreExit: true },
       );
-    }
-    const { status: checkoutStatus, stderr: checkoutErr } = runGit(
-      projectRoot,
-      ["checkout", config.base_branch],
-      { ignoreExit: true },
-    );
-    if (checkoutStatus !== 0) {
-      throw new BranchIsolationError(
-        "base_branch_unavailable",
-        `Could not checkout base branch ${config.base_branch}: ${checkoutErr || "unknown error"}`,
+      if (trackStatus !== 0) {
+        const { status: checkoutRemoteStatus, stderr: checkoutRemoteErr } = runGit(
+          projectRoot,
+          ["checkout", "-b", baseBranch, `origin/${baseBranch}`],
+          { ignoreExit: true },
+        );
+        if (checkoutRemoteStatus !== 0) {
+          throw new BranchIsolationError(
+            "base_branch_unavailable",
+            `Could not create local base branch ${baseBranch} from origin/${baseBranch}: ${trackErr || checkoutRemoteErr || "unknown error"}`,
+            projectRoot,
+            branchName,
+          );
+        }
+      }
+      log.info(
+        { projectRoot, branchName: baseBranch, remoteBranch: `origin/${baseBranch}` },
+        "Created local base branch from origin default branch",
+      );
+    } else {
+      const { status: checkoutStatus, stderr: checkoutErr } = runGit(
         projectRoot,
-        branchName,
+        ["checkout", baseBranch],
+        { ignoreExit: true },
       );
+      if (checkoutStatus !== 0) {
+        throw new BranchIsolationError(
+          "base_branch_unavailable",
+          `Could not checkout base branch ${baseBranch}: ${checkoutErr || "unknown error"}`,
+          projectRoot,
+          branchName,
+        );
+      }
     }
   }
 
@@ -305,14 +450,14 @@ export function ensureFeatureBranch(input: EnsureFeatureBranchInput): EnsureFeat
   // opt into strict mode via `git.strict_base_update: true` — pull failure
   // becomes a hard BranchIsolationError("base_update_failed") classified as
   // blocked_external by the coordinator.
-  const pullResult = runGit(projectRoot, ["pull", "--ff-only", "origin", config.base_branch], {
+  const pullResult = runGit(projectRoot, ["pull", "--ff-only", "origin", baseBranch], {
     ignoreExit: true,
   });
   if (pullResult.status !== 0) {
     if (config.strict_base_update) {
       throw new BranchIsolationError(
         "base_update_failed",
-        `git pull --ff-only origin ${config.base_branch} failed: ${pullResult.stderr || "unknown error"}. ` +
+        `git pull --ff-only origin ${baseBranch} failed: ${pullResult.stderr || "unknown error"}. ` +
           `Project has git.strict_base_update=true; refusing to branch from a stale base.`,
         projectRoot,
         branchName,
@@ -322,7 +467,7 @@ export function ensureFeatureBranch(input: EnsureFeatureBranchInput): EnsureFeat
       {
         projectRoot,
         branchName,
-        baseBranch: config.base_branch,
+        baseBranch,
         stderr: pullResult.stderr,
       },
       "Could not fast-forward base branch before creating feature branch; continuing from local base (git.strict_base_update=false)",


### PR DESCRIPTION
## Summary
- resolve feature branch base via origin/HEAD when project config is absent
- fall back from default main to origin/HEAD, then master, when local main is unavailable
- document branch discovery behavior and add git isolation regression coverage

## Validation
- npm test --workspace=@aif/shared -- --run src/__tests__/gitIsolation.test.ts
- npm run ai:validate