### PR TITLE
fix(projects): reject unsafe parallel auto-queue branches

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -171,6 +171,11 @@ PUT /projects/:id
 
 **Response:** `200 OK` — the updated project object.
 
+**Errors:**
+
+- `400` — Parallel auto-queue is rejected when the project config has `git.create_branches=true`.
+  Disable parallel execution, disable auto-queue mode, or set `git.create_branches=false` before using both modes together.
+
 ### Check Roadmap Status
 
 ```
@@ -276,6 +281,11 @@ clients can update their board indicator.
 ```json
 { "enabled": true }
 ```
+
+**Errors:**
+
+- `400` — Parallel auto-queue is rejected when the project config has `git.create_branches=true`.
+  Disable parallel execution, disable auto-queue mode, or set `git.create_branches=false` before using both modes together.
 
 ### Get Project MCP Config
 

--- a/packages/api/src/__tests__/projects.test.ts
+++ b/packages/api/src/__tests__/projects.test.ts
@@ -121,6 +121,35 @@ describe("projects API", () => {
     expect(body.error).toBeDefined();
   });
 
+  it("rejects enabling parallel execution when auto-queue is already enabled and git.create_branches is true", async () => {
+    const rootPath = mkdtempSync(join(tmpdir(), "aif-parallel-auto-queue-"));
+    testDb.current
+      .insert(projects)
+      .values({
+        id: "branch-auto-queue",
+        name: "Branch Auto Queue",
+        rootPath,
+        autoQueueMode: true,
+      })
+      .run();
+
+    const res = await app.request("/projects/branch-auto-queue", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Branch Auto Queue",
+        rootPath,
+        parallelEnabled: true,
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Parallel auto-queue with git.create_branches=true");
+    expect(body.error).toContain("disable parallel execution");
+    expect(body.error).toContain("set git.create_branches=false");
+  });
+
   it("returns MCP servers from .mcp.json", async () => {
     const rootPath = mkdtempSync(join(tmpdir(), "aif-mcp-"));
     writeFileSync(
@@ -574,6 +603,57 @@ describe("projects API", () => {
       expect(await res.json()).toEqual({ enabled: true });
       const get = await app.request("/projects/p-1/auto-queue-mode");
       expect(await get.json()).toEqual({ enabled: true });
+    });
+
+    it("PATCH rejects enabling auto-queue for parallel projects with git.create_branches=true", async () => {
+      const rootPath = mkdtempSync(join(tmpdir(), "aif-auto-queue-branch-"));
+      testDb.current
+        .insert(projects)
+        .values({
+          id: "p-branch",
+          name: "Branch Project",
+          rootPath,
+          parallelEnabled: true,
+        })
+        .run();
+
+      const res = await app.request("/projects/p-branch/auto-queue-mode", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: true }),
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain("Parallel auto-queue with git.create_branches=true");
+      expect(body.error).toContain("disable auto-queue mode");
+    });
+
+    it("PATCH allows parallel auto-queue when git.create_branches=false", async () => {
+      const rootPath = mkdtempSync(join(tmpdir(), "aif-auto-queue-no-branch-"));
+      mkdirSync(join(rootPath, ".ai-factory"), { recursive: true });
+      writeFileSync(
+        join(rootPath, ".ai-factory", "config.yaml"),
+        "git:\n  create_branches: false\n",
+      );
+      testDb.current
+        .insert(projects)
+        .values({
+          id: "p-no-branch",
+          name: "No Branch Project",
+          rootPath,
+          parallelEnabled: true,
+        })
+        .run();
+
+      const res = await app.request("/projects/p-no-branch/auto-queue-mode", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: true }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ enabled: true });
     });
 
     it("PATCH rejects invalid body", async () => {

--- a/packages/api/src/routes/projects.ts
+++ b/packages/api/src/routes/projects.ts
@@ -35,6 +35,24 @@ const log = logger("projects-route");
 
 export const projectsRouter = new Hono();
 
+const PARALLEL_AUTO_QUEUE_BRANCH_ERROR =
+  "Parallel auto-queue with git.create_branches=true is not supported without worktrees. Either disable parallel execution, disable auto-queue mode, or set git.create_branches=false for this project.";
+
+function validateParallelAutoQueueBranchConfig(input: {
+  rootPath: string;
+  parallelEnabled: boolean;
+  autoQueueMode: boolean;
+}): string | null {
+  if (!input.parallelEnabled || !input.autoQueueMode) return null;
+
+  const config = getProjectConfig(input.rootPath);
+  if (config.git.enabled && config.git.create_branches) {
+    return PARALLEL_AUTO_QUEUE_BRANCH_ERROR;
+  }
+
+  return null;
+}
+
 // GET /projects
 projectsRouter.get("/", (c) => {
   const all = listProjects();
@@ -93,6 +111,16 @@ projectsRouter.put("/:id", jsonValidator(createProjectSchema), async (c) => {
       "Rejected invalid project defaults",
     );
     return c.json(runtimeValidation, 400);
+  }
+
+  const parallelAutoQueueError = validateParallelAutoQueueBranchConfig({
+    rootPath: body.rootPath,
+    parallelEnabled: body.parallelEnabled ?? false,
+    autoQueueMode: existing.autoQueueMode,
+  });
+  if (parallelAutoQueueError) {
+    log.warn({ projectId: id }, "Rejected unsupported parallel auto-queue branch config");
+    return c.json({ error: parallelAutoQueueError }, 400);
   }
 
   const { project: updated, pathError } = updateProject(id, body);
@@ -240,6 +268,16 @@ projectsRouter.patch("/:id/auto-queue-mode", jsonValidator(autoQueueModeSchema),
   const { enabled } = c.req.valid("json");
   const project = findProjectById(id);
   if (!project) return c.json({ error: "Project not found" }, 404);
+
+  const parallelAutoQueueError = validateParallelAutoQueueBranchConfig({
+    rootPath: project.rootPath,
+    parallelEnabled: project.parallelEnabled,
+    autoQueueMode: enabled,
+  });
+  if (parallelAutoQueueError) {
+    log.warn({ projectId: id }, "Rejected unsupported parallel auto-queue branch config");
+    return c.json({ error: parallelAutoQueueError }, 400);
+  }
 
   setAutoQueueMode(id, enabled);
   const updated = findProjectById(id);

--- a/packages/runtime/src/adapters/codex/appServer/__tests__/sessions.test.ts
+++ b/packages/runtime/src/adapters/codex/appServer/__tests__/sessions.test.ts
@@ -163,7 +163,7 @@ describe("codex app-server session discovery", () => {
         limit: 10,
         options: {
           testScenario: "session-discovery-hang",
-          appServerRequestTimeoutMs: 500,
+          appServerRequestTimeoutMs: 2_000,
         },
       }),
     ).rejects.toThrow("Timed out waiting for JSONL RPC response (thread/list)");

--- a/packages/web/src/__tests__/ProjectSelector.test.tsx
+++ b/packages/web/src/__tests__/ProjectSelector.test.tsx
@@ -5,6 +5,7 @@ const mockUseQuery = vi.fn();
 const mutateCreateProject = vi.fn();
 const mutateUpdateProject = vi.fn();
 const mutateDeleteProject = vi.fn();
+const mutateSetAutoQueue = vi.fn();
 const mockToast = vi.fn();
 
 vi.mock("@tanstack/react-query", () => ({
@@ -37,7 +38,7 @@ vi.mock("@/hooks/useProjects", () => ({
     mutate: mutateDeleteProject,
   }),
   useSetAutoQueueMode: () => ({
-    mutate: vi.fn(),
+    mutate: mutateSetAutoQueue,
     isPending: false,
   }),
 }));
@@ -55,6 +56,7 @@ describe("ProjectSelector", () => {
     mutateCreateProject.mockReset();
     mutateUpdateProject.mockReset();
     mutateDeleteProject.mockReset();
+    mutateSetAutoQueue.mockReset();
     mockToast.mockReset();
   });
 
@@ -129,6 +131,30 @@ describe("ProjectSelector", () => {
     );
   });
 
+  it("shows error toast when project update fails", () => {
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+
+    mutateUpdateProject.mockImplementation(
+      (_input: unknown, options: { onError?: (error: Error) => void }) => {
+        options.onError?.(
+          new Error("Parallel auto-queue with git.create_branches=true is not supported"),
+        );
+      },
+    );
+
+    render(<ProjectSelector selectedId="p-1" onSelect={() => {}} onDeselect={() => {}} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /alpha/i }));
+    fireEvent.click(screen.getByTitle("Edit"));
+    fireEvent.click(screen.getByText("Save"));
+
+    expect(mockToast).toHaveBeenCalledWith(
+      "Parallel auto-queue with git.create_branches=true is not supported",
+      "error",
+      8000,
+    );
+  });
+
   describe("auto-queue toggle", () => {
     it("renders Auto-Queue Mode switch in create dialog", () => {
       mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
@@ -152,6 +178,40 @@ describe("ProjectSelector", () => {
 
       expect(screen.getByText("Parallel Execution")).toBeDefined();
       expect(screen.getByText("Auto-Queue Mode")).toBeDefined();
+    });
+
+    it("shows error toast when enabling auto-queue fails after create", () => {
+      mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+      mutateCreateProject.mockImplementation(
+        (_input: unknown, options: { onSuccess?: (project: { id: string }) => void }) => {
+          options.onSuccess?.({ id: "created-project" });
+        },
+      );
+      mutateSetAutoQueue.mockImplementation(
+        (_input: unknown, options: { onError?: (error: Error) => void }) => {
+          options.onError?.(
+            new Error("Parallel auto-queue with git.create_branches=true is not supported"),
+          );
+        },
+      );
+
+      render(<ProjectSelector selectedId="p-1" onSelect={() => {}} onDeselect={() => {}} />);
+      fireEvent.click(screen.getByRole("button", { name: /alpha/i }));
+      fireEvent.click(screen.getByText("New project"));
+      fireEvent.change(screen.getByPlaceholderText("My Project"), {
+        target: { value: "Test Project" },
+      });
+      fireEvent.change(screen.getByPlaceholderText("/Users/me/projects/my-project"), {
+        target: { value: "/tmp/test-project" },
+      });
+      fireEvent.click(screen.getAllByRole("switch")[1]);
+      fireEvent.click(screen.getByText("Create"));
+
+      expect(mockToast).toHaveBeenCalledWith(
+        "Parallel auto-queue with git.create_branches=true is not supported",
+        "error",
+        8000,
+      );
     });
   });
 });

--- a/packages/web/src/components/project/ProjectSelector.tsx
+++ b/packages/web/src/components/project/ProjectSelector.tsx
@@ -40,6 +40,10 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
   const deleteProject = useDeleteProject();
   const setAutoQueue = useSetAutoQueueMode();
   const { toast } = useToast();
+
+  const showMutationError = (error: unknown, fallback: string) => {
+    toast(error instanceof Error ? error.message : fallback, "error", 8000);
+  };
   const [dialogOpen, setDialogOpen] = useState(false);
   const [dialogMode, setDialogMode] = useState<DialogMode>("create");
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -151,17 +155,18 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
         {
           onSuccess: (project) => {
             if (autoQueueMode) {
-              setAutoQueue.mutate({ id: project.id, enabled: true });
+              setAutoQueue.mutate(
+                { id: project.id, enabled: true },
+                {
+                  onError: (error) => showMutationError(error, "Failed to enable auto-queue mode"),
+                },
+              );
             }
             onSelect(project);
             setDialogOpen(false);
           },
           onError: (error) => {
-            toast(
-              error instanceof Error ? error.message : "Failed to create project",
-              "error",
-              8000,
-            );
+            showMutationError(error, "Failed to create project");
           },
         },
       );
@@ -186,10 +191,18 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
         {
           onSuccess: (project) => {
             if (autoQueueMode !== previousAutoQueue) {
-              setAutoQueue.mutate({ id: editingId, enabled: autoQueueMode });
+              setAutoQueue.mutate(
+                { id: editingId, enabled: autoQueueMode },
+                {
+                  onError: (error) => showMutationError(error, "Failed to update auto-queue mode"),
+                },
+              );
             }
             if (selectedId === editingId) onSelect(project);
             setDialogOpen(false);
+          },
+          onError: (error) => {
+            showMutationError(error, "Failed to update project");
           },
         },
       );


### PR DESCRIPTION
## Summary
- Reject the unsupported `parallelEnabled=true` + `autoQueueMode=true` + `git.create_branches=true` combination at the projects API boundary.
- Surface the backend error in the project selector/settings UI.
- Document the API error and add API/web coverage for rejection and allowed `git.create_branches=false` flow.
- Stabilize the Codex app-server session timeout test under full-suite load.

## Validation
- `npm run ai:validate`

Fixes #86

Follow-up for Option B worktree isolation: #99
