### PR TITLE
feat(runtime): per-profile environment overrides for Claude adapter

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -194,6 +194,39 @@ CLI-specific options:
 
 - `claudeCliPath` — override for the `claude` binary path (default: auto-discovered)
 - `CLAUDE_CLI_PATH` env var — same, via environment
+- `environment` — per-profile environment variables injected into the spawned `claude` subprocess. Useful for pinning `CLAUDE_CONFIG_DIR` so different projects run under different `~/.claude/` home directories (multi-account setups). Values must be strings; non-string entries are silently dropped. Per-call `execution.environment` overrides take precedence over profile-level values.
+
+Multi-account example — one profile per Claude login:
+
+```json
+{
+  "name": "Claude CLI (personal)",
+  "runtimeId": "claude",
+  "providerId": "anthropic",
+  "transport": "cli",
+  "options": {
+    "environment": { "CLAUDE_CONFIG_DIR": "/Users/me/.claude-personal" }
+  },
+  "enabled": true
+}
+```
+
+```json
+{
+  "name": "Claude CLI (work)",
+  "runtimeId": "claude",
+  "providerId": "anthropic",
+  "transport": "cli",
+  "options": {
+    "environment": { "CLAUDE_CONFIG_DIR": "/Users/me/.claude-work" }
+  },
+  "enabled": true
+}
+```
+
+Assign each profile as the default task runtime for a different Handoff project (project settings → runtime profile). Subagents spawned for that project then read credentials, plugins, and history from the matching `~/.claude-*/` directory instead of the shared host `~/.claude/`.
+
+> The same field is honored on the SDK transport via `parseExecutionOptions`, but `CLAUDE_CONFIG_DIR` only affects subprocess-style invocations. For SDK transport, pass per-account `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` via `apiKeyEnvVar` instead.
 
 ### Codex (SDK transport)
 

--- a/packages/runtime/src/__tests__/claudeAdapter.test.ts
+++ b/packages/runtime/src/__tests__/claudeAdapter.test.ts
@@ -908,6 +908,74 @@ describe("Claude runtime adapter", () => {
     expect(call.options.effort).toBe("high");
   });
 
