### PR TITLE
fix(settings): clarify that 'Language' settings target agents, not the UI

### DIFF
--- a/packages/web/src/components/settings/ConfigEditor.tsx
+++ b/packages/web/src/components/settings/ConfigEditor.tsx
@@ -140,8 +140,15 @@ export function ConfigEditor({ config, onConfigChange, projectId }: Props) {
   return (
     <div className="space-y-1">
       {/* Language */}
-      <SectionTitle>Language</SectionTitle>
-      <Field label="UI language" hint="Language for AI-agent communication">
+      <SectionTitle>Agent language</SectionTitle>
+      <p className="text-xs text-muted-foreground -mt-1 mb-2">
+        These settings control the language AI agents use in their output (plans, comments,
+        reviews). They do not localize the web UI — the web UI is English only.
+      </p>
+      <Field
+        label="Agent reply language"
+        hint="Language used by AI agents in chat / comments. Does not change the web UI."
+      >
         <Select
           value={config.language?.ui ?? "en"}
           options={LANGUAGE_OPTIONS}
@@ -149,7 +156,7 @@ export function ConfigEditor({ config, onConfigChange, projectId }: Props) {
           selectSize="sm"
         />
       </Field>
-      <Field label="Artifacts language" hint="Language for generated plans, docs">
+      <Field label="Artifacts language" hint="Language for generated plans, docs, postmortems">
         <Select
           value={config.language?.artifacts ?? "en"}
           options={LANGUAGE_OPTIONS}


### PR DESCRIPTION
Closes #111.

## Что и зачем

Цель — устранить misleading UX в Settings: секция \"Language\" с полем \"UI language\" обещает локализацию web-интерфейса, которой в проекте нет.

### Проблема

`packages/web/src/components/settings/ConfigEditor.tsx:144` рендерит:

```tsx
<SectionTitle>Language</SectionTitle>
<Field label=\"UI language\" hint=\"Language for AI-agent communication\">
```

Поле сохраняет `config.language.ui` в `AifConfig`. Это значение потребляют AI-субагенты как preference языка для своего output (план, ревью, чат-ответы). React-UI **полностью на английском** — i18n-библиотек (`react-i18next`, `react-intl`, `formatjs`) в `packages/web` нет, все строки hardcoded.

Пользователь читает \"UI language\" как \"язык интерфейса\", выбирает русский, ничего не меняется. Развёрнутое описание и сценарий — в #111.

## Изменения

| Что | Было | Стало |
|---|---|---|
| Section title | `Language` | `Agent language` |
| Field label | `UI language` | `Agent reply language` |
| Field hint | `Language for AI-agent communication` | `Language used by AI agents in chat / comments. Does not change the web UI.` |
| Section disclaimer | — | Параграф под заголовком: *\"These settings control the language AI agents use in their output (plans, comments, reviews). They do not localize the web UI — the web UI is English only.\"* |

**Без изменения поведения и схемы.** Field key `config.language.ui` сохранён как есть — on-disk config, API-контракты (`packages/api/src/__tests__/settings.test.ts:190`) и тесты `projectConfig.test.ts` остаются совместимыми.

## Обоснование выбранного решения

- **Почему только rename, а не реальный i18n.** Полная локализация web-UI — большая работа: выбор i18n-библиотеки, extraction сотен строк, перевод, ревью, runtime locale switcher, persisting в localStorage/настройках. Это feature request, не bug fix. Здесь устраняется именно UX-баг (misleading label).
- **Почему не переименовать field key (`language.ui` → `language.agent`).** Это breaking change для существующих установок и AI Factory configs. UX-проблема живёт только в label'е, не в данных.
- **Почему \"Agent reply language\".** \"Reply\" точнее, чем \"output\" — отличает от **Artifacts language** (план/докс), которое уже есть отдельным полем рядом.
- **Disclaimer-параграф под секцией.** Hint у поля видят не все. Section-level disclaimer ловит и тех, кто только сканирует заголовки.

## Что не сделано (отдельные follow-up'ы)

- Реальная i18n web-интерфейса — feature request, не покрывается этим PR.
- Возможный rename schema `config.language.ui` → `config.language.agent` — breaking, обсуждать отдельно.

## Проверка

- `npm run build --workspace=@aif/web` — зелёный.
- Визуально: секция теперь честно называется \"Agent language\", поле — \"Agent reply language\", disclaimer виден сразу под заголовком.
- API/persistence не тронуты — все существующие тесты `settings.test.ts` и `projectConfig.test.ts` остаются валидными без изменений.