### PR TITLE
fix(web): make randomUUID work outside secure contexts

### DIFF
--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -9,6 +9,7 @@ import type {
   RuntimeLimitSnapshot,
 } from "@aif/shared/browser";
 import { api, ApiError } from "@/lib/api";
+import { randomUUID } from "@/lib/uuid";
 import { getWsClientId } from "./useWebSocket";
 
 interface SessionStreamState {
@@ -297,7 +298,7 @@ export function useChat(
         currentSessionIdRef.current = null;
       }
 
-      const newConversationId = crypto.randomUUID();
+      const newConversationId = randomUUID();
       const effectiveSessionId = forceNewSession
         ? null
         : (sessionId ?? currentSessionIdRef.current);

--- a/packages/web/src/lib/uuid.test.ts
+++ b/packages/web/src/lib/uuid.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { randomUUID } from "./uuid";
+
+const V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("randomUUID", () => {
+  it("returns a valid v4 UUID via native randomUUID (secure context)", () => {
+    expect(randomUUID()).toMatch(V4);
+  });
+
+  it("falls back to getRandomValues when randomUUID is missing (insecure http context)", () => {
+    // Simulate plain-HTTP, non-localhost origin: randomUUID is undefined,
+    // getRandomValues is still present. This is the case that used to throw
+    // `TypeError: crypto.randomUUID is not a function`.
+    vi.stubGlobal("crypto", {
+      getRandomValues: <T extends ArrayBufferView>(arr: T): T => {
+        const view = arr as unknown as Uint8Array;
+        for (let i = 0; i < view.length; i++) view[i] = (i * 37 + 11) & 0xff;
+        return arr;
+      },
+    });
+
+    const id = randomUUID();
+    expect(id).toMatch(V4);
+    // Version + variant nibbles must be set correctly.
+    expect(id[14]).toBe("4");
+    expect(["8", "9", "a", "b"]).toContain(id[19]);
+  });
+
+  it("still returns a valid v4 UUID with no Web Crypto at all (last resort)", () => {
+    vi.stubGlobal("crypto", undefined);
+    expect(randomUUID()).toMatch(V4);
+  });
+
+  it("produces unique values", () => {
+    const ids = new Set(Array.from({ length: 1000 }, () => randomUUID()));
+    expect(ids.size).toBe(1000);
+  });
+});

--- a/packages/web/src/lib/uuid.ts
+++ b/packages/web/src/lib/uuid.ts
@@ -1,0 +1,42 @@
+/**
+ * Generate an RFC 4122 v4 UUID that also works in non-secure browsing contexts.
+ *
+ * `crypto.randomUUID()` is only exposed in a *secure context* — HTTPS or
+ * `http://localhost`. When the app is served over plain HTTP from a non-localhost
+ * origin (e.g. a LAN IP such as `http://10.10.100.29`), `crypto.randomUUID` is
+ * `undefined`, and calling it throws
+ * `TypeError: crypto.randomUUID is not a function`.
+ *
+ * `crypto.getRandomValues()` is available in insecure contexts too, so we fall
+ * back to deriving the UUID from it — keeping cryptographically strong randomness
+ * without requiring HTTPS.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID#secure_context
+ */
+export function randomUUID(): string {
+  const cryptoObj = globalThis.crypto as Crypto | undefined;
+
+  // Secure context (https / localhost): use the native implementation.
+  if (typeof cryptoObj?.randomUUID === "function") {
+    return cryptoObj.randomUUID();
+  }
+
+  // Insecure context (plain http on a non-localhost host): getRandomValues is
+  // still available — derive an RFC 4122 v4 UUID from 16 random bytes.
+  if (typeof cryptoObj?.getRandomValues === "function") {
+    const bytes = cryptoObj.getRandomValues(new Uint8Array(16));
+    bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
+    bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant 10xx
+    const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+  }
+
+  // Last resort (no Web Crypto at all — practically never in a browser): a
+  // non-cryptographic v4 UUID. These ids are used as chat/stream keys, which do
+  // not require crypto-grade randomness, so this is an acceptable degradation
+  // over throwing.
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (ch) => {
+    const r = (Math.random() * 16) | 0;
+    return (ch === "x" ? r : (r & 0x3) | 0x8).toString(16);
+  });
+}


### PR DESCRIPTION
  ## Fix: `crypto.randomUUID is not a function` when served over plain HTTP on a non-localhost host

  ### Problem
  Deploying the web UI to an internal server and opening it via a LAN address
  over plain HTTP — e.g. `http://10.10.100.29:5180` (not `localhost`, not HTTPS) —
  crashes when sending a chat message:

  Uncaught (in promise) TypeError: crypto.randomUUID is not a function
      at sendMessage (useChat.ts)

  ### Root cause
  `crypto.randomUUID()` is only exposed in a **secure context** — HTTPS or
  `http://localhost`. On a plain-HTTP, non-localhost origin the browser leaves
  `crypto.randomUUID` `undefined`, so the call in
  `packages/web/src/hooks/useChat.ts` throws. (Works on localhost / behind HTTPS,
  which hides it in typical dev.)
  See: https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID#secure_context

  ### Fix
  Add `packages/web/src/lib/uuid.ts` — a small dependency-free `randomUUID()` that
  uses the native `crypto.randomUUID()` when present and otherwise derives an
  RFC 4122 v4 UUID from `crypto.getRandomValues()`, which **is** available in
  insecure contexts (so randomness stays crypto-grade). Swap the single browser
  call site to use it.

  ### Tests
  `uuid.test.ts`: native path, insecure-context fallback (the case that used to
  throw), no-crypto last resort, and uniqueness. `vitest`, `eslint`, `tsc` all pass.

  ### Note
  Serving over HTTPS or via `localhost` also resolves it, but this makes the app
  work on a bare internal HTTP host out of the box.

  PR/коммит/ветку оставляю тебе (ты сказал, что сам сделаешь). Хочешь — закоммичу в новую ветку и оформлю PR через gh/glab, если репозиторий это поддерживает.

  ### Tests
  `uuid.test.ts`: native path, insecure-context fallback (the case that used to
  throw), no-crypto last resort, and uniqueness. `vitest`, `eslint`, `tsc` all pass.

  ### Note
  Serving over HTTPS or via `localhost` also resolves it, but this makes the app
  work on a bare internal HTTP host out of the box.