+  it("forwards profile.options.environment to Claude SDK env with documented precedence", async () => {
+    vi.stubEnv("ANTHROPIC_API_KEY", "sk-ant-test");
+    queryMock.mockImplementation(immediateSuccess("env-ok"));
+    const adapter = createClaudeRuntimeAdapter();
+
+    await adapter.run(
+      createRunInput({
+        model: "sonnet",
+        options: {
+          apiKeyEnvVar: "ANTHROPIC_API_KEY",
+          environment: {
+            PROFILE_KEY: "profile-value",
+            HOOK_OVER: "from-profile",
+            PRECEDENCE_KEY: "from-profile",
+            DROP_NUMBER: 42 as unknown as string,
+          },
+        },
+        execution: {
+          environment: { PER_CALL_KEY: "per-call-value", PRECEDENCE_KEY: "from-execution" },
+          hooks: {
+            environment: {
+              LEGACY_KEY: "legacy-value",
+              HOOK_OVER: "from-hook",
+              PRECEDENCE_KEY: "from-hook",
+            },
+          },
+        },
+      }),
+    );
+
+    expect(queryMock).toHaveBeenCalledTimes(1);
+    const env = queryMock.mock.calls[0][0].options.env as Record<string, string>;
+
+    // profile.options.environment is forwarded to the SDK
+    expect(env.PROFILE_KEY).toBe("profile-value");
+    // legacy execution.hooks.environment still works on its own
+    expect(env.LEGACY_KEY).toBe("legacy-value");
+    // per-call execution.environment still works on its own
+    expect(env.PER_CALL_KEY).toBe("per-call-value");
+    // precedence (later wins): hooks < options < execution
+    expect(env.HOOK_OVER).toBe("from-profile");
+    expect(env.PRECEDENCE_KEY).toBe("from-execution");
+    // non-string entries from profile.options.environment are dropped
+    expect(env).not.toHaveProperty("DROP_NUMBER");
+  });
+
+  it("ignores arrays passed as profile.options.environment (plain-object guard)", async () => {
+    vi.stubEnv("ANTHROPIC_API_KEY", "sk-ant-test");
+    queryMock.mockImplementation(immediateSuccess("env-array"));
+    const adapter = createClaudeRuntimeAdapter();
+
+    await adapter.run(
+      createRunInput({
+        model: "sonnet",
+        options: {
+          apiKeyEnvVar: "ANTHROPIC_API_KEY",
+          environment: ["x", "y"] as unknown as Record<string, string>,
+        },
+      }),
+    );
+
+    expect(queryMock).toHaveBeenCalledTimes(1);
+    const env = queryMock.mock.calls[0][0].options.env as Record<string, string>;
+    // numeric-keyed array entries must not leak through as env vars
+    expect(env).not.toHaveProperty("0");
+    expect(env).not.toHaveProperty("1");
+  });
+
   it("maps numeric effort values to supported Claude effort levels", async () => {
     queryMock.mockImplementation(immediateSuccess("effort-mapped"));
     const adapter = createClaudeRuntimeAdapter();

--- a/packages/runtime/src/__tests__/claudeCli.test.ts
+++ b/packages/runtime/src/__tests__/claudeCli.test.ts
@@ -700,4 +700,64 @@ describe("runClaudeCli", () => {
 
     expect(onStderr).toHaveBeenCalledWith("some warning");
   });
+
+  it("injects profile.options.environment into the spawned subprocess env", async () => {
+    const input = createInput({
+      options: {
+        environment: { CLAUDE_CONFIG_DIR: "/tmp/test-claude-personal" },
+      },
+    });
+    const promise = runClaudeCli(input);
+
+    simulateStreamAndClose(0, successfulStream({ sessionId: "sess-profile-env", text: "Done" }));
+
+    await promise;
+
+    const { spawnOptions } = getSpawnInvocation();
+    const env = spawnOptions.env as Record<string, string>;
+    expect(env.CLAUDE_CONFIG_DIR).toBe("/tmp/test-claude-personal");
+  });
+
+  it("lets execution.environment override profile.options.environment", async () => {
+    const input = createInput({
+      options: {
+        environment: { CLAUDE_CONFIG_DIR: "/tmp/profile-default" },
+      },
+      execution: {
+        environment: { CLAUDE_CONFIG_DIR: "/tmp/per-call-override" },
+      },
+    });
+    const promise = runClaudeCli(input);
+
+    simulateStreamAndClose(0, successfulStream({ sessionId: "sess-env-override", text: "Done" }));
+
+    await promise;
+
+    const { spawnOptions } = getSpawnInvocation();
+    const env = spawnOptions.env as Record<string, string>;
+    expect(env.CLAUDE_CONFIG_DIR).toBe("/tmp/per-call-override");
+  });
+
+  it("ignores non-string values in profile.options.environment", async () => {
+    const input = createInput({
+      options: {
+        environment: {
+          CLAUDE_CONFIG_DIR: "/tmp/valid",
+          INVALID_NUMBER: 42 as unknown as string,
+          INVALID_NULL: null as unknown as string,
+        },
+      },
+    });
+    const promise = runClaudeCli(input);
+
+    simulateStreamAndClose(0, successfulStream({ sessionId: "sess-env-filter", text: "Done" }));
+
+    await promise;
+
+    const { spawnOptions } = getSpawnInvocation();
+    const env = spawnOptions.env as Record<string, string>;
+    expect(env.CLAUDE_CONFIG_DIR).toBe("/tmp/valid");
+    expect(env).not.toHaveProperty("INVALID_NUMBER");
+    expect(env).not.toHaveProperty("INVALID_NULL");
+  });
 });

--- a/packages/runtime/src/adapters/claude/cli.ts
+++ b/packages/runtime/src/adapters/claude/cli.ts
@@ -19,7 +19,7 @@ import {
 } from "../../timeouts.js";
 import { classifyClaudeResultSubtype, classifyClaudeRuntimeError } from "./errors.js";
 import { normalizeClaudeLimitSnapshot } from "./limit.js";
-import { normalizeClaudeEffort } from "./options.js";
+import { normalizeClaudeEffort, resolveProfileEnvironment } from "./options.js";
 import { buildToolUseEvents } from "../../toolEvents.js";
 import { parseClaudeAskUserQuestion } from "./questions.js";
 import type { ClaudeProviderIdentity } from "./providerIdentity.js";
