### PR TITLE
fix(docker): make build resilient to prebuild network timeouts

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -23,7 +23,21 @@ COPY packages/api/package.json packages/api/
 COPY packages/web/package.json packages/web/
 COPY packages/agent/package.json packages/agent/
 COPY packages/mcp/package.json packages/mcp/
-RUN npm ci --ignore-scripts && npm rebuild
+# Native modules (better-sqlite3) ship prebuilt binaries via prebuild-install.
+# When the prebuild fetch times out (intermittent npm registry / GitHub
+# releases slowness), npm falls back to `node-gyp rebuild`, which needs
+# python3 + build-essential — neither present in node:22-slim. Without those
+# the build fails with a misleading "Python is not set" error. Install the
+# build toolchain upfront, raise npm fetch retries, and clean the apt cache
+# in the same layer to keep image size down.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3 build-essential ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm config set fetch-retries 5 \
+    && npm config set fetch-retry-mintimeout 20000 \
+    && npm config set fetch-retry-maxtimeout 120000 \
+    && npm ci --ignore-scripts \
+    && npm rebuild
 
 # ---- Build ----
 FROM deps AS build


### PR DESCRIPTION
Closes #117.

## Что и зачем

Цель — устранить недетерминированный фейл `docker compose up --build` на стадии `npm rebuild better-sqlite3` и убрать misleading «Python is not set» error.

### Проблема

При первом `docker compose up --build` на нестабильной сети `prebuild-install` падает по timeout, npm fallback'ит на `node-gyp rebuild`, который требует python3 + build-essential. В `node:22-slim` их нет → build падает с обманчивой ошибкой про Python. Развёрнутое описание и сценарий — в #117.

## Изменения

Один блок в `.docker/Dockerfile` (deps stage):

```dockerfile
RUN apt-get update \
    && apt-get install -y --no-install-recommends python3 build-essential ca-certificates \
    && rm -rf /var/lib/apt/lists/* \
    && npm config set fetch-retries 5 \
    && npm config set fetch-retry-mintimeout 20000 \
    && npm config set fetch-retry-maxtimeout 120000 \
    && npm ci --ignore-scripts \
    && npm rebuild
```

## Обоснование выбранных решений

- **Почему install python3 + build-essential.** node-gyp fallback требует Python и компилятор. Без них любой timeout в prebuild = смерть build. С ними — graceful fallback на компиляцию из исходников (медленнее, но завершается).
- **Почему `npm config set fetch-retries 5`.** Дефолт = 2. На flaky сетях этого мало. 5 retries с экспоненциальным backoff (mintimeout=20s, maxtimeout=120s) покрывают типичные npm registry / GitHub releases lag-окна.
- **Почему всё в одном RUN-layer.** Иначе apt-cache попадает в layer и раздувает образ. `rm -rf /var/lib/apt/lists/*` в том же RUN — стандартная Docker best-practice.
- **Почему добавление apt-get не растит финальный image.** Multi-stage: `api` и `agent` final stages копируют только `/app/node_modules` из deps. Toolchain в final image не попадает. Размер deps stage += ~150 MB, но deps живёт только в build-cache на машине разработчика / CI.
- **Почему не switched на `node:22` (full image).** Slim+toolchain меньше, чем full base. `node:22` около 1.1 GB, `node:22-slim` + toolchain ~ 600 MB.
- **Почему оставлен `prebuild-install || node-gyp rebuild` flow as-is.** Это упаковано в `npm rebuild` от npm, не наша зона. Мы только делаем оба пути выживаемыми.

## Backward compatibility

- **Default flow (быстрый сетевой fetch):** без изменений. prebuild-install скачивает prebuilt бинарник, node-gyp не запускается. Дополнительный python3 в layer не используется в runtime.
- **Slow network / outage:** теперь строится через node-gyp вместо смерти. Дольше (~30 сек на компиляцию), но завершается.
- **Final image size:** без изменений (multi-stage, как описано выше).
- **Existing build cache:** инвалидируется один раз (изменён RUN-команды), потом нормально.

## Проверка

- На сервере (Linux 6.8 x86_64, Docker 29.4.1, Compose v5.1.3): observed gap воспроизведён без этого PR (первый build упал на 'Python is not set'), retry прошёл. После применения этого PR fallback на node-gyp работает на первом же запуске.

## Не вошло (отдельные потенциальные follow-ups)

- Pin конкретной версии `prebuild-install` для reproducibility (orthogonal к этому PR).
- Добавление `--platform=linux/amd64` в base FROM для arm64-host build deterministic (вопрос dev experience, не build robustness).
