### PR TITLE
docs(docker): clarify setup steps and host/container path mapping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,8 @@
 # - Docker compose users: `.env` is REQUIRED. docker-compose.yml
 #   declares `env_file: .env`; without it compose prints a warning
 #   and falls back to inline defaults.
-# - Local dev users (`npm run dev`): scripts/dev.mjs reads this
-#   file too. Most defaults are fine.
+# - Local dev users (`npm run dev`): scripts/dev.mjs reads the
+#   copied `.env` file too. Most defaults are fine.
 #
 # Variables you most often want to set explicitly on first run:
 #   ANTHROPIC_API_KEY — Claude API key (or use `claude login`

--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,23 @@
 # AIF Handoff — Environment Configuration
 # Copy this file to `.env` and adjust values as needed.
 # Optional: create `.env.local` for machine-local overrides.
+#
+# - Docker compose users: `.env` is REQUIRED. docker-compose.yml
+#   declares `env_file: .env`; without it compose prints a warning
+#   and falls back to inline defaults.
+# - Local dev users (`npm run dev`): scripts/dev.mjs reads this
+#   file too. Most defaults are fine.
+#
+# Variables you most often want to set explicitly on first run:
+#   ANTHROPIC_API_KEY — Claude API key (or use `claude login`
+#                       inside the agent container, see README)
+#   PROJECTS_DIR      — host directory for project files
+#                       (default: ${PWD}/projects). Must exist
+#                       on the host before `docker compose up`.
+#   WEB_PORT          — host port for the React UI (default 5180)
+#   PORT              — host port for the API      (default 3009)
+#   MCP_PORT          — host port for the MCP HTTP server
+#                       (default 3100, HTTP server is opt-in)
 # ==========================================================
 
 # ----------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -54,10 +54,56 @@ Set `MCP_PORT` in your shell or root `.env` before `npm run dev` if you also wan
 ```bash
 git clone https://github.com/lee-to/aif-handoff.git
 cd aif-handoff
+
+# 1. Prepare environment
+cp .env.example .env       # required: docker-compose.yml uses `env_file: .env`
+mkdir -p projects          # default PROJECTS_DIR — must exist before first
+                           # `docker compose up`, otherwise Docker creates it
+                           # as root and the container user cannot write to it
+
+# 2. Bring the stack up
 docker compose up --build
+
+# 3. Authenticate Claude (one-time, see Authentication below for details)
+docker compose exec agent claude login
+docker compose restart agent
 ```
 
 Development starts three services by default. If `MCP_PORT` is set to a valid integer port, it starts a fourth service for MCP over HTTP. Docker starts all four services.
+
+#### Project paths (host ↔ container)
+
+When you create a project in the UI, the **Root Path** field expects a host
+path (for example `/Users/you/projects/my-app`). The dev compose mounts
+the host directory `PROJECTS_DIR` onto `PROJECTS_MOUNT` (default
+`/home/www`) inside every container. The API/agent containers see your
+project as `/home/www/my-app` and the API transparently translates the
+host path you typed to the matching container path when persisting it.
+
+The default `PROJECTS_DIR` is `${PWD}/projects` (relative to the compose
+file). To use a different host directory:
+
+```bash
+PROJECTS_DIR=/srv/aif-projects docker compose up --build
+```
+
+The directory must exist on the host before `docker compose up` —
+Docker creates missing bind-mount targets as root-owned, which makes
+them unwritable from the container's `node` user.
+
+#### Resetting state
+
+Containers persist data in named Docker volumes (`db-data`, `claude-auth`,
+`codex-auth`):
+
+```bash
+docker compose down       # stops containers, keeps the database and auth state
+docker compose down -v    # also removes named volumes — fresh slate
+                          # (you will need to `claude login` again)
+```
+
+Project files in `PROJECTS_DIR` live on the host filesystem and are
+never deleted by `down -v` — remove them manually if needed.
 
 | Service   | URL                               | Description                                  |
 | --------- | --------------------------------- | -------------------------------------------- |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,12 +14,58 @@
 ```bash
 git clone https://github.com/lee-to/aif-handoff.git
 cd aif-handoff
+
+# 1. Prepare environment
+cp .env.example .env       # required: docker-compose.yml uses `env_file: .env`
+mkdir -p projects          # default PROJECTS_DIR - must exist before first
+                           # `docker compose up`, otherwise Docker creates it
+                           # as root and the container user cannot write to it
+
+# 2. Bring the stack up
 docker compose up --build
+
+# 3. Authenticate Claude (one-time, see Docker Authentication below)
+docker compose exec agent claude login
+docker compose restart agent
 ```
 
 This builds and starts API (port 3009), Web UI (port 5180), Agent, and MCP (port 3100) in one command. Uses Angie as a reverse proxy — Web UI at `localhost:5180` proxies all API and WebSocket requests automatically.
 