@@ -799,7 +799,10 @@ export async function runClaudeCli(
   });
   const apiKeyEnvVar =
     typeof options.apiKeyEnvVar === "string" ? options.apiKeyEnvVar : "ANTHROPIC_API_KEY";
-  const env = buildCuratedEnv(apiKeyEnvVar, execution?.environment);
+  const env = buildCuratedEnv(apiKeyEnvVar, {
+    ...resolveProfileEnvironment(input),
+    ...execution?.environment,
+  });
 
   logger?.info?.(
     {

--- a/packages/runtime/src/adapters/claude/options.ts
+++ b/packages/runtime/src/adapters/claude/options.ts
@@ -50,6 +50,26 @@ function toStringRecord(value: Record<string, unknown> | null): Record<string, s
   return Object.fromEntries(entries);
 }
 
+/**
+ * Resolve per-profile environment overrides from `profile.options.environment`.
+ *
+ * Reads a `Record<string, string>` from the profile's options block and returns
+ * it as a plain key/value map (non-string values are dropped). Returns
+ * `undefined` when no overrides are configured.
+ *
+ * Consumed by both the SDK path (via `parseExecutionOptions`) and the CLI path
+ * (via `buildCuratedEnv` in `cli.ts`) so a single profile field reaches the
+ * spawned `claude` subprocess regardless of transport. Typical use case:
+ * pinning `CLAUDE_CONFIG_DIR` per profile so different Handoff projects can run
+ * under different `~/.claude/` home directories (multi-account setups) without
+ * mutating the host process environment.
+ */
+export function resolveProfileEnvironment(
+  input: RuntimeRunInput,
+): Record<string, string> | undefined {
+  return toStringRecord(toRecord(toRecord(input.options)?.environment));
+}
+
 function readForkSourceSessionId(input: RuntimeRunInput): string | null {
   const sourceSessionId = (input as Partial<RuntimeSessionForkInput>).sourceSessionId;
   return typeof sourceSessionId === "string" && sourceSessionId.trim().length > 0
@@ -129,6 +149,7 @@ export function parseExecutionOptions(
       exec?.runTimeoutMs ?? (typeof src.runTimeoutMs === "number" ? src.runTimeoutMs : undefined),
     environment: {
       ...toStringRecord(toRecord(src.environment)),
+      ...resolveProfileEnvironment(input),
       ...exec?.environment,
     },
     stderr:

--- a/packages/runtime/src/adapters/claude/options.ts
+++ b/packages/runtime/src/adapters/claude/options.ts
@@ -57,6 +57,10 @@ function toStringRecord(value: Record<string, unknown> | null): Record<string, s
  * it as a plain key/value map (non-string values are dropped). Returns
  * `undefined` when no overrides are configured.
  *
+ * Arrays are explicitly rejected even though `typeof [] === "object"` — without
+ * this guard a profile shaped like `environment: ["x"]` would leak through as
+ * an env entry `{ "0": "x" }`, which contradicts the documented contract.
+ *
  * Consumed by both the SDK path (via `parseExecutionOptions`) and the CLI path
  * (via `buildCuratedEnv` in `cli.ts`) so a single profile field reaches the
  * spawned `claude` subprocess regardless of transport. Typical use case:
@@ -67,7 +71,11 @@ function toStringRecord(value: Record<string, unknown> | null): Record<string, s
 export function resolveProfileEnvironment(
   input: RuntimeRunInput,
 ): Record<string, string> | undefined {
-  return toStringRecord(toRecord(toRecord(input.options)?.environment));
+  const candidate = toRecord(input.options)?.environment;
+  if (candidate == null || typeof candidate !== "object" || Array.isArray(candidate)) {
+    return undefined;
+  }
+  return toStringRecord(candidate as Record<string, unknown>);
 }
 
 function readForkSourceSessionId(input: RuntimeRunInput): string | null {


### PR DESCRIPTION
## Summary

- Adds an `options.environment` field on Claude runtime profiles that injects profile-scoped env vars into the spawned Claude subprocess (CLI transport) and the Claude SDK execution options (SDK transport).
- Primary motivation: run multiple Claude logins on a single host by pinning `CLAUDE_CONFIG_DIR` per profile, so different Handoff projects can use different `~/.claude/` home directories without mutating the host process environment, restarting Handoff, or rebuilding containers.
- Fully additive — profiles that omit `options.environment` behave exactly as before.

## Use case

Today, a single Handoff host shares one Claude identity across every project: subagents inherit credentials, plugins, MCP servers, memory, and chat history from whatever `~/.claude/` the Handoff process started under. Teams that want to keep personal/work or per-client Claude accounts isolated have to either (a) run separate Handoff instances on different ports, or (b) rebuild the container with a different baked-in env — both heavy.

With this PR a user can keep one Handoff instance, define two Claude CLI profiles:

```json
{
  "name": "Claude CLI (personal)",
  "runtimeId": "claude",
  "providerId": "anthropic",
  "transport": "cli",
  "options": {
    "environment": { "CLAUDE_CONFIG_DIR": "/Users/me/.claude-personal" }
  }
}
```

```json
{
  "name": "Claude CLI (work)",
  "runtimeId": "claude",
  "providerId": "anthropic",
  "transport": "cli",
  "options": {
    "environment": { "CLAUDE_CONFIG_DIR": "/Users/me/.claude-work" }
  }
}
```

…assign each as the default task runtime for a different project, and subagents spawned for that project read credentials/plugins/history from the matching `~/.claude-*/` directory. No host env mutation, no per-project Handoff process.

## Changes

`packages/runtime/src/adapters/claude/options.ts`
- New exported helper `resolveProfileEnvironment(input)` reads `profile.options.environment` and returns a `Record<string, string>` (non-string values dropped).
- `parseExecutionOptions()` merges the helper output into `execution.environment` between the legacy `execution.hooks.environment` source and the per-call `execution.environment` override.

`packages/runtime/src/adapters/claude/cli.ts`
- Imports `resolveProfileEnvironment` and merges it into the `executionEnv` argument passed to `buildCuratedEnv()` so the spawned `claude` subprocess receives the profile env vars. Same precedence as the SDK path.

`packages/runtime/src/__tests__/claudeCli.test.ts`
- 3 new tests against the existing mocked `spawn`:
  - profile env injection lands in `spawnOptions.env`
  - per-call `execution.environment` overrides profile values
  - non-string values are silently dropped

`docs/providers.md`
- New "Multi-account example" subsection under Claude (CLI) showing two profiles pinning different `CLAUDE_CONFIG_DIR` values, with a note that `CLAUDE_CONFIG_DIR` only meaningfully affects subprocess transports.

## Behavior contract

- Values must be strings; non-string entries are silently filtered (consistent with the existing `toStringRecord` helper used elsewhere in the file).
- Precedence (later wins): `execution.hooks.environment` → `options.environment` → `execution.environment`.
- The whitelist in `cli.ts:ALLOWED_ENV_PREFIXES` already lets `CLAUDE_*` through from `process.env`, but that path is host-wide — `options.environment` is the per-profile equivalent.
- API schema needs no change: `runtimeOptionsSchema = z.record(z.string(), z.unknown())` already accepts arbitrary keys under `options`.
- `optionsJson` is persisted as-is in SQLite, so no migration is needed.

## Backwards compatibility

100% additive. Profiles without `options.environment` produce identical `execution.environment` and identical spawned-subprocess env. All existing tests (786) pass unchanged.

## AI Model

- [x] Claude Opus 4.7
- [ ] Claude Sonnet 4.6
- [ ] Claude Haiku 4.5
- [ ] Other:
- [ ] No AI used

## Test Plan

- [x] Tests pass (`npx turbo test --filter=@aif/runtime` — 786/786, including 3 new CLI adapter tests)
- [x] Lint passes (`npx turbo lint --filter=@aif/runtime`)
- [x] Format check passes (`npx prettier --check` on touched files)
- [x] Full build green (`npx turbo build` — 7/7)
- [x] Manually verified end-to-end against compiled JS (`node` script that imports `dist/adapters/claude/options.js` and asserts: `resolveProfileEnvironment` filters non-string values; `parseExecutionOptions` merges profile env into `execution.environment`; per-call `execution.environment` wins over profile; `options.environment` wins over legacy `execution.hooks.environment`)
- [x] Documentation updated (`docs/providers.md` Claude (CLI) section)