### PR TITLE
fix(docker): retry apt-get on transient Debian mirror hash mismatch

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -12,6 +12,11 @@ ENV HTTP_PROXY=${HTTP_PROXY} \
     http_proxy=${HTTP_PROXY} \
     https_proxy=${HTTPS_PROXY} \
     no_proxy=${NO_PROXY}
+# Resilient apt wrapper — retries on transient mirror/CDN failures (Hash Sum
+# mismatch, sporadic 5xx). See script header for details. Available to all
+# Debian-based downstream stages (deps, build, api, agent, mcp).
+COPY .docker/apt-install.sh /usr/local/bin/apt-install
+RUN chmod +x /usr/local/bin/apt-install
 
 # ---- Dependencies ----
 FROM base AS deps
@@ -28,12 +33,10 @@ COPY packages/mcp/package.json packages/mcp/
 # releases slowness), npm falls back to `node-gyp rebuild`, which needs
 # python3 + build-essential — neither present in node:22-slim. Without those
 # the build fails with a misleading "Python is not set" error. Install the
-# build toolchain upfront, raise npm fetch retries, and clean the apt cache
-# in the same layer to keep image size down.
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends python3 build-essential ca-certificates \
-    && rm -rf /var/lib/apt/lists/* \
-    && npm config set fetch-retries 5 \
+# build toolchain upfront and raise npm fetch retries. apt-install handles
+# transient mirror failures and cleans /var/lib/apt/lists/* on exit.
+RUN apt-install python3 build-essential ca-certificates
+RUN npm config set fetch-retries 5 \
     && npm config set fetch-retry-mintimeout 20000 \
     && npm config set fetch-retry-maxtimeout 120000 \
     && npm ci --ignore-scripts \
@@ -47,7 +50,7 @@ RUN npx turbo build
 # ---- API ----
 FROM base AS api
 ENV NODE_ENV=production HOME=/home/node
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates gosu git && rm -rf /var/lib/apt/lists/* \
+RUN apt-install ca-certificates gosu git \
     && npm i -g @anthropic-ai/claude-code @openai/codex
 COPY --chown=node:node --from=deps /app/node_modules ./node_modules
 COPY --chown=node:node --from=build /app/packages/shared ./packages/shared
@@ -82,7 +85,7 @@ EXPOSE 80 443
 # ---- Agent ----
 FROM base AS agent
 ENV NODE_ENV=production HOME=/home/node
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates gosu git curl && rm -rf /var/lib/apt/lists/* \
+RUN apt-install ca-certificates gosu git curl \
     && npm i -g @anthropic-ai/claude-code @openai/codex
 COPY --chown=node:node --from=deps /app/node_modules ./node_modules
 COPY --chown=node:node --from=build /app/packages/shared ./packages/shared
@@ -99,7 +102,7 @@ CMD ["npx", "tsx", "packages/agent/src/index.ts"]
 # ---- MCP ----
 FROM base AS mcp
 ENV NODE_ENV=production HOME=/home/node
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates gosu && rm -rf /var/lib/apt/lists/*
+RUN apt-install ca-certificates gosu
 COPY --chown=node:node --from=deps /app/node_modules ./node_modules
 COPY --chown=node:node --from=build /app/packages/shared ./packages/shared
 COPY --chown=node:node --from=build /app/packages/data ./packages/data

--- a/.docker/apt-install.sh
+++ b/.docker/apt-install.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Resilient apt-get install wrapper for Docker builds.
+#
+# Handles transient Debian mirror / CDN failures observed during build:
+#   - "Hash Sum mismatch" — CDN serves stale .deb that disagrees with the
+#     freshly downloaded Packages index. Same filesize, different SHA →
+#     network-layer substitution (intermediate caching proxy or partially
+#     synced mirror). `Acquire::http::No-Cache=true` forces upstream re-fetch;
+#     wiping /var/lib/apt/lists between attempts re-pulls the index so a
+#     poisoned index doesn't keep poisoning subsequent installs.
+#   - Sporadic 5xx / connection resets on deb.debian.org — covered by the
+#     built-in `Acquire::Retries=5` (per-file retry inside a single invocation)
+#     plus the outer 3-attempt loop (re-do update+install from scratch).
+#
+# Always cleans /var/lib/apt/lists/* on exit so callers don't have to chain
+# `&& rm -rf` to keep image size down.
+set -eu
+
+APT_OPTS="-o Acquire::Retries=5 -o Acquire::http::No-Cache=true"
+MAX_ATTEMPTS=3
+
+cleanup() {
+    rm -rf /var/lib/apt/lists/*
+}
+trap cleanup EXIT
+
+attempt=1
+while [ "$attempt" -le "$MAX_ATTEMPTS" ]; do
+    if apt-get update $APT_OPTS \
+        && apt-get install -y --no-install-recommends $APT_OPTS "$@"; then
+        exit 0
+    fi
+    if [ "$attempt" -eq "$MAX_ATTEMPTS" ]; then
+        echo "apt-install: failed after $MAX_ATTEMPTS attempts" >&2
+        exit 1
+    fi
+    echo "apt-install: attempt $attempt/$MAX_ATTEMPTS failed; clearing apt lists and retrying..." >&2
+    rm -rf /var/lib/apt/lists/*
+    sleep $((attempt * 5))
+    attempt=$((attempt + 1))
+done


### PR DESCRIPTION
## Проблема

При первой попытке поднять проект через `docker compose up --build` сборка иногда падает на `apt-get install` с такой ошибкой:

```
E: Failed to fetch http://deb.debian.org/debian/pool/main/g/gdbm/libgdbm6_1.23-3_amd64.deb
   Hash Sum mismatch
   Hashes of expected file:
    - SHA256:95fe4a1336532450e67bd067892f46eaa484139919ea8d067a9ffcbf5a4bf883
    - Filesize:72248 [weak]
   Hashes of received file:
    - SHA256:00dcccb281915775b83aa48a14e0ad37c6cc8e895d4f714327f4757b05a9fa90
    - Filesize:72248 [weak]
```

Ключевое наблюдение: **размер совпал, а SHA — нет**. Это значит, что байты файла подменены где-то по сети — кэширующим HTTP-прокси, недосинхронизированным mirror'ом или CDN edge-нодой со «застрявшим» объектом. Свежий `apt-get update` уже скачал новый `Packages.gz`, а зеркало в ответ на запрос конкретного `.deb` всё ещё отдаёт старую версию.

При воспроизведении я ловил `Hash Sum mismatch` **4 раза за один билд** на 4 разных пакетах:
- `libgdbm6` (зависимость `python3` в стадии `deps`),
- `Packages` индекс,
- `libssl3`,
- `perl`.

Все четыре случая — в разных стадиях Dockerfile (`deps`, `api`, `agent`, `mcp`).

## Почему обычные приёмы не помогают

- `docker compose build --no-cache` — чистит только Docker BuildKit cache; на mirror'е/CDN мусор всё ещё лежит и снова прилетает.
- Только `Acquire::Retries=5` — apt ретраит **один и тот же файл**. Если `Packages.gz` поломан, повторная скачка того же индекса вернёт тот же поломанный индекс.
- `--fix-missing` — пропускает «потерянные» пакеты, но `python3`/`ca-certificates`/`git` критичны, без них дальше не собрать.

## Решение

Тот же подход, что и в **b1e7085** (`fix(docker): make build resilient to prebuild network timeouts`), только применённый к apt. Делаем `apt` устойчивым к транзиентным сбоям зеркала тремя слоями защиты:

1. **`Acquire::Retries=5`** — apt сам ретраит каждую неудачную загрузку до 5 раз внутри одной попытки.
2. **`Acquire::http::No-Cache=true`** — отправляет HTTP-запросы с заголовком, заставляющим промежуточные прокси/CDN тянуть свежую версию от origin'а, а не отдавать stale-объект из своего кэша. Лечит главную причину `Hash Sum mismatch` (отравленный кэш).
3. **Внешний loop из 3 попыток с очисткой `/var/lib/apt/lists/*` между ними** — если поломан сам индекс (а не отдельный `.deb`), `Acquire::Retries` бесполезен. Только полная стирка списков + новый `apt-get update` вытаскивают свежий индекс с origin'а.

## Что в патче

### Новый файл: `.docker/apt-install.sh`

Маленький shell-скрипт (POSIX, без bash-измов) с тремя гарантиями:

- Принимает имена пакетов как аргументы: `apt-install python3 build-essential ca-certificates`.
- Прозрачен для caller'а: на успехе `exit 0`, на провале после 3 попыток `exit 1` с понятным сообщением `apt-install: failed after 3 attempts`.
- `trap cleanup EXIT` — `/var/lib/apt/lists/*` чистится **на любом пути выхода**. Размер слоя не растёт, даже если кто-то прервёт скрипт сигналом.

### Изменения в `.docker/Dockerfile`

- `COPY .docker/apt-install.sh /usr/local/bin/apt-install` + `chmod +x` в стадии **`base`**. Так как все Debian-стадии (`deps`, `build`, `api`, `agent`, `mcp`) наследуются от `base`, утилита доступна везде без копирования в каждую стадию.
- Все 4 цепочки вида `apt-get update && apt-get install ... --no-install-recommends ... && rm -rf /var/lib/apt/lists/*` заменены на `apt-install ...`. Поведение на happy path идентично (тот же набор пакетов, та же чистка кэша), отличие только в автоматическом восстановлении при транзиентном сбое mirror'а.
- Стадия **`web`** не трогалась — она на Alpine/apk, у `apk add --no-cache` другая модель и этим багом не страдает.

## Проверка

Прогнал `docker compose build --no-cache` на той же сети, где изначально воспроизводился баг. Лог поймал 4 события `Hash Sum mismatch` за один билд — все 4 успешно отыграл retry-loop (на 2-й или 3-й попытке). После сборки `docker compose up -d` поднимает все 4 контейнера:

```
NAME                  STATUS         PORTS
aif-handoff-agent-1   Up 19 seconds  3010/tcp
aif-handoff-api-1     Up 19 seconds  0.0.0.0:3009->3009/tcp
aif-handoff-mcp-1     Up 19 seconds  0.0.0.0:3100->3100/tcp
aif-handoff-web-1     Up 19 seconds  0.0.0.0:5180->80/tcp
```

- `GET http://localhost:3009/health` → **200**
- `GET http://localhost:5180/` → **200**
- В логах api: миграции БД проходят, WebSocket поднят, Codex indexer стартует — ошибок нет.

## Размер образа

Не изменился. `apt-install.sh` чистит `/var/lib/apt/lists/*` на любом exit-пути (через `trap cleanup EXIT`) — ровно то же, что делал `&& rm -rf /var/lib/apt/lists/*` в исходном `RUN`. Сам скрипт занимает ~1 KB.

## Test plan

- [x] `docker compose build --no-cache` проходит при стабильной сети (happy path).
- [x] `docker compose build --no-cache` проходит при возникновении `Hash Sum mismatch` (transient path) — поймано 4 случая, все восстановились.
- [x] `docker compose up -d` поднимает все сервисы, `/health` отдаёт 200.
- [x] Размер итоговых образов не изменился (apt cache чистится через `trap`).
- [x] Стадия `web` (Alpine) не задета.

## Связанное

- **b1e7085** `fix(docker): make build resilient to prebuild network timeouts` — тот же класс проблемы (транзиентный сетевой сбой во время Docker-build), решён тем же стилем (ретраи + fallback в одном слое). Этот PR — апт-эквивалент того фикса.