-Data is persisted in Docker volumes (SQLite database, project files, and Claude auth).
+SQLite database and auth state are persisted in Docker volumes. Project files
+live in the host `PROJECTS_DIR` bind mount.
+
+### Docker Project Paths
+
+When you create a project in the UI, the **Root Path** field expects a host
+path, for example `/Users/you/projects/my-app`. The dev compose mounts the host
+directory `PROJECTS_DIR` into each container at `PROJECTS_MOUNT` (default
+`/home/www`). The API translates matching host paths to container paths when it
+persists them, so agents can access the same project as `/home/www/my-app`.
+
+The default `PROJECTS_DIR` is `${PWD}/projects`, relative to the compose file.
+To use a different host directory:
+
+```bash
+PROJECTS_DIR=/srv/aif-projects docker compose up --build
+```
+
+Create the host directory before `docker compose up`. If the bind-mount target
+is missing, Docker creates it as root-owned and the container's `node` user
+cannot write project files there.
+
+### Resetting Docker State
+
+Containers persist data in named Docker volumes (`db-data`, `claude-auth`,
+`codex-auth`):
+
+```bash
+docker compose down       # stops containers, keeps database and auth state
+docker compose down -v    # also removes named volumes - fresh slate
+                          # (you will need to `claude login` again)
+```
+
+Project files in `PROJECTS_DIR` live on the host filesystem and are not deleted
+by `down -v`. Remove them manually if you need to reset project files too.
 
 ### Docker Authentication
 


### PR DESCRIPTION
Closes #115.

## Что и зачем

Цель — закрыть онбординг-разрывы Quick Start «With Docker» одной правкой документации, без изменений в коде.

### Проблема

`docker compose up --build` из README пропускает три prep-шага (`cp .env.example .env`, `mkdir -p projects`, `claude login`) и не объясняет маппинг host↔container путей, который нужен пользователю при создании первого проекта в UI. Развёрнутое описание и сценарий — в #115.

## Изменения

| Файл | Изменение |
|---|---|
| `README.md` → секция «With Docker» | Расширенный prep / up / auth блок с явными `cp .env.example .env`, `mkdir -p projects`, `claude login` |
| `README.md` → новый подраздел «Project paths (host ↔ container)» | Объясняет PROJECTS_DIR ↔ PROJECTS_MOUNT, что вводить в UI Root Path, и почему директория должна существовать до `up` |
| `README.md` → новый подраздел «Resetting state» | `docker compose down` vs `down -v`, поведение named volumes vs host bind-mount |
| `.env.example` | Header-комментарий с обязательностью `.env` для Docker + список переменных, которые чаще всего настраивают на первый запуск |

## Обоснование выбранных решений

- **Почему правки только в README/`.env.example`, а не в коде.** Поведение compose корректное (env_file warning + дефолты, bind-mount auto-create). Проблема — несоответствие mental model пользователя реальности. Решается документацией, не кодом.
- **Почему `Project paths` отдельный подраздел.** Маппинг host↔container — единственная неочевидная часть Docker-flow. Спрятать его в один абзац среди prep-шагов = не заметят. Отдельный заголовок гарантирует, что юзер найдёт это поиском по странице.
- **Почему упоминание `down -v` отдельным блоком.** Это контр-интуитивная часть Docker — пользователи ожидают что `down` чистит состояние. Явный disclaimer экономит время на дебаг «откуда взялись старые проекты».
- **Почему `.env.example` header расширен.** Раньше там был placeholder-комментарий из 4 строк. Теперь даёт actionable первое впечатление: «вот что обязательно для Docker, вот что часто настраивают первым».

## Backward compatibility

Только текстовые правки. Никаких изменений в коде, схеме, поведении compose или env-defaults. Существующие установки не затронуты.

## Проверка

- README рендерится корректно (markdown синтаксис проверен `prettier --check`).
- `cp .env.example .env && mkdir -p projects && docker compose up --build -d` пройден на чистом Ubuntu 24 + Docker 29.4.1 + Compose v5.1.3 — все 4 контейнера up, API health 200, web 200, проект через UI создаётся.