### PR TITLE
feat(projects): add compact project task overview endpoint (additive)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -139,6 +139,64 @@ GET /projects
 ]
 ```
 
+### Project Task Overview
+
+```
+GET /projects/overview
+```
+
+Returns compact per-project task aggregates for the projects overview screen.
+This endpoint does not return full task rows.
+
+**Response:** `200 OK`
+
+```json
+[
+  {
+    "projectId": "uuid",
+    "totalTasks": 12,
+    "completedTasks": 2,
+    "verifiedTasks": 0,
+    "backlogTasks": 4,
+    "activeTasks": 6,
+    "blockedTasks": 1,
+    "autoModeTasks": 3,
+    "fixTasks": 1,
+    "totalRetries": 3,
+    "totalTokenInput": 1200,
+    "totalTokenOutput": 800,
+    "totalTokenTotal": 2000,
+    "totalCostUsd": 0.25,
+    "statusCounts": {
+      "backlog": 4,
+      "planning": 1,
+      "plan_ready": 2,
+      "implementing": 1,
+      "review": 1,
+      "blocked_external": 1,
+      "done": 2,
+      "verified": 0
+    },
+    "statusPreviews": {
+      "backlog": [{ "id": "task-1", "title": "Queued work" }],
+      "planning": [],
+      "plan_ready": [],
+      "implementing": [],
+      "review": [],
+      "blocked_external": [],
+      "done": [],
+      "verified": []
+    }
+  }
+]
+```
+
+`completedTasks` counts `done` + `verified`. `activeTasks` counts every status
+that is not `backlog`, `done`, or `verified`. `blockedTasks` counts
+`blocked_external`. `statusPreviews` lists are small (bounded in SQL) and
+include only task id/title pairs — never plan text, logs, or other detail-only
+fields.
+
 ### Create Project
 
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -343,6 +343,9 @@ loads bounded:
   options, auto-review state, and QA markdown artifacts.
 - `GET /tasks/:id` remains the full task detail endpoint for task detail, chat,
   comments, and agent workflows.
+- `GET /projects/overview` uses `listProjectTaskOverviews()` to serve compact
+  per-project counts, metric totals, and small title previews without loading
+  every task row into the web client.
 
 ## Database
 

--- a/packages/api/src/__tests__/projects.test.ts
+++ b/packages/api/src/__tests__/projects.test.ts
@@ -131,6 +131,71 @@ describe("projects API", () => {
     expect(await res.json()).toEqual([]);
   });
 
+  it("returns compact project task overviews", async () => {
+    const db = testDb.current;
+    db.insert(projects)
+      .values([
+        { id: "overview-a", name: "Overview A", rootPath: "/tmp/a" },
+        { id: "overview-b", name: "Overview B", rootPath: "/tmp/b" },
+      ])
+      .run();
+    db.insert(tasks)
+      .values([
+        {
+          id: "task-a-1",
+          projectId: "overview-a",
+          title: "Backlog item",
+          status: "backlog",
+          plan: "heavy plan",
+          implementationLog: "heavy implementation log",
+          reviewComments: "heavy review comments",
+          agentActivityLog: "heavy activity log",
+          tokenInput: 10,
+          tokenOutput: 20,
+          tokenTotal: 30,
+          costUsd: 0.25,
+        },
+        {
+          id: "task-a-2",
+          projectId: "overview-a",
+          title: "Done item",
+          status: "done",
+          retryCount: 2,
+        },
+        {
+          id: "task-b-1",
+          projectId: "overview-b",
+          title: "Other item",
+          status: "review",
+        },
+      ])
+      .run();
+
+    const res = await app.request("/projects/overview");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const overviewA = body.find(
+      (overview: { projectId: string }) => overview.projectId === "overview-a",
+    );
+
+    expect(overviewA).toMatchObject({
+      projectId: "overview-a",
+      totalTasks: 2,
+      completedTasks: 1,
+      backlogTasks: 1,
+      totalRetries: 2,
+      totalTokenInput: 10,
+      totalTokenOutput: 20,
+      totalTokenTotal: 30,
+      totalCostUsd: 0.25,
+    });
+    expect(overviewA.statusCounts.backlog).toBe(1);
+    expect(overviewA.statusCounts.done).toBe(1);
+    expect(overviewA.statusPreviews.backlog).toEqual([{ id: "task-a-1", title: "Backlog item" }]);
+    expect(overviewA.statusPreviews.backlog[0]).not.toHaveProperty("plan");
+    expect(overviewA.statusPreviews.backlog[0]).not.toHaveProperty("implementationLog");
+  });
+
   it("rejects invalid root path for create", async () => {
     const res = await app.request("/projects", {
       method: "POST",

--- a/packages/api/src/repositories/projects.ts
+++ b/packages/api/src/repositories/projects.ts
@@ -7,6 +7,7 @@ import {
   createProject as createProjectRecord,
   deleteProject as deleteProjectRecord,
   findProjectById,
+  listProjectTaskOverviews,
   listProjects,
   type ProjectRow,
   updateProject as updateProjectRecord,
@@ -158,4 +159,4 @@ export function getProjectMcpServers(projectId: string): Record<string, unknown>
   }
 }
 
-export { listProjects, findProjectById };
+export { listProjects, listProjectTaskOverviews, findProjectById };

--- a/packages/api/src/routes/projects.ts
+++ b/packages/api/src/routes/projects.ts
@@ -27,6 +27,7 @@ import { getAutoQueueMode, setAutoQueueMode } from "@aif/data";
 import { broadcast } from "../ws.js";
 import {
   listProjects,
+  listProjectTaskOverviews,
   findProjectById,
   createProject,
   updateProject,
@@ -192,6 +193,16 @@ projectsRouter.get("/", (c) => {
   const all = listProjects();
   log.debug({ count: all.length }, "Listed all projects");
   return c.json(all);
+});
+
+// GET /projects/overview - compact task metrics and previews for the overview screen
+projectsRouter.get("/overview", (c) => {
+  const overview = listProjectTaskOverviews();
+  log.debug(
+    { projectCount: overview.length, responseType: "ProjectTaskOverview" },
+    "Listed project task overview",
+  );
+  return c.json(overview);
 });
 
 // POST /projects

--- a/packages/data/src/__tests__/index.test.ts
+++ b/packages/data/src/__tests__/index.test.ts
@@ -37,6 +37,7 @@ const {
   getLatestHumanComment,
   getLatestReworkComment,
   listProjects,
+  listProjectTaskOverviews,
   findProjectById,
   createProject,
   updateProject,
@@ -250,6 +251,68 @@ describe("data layer", () => {
       const result = listTaskListItems("proj-1");
 
       expect(result.map((task) => task.id)).toEqual([backlog.id, planning.id, blocked.id]);
+    });
+  });
+
+  describe("listProjectTaskOverviews", () => {
+    it("returns compact per-project aggregates and limited previews", () => {
+      seedProject("proj-2");
+      createTask({
+        projectId: "proj-1",
+        title: "Backlog A",
+        description: "D",
+        isFix: true,
+        tags: ["x"],
+      });
+      const firstBacklog = createTask({
+        projectId: "proj-1",
+        title: "Backlog first by position",
+        description: "D",
+        position: 10,
+      })!;
+      const backlog = listTasks("proj-1").find((task) => task.title === "Backlog A")!;
+      updateTask(backlog.id, {
+        tokenInput: 5,
+        tokenOutput: 6,
+        tokenTotal: 11,
+      });
+      const done = createTask({
+        projectId: "proj-1",
+        title: "Done B",
+        description: "D",
+        autoMode: false,
+      })!;
+      updateTaskStatus(done.id, "done", {
+        retryCount: 2,
+      });
+      updateTask(done.id, {
+        tokenInput: 10,
+        tokenOutput: 15,
+        tokenTotal: 25,
+        costUsd: 0.5,
+      });
+      createTask({ projectId: "proj-2", title: "Other project", description: "D" });
+
+      const overviews = listProjectTaskOverviews(1);
+      const proj1 = overviews.find((overview) => overview.projectId === "proj-1")!;
+      const proj2 = overviews.find((overview) => overview.projectId === "proj-2")!;
+
+      expect(proj1.totalTasks).toBe(3);
+      expect(proj1.completedTasks).toBe(1);
+      expect(proj1.backlogTasks).toBe(2);
+      expect(proj1.fixTasks).toBe(1);
+      expect(proj1.totalRetries).toBe(2);
+      expect(proj1.totalTokenInput).toBe(15);
+      expect(proj1.totalTokenOutput).toBe(21);
+      expect(proj1.totalTokenTotal).toBe(36);
+      expect(proj1.totalCostUsd).toBe(0.5);
+      expect(proj1.statusCounts.backlog).toBe(2);
+      expect(proj1.statusCounts.done).toBe(1);
+      expect(proj1.statusPreviews.backlog).toEqual([
+        { id: firstBacklog.id, title: "Backlog first by position" },
+      ]);
+      expect(proj1.statusPreviews.done).toEqual([{ id: done.id, title: "Done B" }]);
+      expect(proj2.totalTasks).toBe(1);
     });
   });
 

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -61,6 +61,7 @@ import {
   type Task,
   type TaskListItem,
   type TaskStatus,
+  type ProjectTaskOverview,
   resolveRuntimeLimitFutureHint,
   sanitizeRuntimeLimitSnapshotForExposure,
   selectViolatedWindowForExactThreshold,
@@ -1295,6 +1296,153 @@ export function getAppDefaultRuntimeProfileId(
 
 export function listProjects(): ProjectRow[] {
   return getDb().select().from(projects).all();
+}
+
+function emptyStatusCounts(): Record<TaskStatus, number> {
+  const counts = {} as Record<TaskStatus, number>;
+  for (const status of TASK_STATUSES) {
+    counts[status] = 0;
+  }
+  return counts;
+}
+
+function emptyStatusPreviews(): ProjectTaskOverview["statusPreviews"] {
+  const previews = {} as ProjectTaskOverview["statusPreviews"];
+  for (const status of TASK_STATUSES) {
+    previews[status] = [];
+  }
+  return previews;
+}
+
+function emptyProjectTaskOverview(projectId: string): ProjectTaskOverview {
+  return {
+    projectId,
+    totalTasks: 0,
+    completedTasks: 0,
+    verifiedTasks: 0,
+    backlogTasks: 0,
+    activeTasks: 0,
+    blockedTasks: 0,
+    autoModeTasks: 0,
+    fixTasks: 0,
+    totalRetries: 0,
+    totalTokenInput: 0,
+    totalTokenOutput: 0,
+    totalTokenTotal: 0,
+    totalCostUsd: 0,
+    statusCounts: emptyStatusCounts(),
+    statusPreviews: emptyStatusPreviews(),
+  };
+}
+
+function toFiniteNumber(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+type ProjectTaskPreviewQueryRow = {
+  id: string;
+  projectId: string;
+  title: string;
+  status: TaskStatus;
+};
+
+export function listProjectTaskOverviews(previewLimit = 3): ProjectTaskOverview[] {
+  const db = getDb();
+  const normalizedPreviewLimit = Number.isFinite(previewLimit)
+    ? Math.max(0, Math.trunc(previewLimit))
+    : 0;
+  const projectRows = listProjects();
+  const overviewByProjectId = new Map(
+    projectRows.map((project) => [project.id, emptyProjectTaskOverview(project.id)]),
+  );
+
+  const aggregateRows = db
+    .select({
+      projectId: tasks.projectId,
+      status: tasks.status,
+      taskCount: count(),
+      autoModeTasks: sql<number>`coalesce(sum(case when ${tasks.autoMode} = 1 then 1 else 0 end), 0)`,
+      fixTasks: sql<number>`coalesce(sum(case when ${tasks.isFix} = 1 then 1 else 0 end), 0)`,
+      totalRetries: sql<number>`coalesce(sum(${tasks.retryCount}), 0)`,
+      totalTokenInput: sql<number>`coalesce(sum(${tasks.tokenInput}), 0)`,
+      totalTokenOutput: sql<number>`coalesce(sum(${tasks.tokenOutput}), 0)`,
+      totalTokenTotal: sql<number>`coalesce(sum(${tasks.tokenTotal}), 0)`,
+      totalCostUsd: sql<number>`coalesce(sum(${tasks.costUsd}), 0)`,
+    })
+    .from(tasks)
+    .groupBy(tasks.projectId, tasks.status)
+    .all();
+
+  for (const row of aggregateRows) {
+    const overview = overviewByProjectId.get(row.projectId);
+    if (!overview) continue;
+
+    const taskCount = toFiniteNumber(row.taskCount);
+    const status = row.status;
+    overview.totalTasks += taskCount;
+    overview.statusCounts[status] = taskCount;
+    overview.autoModeTasks += toFiniteNumber(row.autoModeTasks);
+    overview.fixTasks += toFiniteNumber(row.fixTasks);
+    overview.totalRetries += toFiniteNumber(row.totalRetries);
+    overview.totalTokenInput += toFiniteNumber(row.totalTokenInput);
+    overview.totalTokenOutput += toFiniteNumber(row.totalTokenOutput);
+    overview.totalTokenTotal += toFiniteNumber(row.totalTokenTotal);
+    overview.totalCostUsd += toFiniteNumber(row.totalCostUsd);
+
+    if (status === "done" || status === "verified") {
+      overview.completedTasks += taskCount;
+    }
+    if (status === "verified") {
+      overview.verifiedTasks += taskCount;
+    }
+    if (status === "backlog") {
+      overview.backlogTasks += taskCount;
+    }
+    if (status === "blocked_external") {
+      overview.blockedTasks += taskCount;
+    }
+    if (status !== "backlog" && status !== "done" && status !== "verified") {
+      overview.activeTasks += taskCount;
+    }
+  }
+
+  if (normalizedPreviewLimit > 0) {
+    const previewRows = db.all<ProjectTaskPreviewQueryRow>(sql`
+      select
+        id,
+        project_id as "projectId",
+        title,
+        status
+      from (
+        select
+          ${tasks.id} as id,
+          ${tasks.projectId} as project_id,
+          ${tasks.title} as title,
+          ${tasks.status} as status,
+          row_number() over (
+            partition by ${tasks.projectId}, ${tasks.status}
+            order by ${tasks.position} asc, ${tasks.id} asc
+          ) as preview_rank
+        from ${tasks}
+      )
+      where preview_rank <= ${normalizedPreviewLimit}
+      order by project_id asc, status asc, preview_rank asc
+    `);
+
+    for (const row of previewRows) {
+      const overview = overviewByProjectId.get(row.projectId);
+      if (!overview) continue;
+
+      const previews = overview.statusPreviews[row.status];
+      previews.push({ id: row.id, title: row.title });
+    }
+  }
+
+  log.debug(
+    { projectCount: projectRows.length, projection: "project-task-overview" },
+    "Listed project task overviews",
+  );
+  return projectRows.map((project) => overviewByProjectId.get(project.id)!);
 }
 
 export function findProjectById(id: string): ProjectRow | undefined {

--- a/packages/shared/src/browser.ts
+++ b/packages/shared/src/browser.ts
@@ -15,6 +15,8 @@ export {
   type UpdateAppSettingsInput,
   type Task,
   type TaskListItem,
+  type ProjectTaskPreview,
+  type ProjectTaskOverview,
   type CreateTaskInput,
   type UpdateTaskInput,
   type TaskComment,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -63,6 +63,8 @@ export {
   type UpdateAppSettingsInput,
   type Task,
   type TaskListItem,
+  type ProjectTaskPreview,
+  type ProjectTaskOverview,
   type TaskActiveRuntimeSelection,
   type CreateTaskInput,
   type UpdateTaskInput,

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -193,6 +193,30 @@ export interface TaskListItem {
   hasPlan: boolean;
 }
 
+export interface ProjectTaskPreview {
+  id: string;
+  title: string;
+}
+
+export interface ProjectTaskOverview {
+  projectId: string;
+  totalTasks: number;
+  completedTasks: number;
+  verifiedTasks: number;
+  backlogTasks: number;
+  activeTasks: number;
+  blockedTasks: number;
+  autoModeTasks: number;
+  fixTasks: number;
+  totalRetries: number;
+  totalTokenInput: number;
+  totalTokenOutput: number;
+  totalTokenTotal: number;
+  totalCostUsd: number;
+  statusCounts: Record<TaskStatus, number>;
+  statusPreviews: Record<TaskStatus, ProjectTaskPreview[]>;
+}
+
 export interface TaskActiveRuntimeSelection {
   status: TaskStatus;
   profileMode: "task" | "plan" | "review";


### PR DESCRIPTION
## Summary

Per review, rescoped to **purely additive**: `GET /projects/overview` endpoint + shared types + data layer + docs + tests. **No UI migration, no flag.** Head: `916e0a9` (10 files, +378/-1).

The dashboard UI migration (App.tsx, ProjectsOverview → `/overview`) moved to a separate follow-up PR, per the review's option 1 ("keep this PR purely additive: endpoint, data layer, shared types, docs, tests").

## What's here

- **Shared types:** `ProjectTaskOverview`, `ProjectTaskPreview` (exported via `@aif/shared` + `@aif/shared/browser`).
- **Data layer:** `listProjectTaskOverviews(previewLimit)` — per-project status counts, metric totals (`total*`), retry/flag counts, small title previews bounded in SQL via `row_number()`.
- **API:** `GET /projects/overview` route + repository re-export.
- **Docs:** `### Project Task Overview` documents the actual wire shape (`totalToken*`, `blockedTasks`, `completedTasks`/…) — fixes the docs/contract mismatch raised in the #138 review (must-fix #1).

## Why no flag

The endpoint is **purely additive** — it adds a new route without changing or replacing any existing contract. Nothing user-facing switches behavior in this PR. The dashboard keeps its current behavior (legacy bare `GET /tasks`) until the separate UI-migration PR lands.

## Chain context

| PR | Scope | State |
|---|---|---|
| **#138** | `TaskListItem` + lite scoped `GET /tasks` + Board migration | ✅ approved |
| **#139 (this)** | `GET /projects/overview` endpoint (additive) | pure backend, no UI |
| **follow-up** | dashboard UI migration → `/overview` | separate PR |
| **#142** | remove dead `listTasks()` no-arg client overload (non-breaking) | stacked |
| **#140** | perf runner (independent) | ✅ approved |

## Verification

- `tsc --noEmit` clean across shared/data/api/web.
- Tests: data **214**, api **405**, web **666** — all green.
- `prettier` + `build` green.

## Fork-to-fork note

GitHub doesn't allow fork-to-fork PRs, so this targets `main` and its diff temporarily includes #138's commits **until #138 merges**, then auto-rebases to this single commit (`916e0a9`). Review #138 first.