### PR TITLE
fix(mcp): support concurrent clients on HTTP transport

### DIFF
--- a/.ai-factory/patches/2026-07-10-16.22.md
+++ b/.ai-factory/patches/2026-07-10-16.22.md
@@ -1,0 +1,75 @@
+# Gate MCP HTTP multi-session behind an off-by-default env flag
+
+**Date:** 2026-07-10 16:22
+**Files:** packages/mcp/src/env.ts, packages/mcp/src/server.ts, packages/mcp/src/__tests__/httpTransport.test.ts, docs/mcp-sync.md, .env.example
+**Severity:** medium
+
+## Problem
+
+PR #146 fixed the MCP HTTP transport so multiple clients (Claude Code windows)
+can connect, by replacing the single process-wide stateful transport with
+stateless per-request server/transport construction. Code review (REQUEST_CHANGES)
+flagged three issues:
+
+1. **Must fix:** the `/mcp` path unconditionally flipped every HTTP deployment to
+   the new stateless behavior — a non-trivial change to an external MCP transport
+   contract with no rollout guard.
+2. **Should fix:** the stateless path accepted any HTTP method, so the SDK
+   client's optional `GET /mcp` SSE stream held an idle server/transport open per
+   client for events this server never pushes through the transport.
+3. **Should fix:** the regression test only proved two `initialize` requests stop
+   colliding — it never proved a client can `initialize` then actually
+   `tools/list`/`tools/call` through the stateless path.
+
+## Root Cause
+
+1. The fix optimized for correctness but ignored the project rollout rule: a risky
+   behavior change on an external contract must default to the previous behavior.
+   Shipping the new transport as the unconditional default gives operators no safe
+   fallback if the stateless path misbehaves in their environment.
+2. Routing sent all methods into a fresh transport. In stateless request/response
+   usage there is no reason to serve `GET` SSE — events are delivered out-of-band
+   via the API broadcast endpoint (`utils/broadcast.ts`), so an accepted GET is a
+   pure resource leak.
+3. The test asserted the absence of `-32600` but not the presence of working tool
+   calls, so a transport change that fixed init while breaking real MCP usage
+   would pass.
+
+## Solution
+
+- Added `AIF_MCP_HTTP_MULTI_SESSION_ENABLED` (default **false**) parsed once in
+  `loadMcpEnv` (`env.ts`) using the shared `1/true/yes/on` boolean convention.
+- `createMcpHttpHandler` now selects the `/mcp` behavior once at build time:
+  - flag **true** → `createStatelessMcpDispatcher`: fresh server+transport per
+    `POST`; non-POST methods get `405 Allow: POST` (no idle SSE stream).
+  - flag **false** → `createSingleSessionMcpDispatcher`: one shared stateful
+    transport (`sessionIdGenerator: () => randomUUID()`) connected lazily once —
+    preserves the exact previous behavior (2nd client still gets `-32600`).
+- Test suite exercises both paths: the multi-session suite adds `initialize →
+  tools/list` (proves real usage) and `GET /mcp → 405`; a new legacy suite proves
+  the flag-off path still returns `-32600` for the 2nd client.
+- Documented the flag in `.env.example` and `docs/mcp-sync.md` (prose + env table).
+
+Verified: `@aif/mcp` tests (88 passing), lint, `format:check`, and monorepo
+`build` (typecheck) all green.
+
+## Prevention
+
+- **Gate external-contract behavior changes behind an off-by-default env flag.**
+  When a change alters how an outside client talks to us (transport, protocol,
+  API shape), keep the old behavior as the default and make the new behavior an
+  explicit opt-in. Flip the default only after the new path has soaked.
+- **Regression tests must assert real end-to-end usage, not just the absence of
+  the reported error.** For a protocol/transport fix, drive the full client
+  sequence (`initialize` → `tools/list`) so a fix that trades one break for
+  another is caught.
+- **SDK note (MCP `@modelcontextprotocol/sdk` 1.29.0):** stateless mode
+  (`sessionIdGenerator: undefined`) needs a fresh transport per request (reuse
+  causes message-ID collisions). `validateSession` early-returns when session
+  management is off, and there is no protocol-layer initialize-gate, so a
+  standalone `tools/list` POST is served — stateless fully supports real usage.
+  Serve `POST` only and answer optional `GET` SSE with `405`.
+
+## Tags
+
+`#mcp` `#feature-flag` `#rollout` `#http-transport` `#stateless` `#test-coverage` `#code-review`

--- a/.ai-factory/plans/feature-mcp-http-multi-session.md
+++ b/.ai-factory/plans/feature-mcp-http-multi-session.md
@@ -1,0 +1,185 @@
+# Implementation Plan: Multi-Session MCP HTTP Transport
+
+Branch: feature/mcp-http-multi-session
+Created: 2026-07-06
+
+## Original Request
+multi-session MCP HTTP transport
+
+## Settings
+- Testing: yes
+- Logging: verbose
+- Docs: yes  # mandatory docs checkpoint in /aif-implement
+
+## Roadmap Linkage
+Milestone: "none"
+Rationale: Bug fix within the already-completed "Bidirectional Handoff ↔ AIF Sync" milestone; not a new milestone.
+
+## Problem Statement
+
+`packages/mcp/src/index.ts` `startHttp()` creates **one** `McpServer` and **one**
+`StreamableHTTPServerTransport({ sessionIdGenerator: () => randomUUID() })` for the
+whole process, and routes every `/mcp` request into that single transport.
+
+`sessionIdGenerator` being a function puts the transport in **stateful mode**, which is
+built for a single session. The first Claude Code window sends `initialize` → the transport
+sets `_initialized = true`. Any second window's `initialize` into the same transport returns
+JSON-RPC `-32600 "Server already initialized"` (SDK `webStandardStreamableHttp.js`). Result:
+only one session ever connects; other windows fail.
+
+### Chosen fix: stateless per-request transport
+
+Switch to `sessionIdGenerator: undefined` (**stateless mode**) and create a fresh
+`McpServer` + `StreamableHTTPServerTransport` per `/mcp` request, closing both when the
+response ends. This is the canonical MCP stateless pattern from the SDK examples and lets
+any window connect independently.
+
+This is safe here because server→client events do **not** flow through the MCP transport:
+`utils/broadcast.ts:20-21` and `notifier.ts:26` push updates via HTTP `POST` to the API
+(`/tasks/:id/broadcast`). No session-scoped SSE streaming is needed, so stateful session
+tracking (a `Map<sessionId, transport>`) is unnecessary complexity.
+
+### Key constraint: shared RateLimiter
+
+`createMcpServer()` currently builds a `new RateLimiter(...)` internally (`index.ts:35-38`),
+and `RateLimiter` holds a stateful in-memory token-bucket `Map` (`rateLimit.ts:22`). If we
+create a new server per request, a new RateLimiter would be created per request and its
+buckets would reset every call — silently disabling rate limiting. Therefore the
+`RateLimiter`/`ToolContext` MUST be hoisted to startup scope and **shared** across all
+per-request servers.
+
+## Tasks
+
+### Phase 1: Refactor for shared context & testability (no behavior change)
+
+- [x] Task 1: Create import-safe `packages/mcp/src/server.ts` and hoist shared `ToolContext`/`RateLimiter`.
+  - **Why a new module:** `index.ts` calls `main()` at top level, so it **self-starts the
+    server on import**. A test that imports the HTTP handler from `index.ts` would boot the
+    process (or `process.exit(1)` on env error). Move the testable factories into a
+    side-effect-free `server.ts`; `index.ts` stays the thin runnable entry (Task 2).
+  - Add `createToolContext(env)` in `server.ts` that constructs the `RateLimiter` and returns
+    the `ToolContext` once.
+  - Move `createMcpServer` into `server.ts` and change its signature to accept an injected
+    `context: ToolContext` (`createMcpServer(context)`), registering the same 9 tools against
+    the shared context instead of building a `RateLimiter` inside.
+  - Move `startStdio` into `server.ts`; it builds the context once and passes it in (stdio
+    stays single-session; behavior unchanged).
+  - LOGGING (verbose): `DEBUG` on `createToolContext` with resolved rate-limit config
+    (rpm/burst read+write); keep the `[mcp:...]` prefix and DEBUG/INFO/ERROR levels.
+  - Files: `packages/mcp/src/server.ts` (new), `packages/mcp/src/index.ts`
+
+- [x] Task 2: Extract the HTTP request handler seam into `server.ts`; make `index.ts` a thin entry. (depends on 1)
+  - Add `createMcpHttpHandler(env, context)` in `server.ts` returning a Node `(req, res)`
+    handler that owns the `/health`, `/mcp`, and `404` routing (currently inline in
+    `startHttp`). Move `startHttp` into `server.ts`; it builds `context` once via
+    `createToolContext(env)`, builds the handler, passes it to `createServer(...)`, and keeps
+    `listen()` + the existing graceful-shutdown block.
+  - Reduce `index.ts` to `import { main } from "./server.js"; main().catch(...)` plus the
+    existing public re-exports (`loadMcpEnv`, `RateLimiter`, error helpers,
+    `ToolContext`/`ToolRegistrar` types) — re-export them from `server.ts` so `@aif/mcp`
+    consumers are unaffected. `index.ts` must remain the ONLY module with a top-level `main()`.
+  - **Import ordering (correctness):** keep `import "./stdioEnv.js"` as the FIRST line of
+    `index.ts`, before `import "./server.js"`, and do NOT import it from `server.ts`. It sets
+    `LOG_DESTINATION=stderr` before `@aif/shared`'s logger initialises; in stdio mode, logging
+    to stdout otherwise corrupts JSON-RPC (`stdioEnv.ts:2`, commit `cdad443`). Tests import
+    `server.ts` and must not flip `LOG_DESTINATION`.
+  - Keeps the **current** single stateful transport for now — pure restructure, behavior
+    unchanged. `createMcpHttpHandler` / `createToolContext` are exported from `server.ts` for tests.
+  - LOGGING (verbose): `DEBUG` per `/mcp` dispatch (HTTP method); keep the existing
+    `INFO` "listening" log on `listen()`.
+  - Files: `packages/mcp/src/server.ts`, `packages/mcp/src/index.ts`
+
+### Phase 2: Stateless per-request fix (red → green)
+
+- [x] Task 3: Add integration test `packages/mcp/src/__tests__/httpTransport.test.ts`. (depends on 2)
+  - Follow existing test conventions in `__tests__/tools.test.ts` (vitest; mock
+    `@aif/shared` `getEnv` and `@aif/shared/server` `getDb` with an in-memory test DB). Import
+    the handler from `server.ts` — NOT `index.ts`, which self-runs `main()`.
+  - Bind a real server: `http.createServer(createMcpHttpHandler(env, context)).listen(0)`,
+    read the ephemeral port, drive it with `fetch`.
+  - **Request contract (critical — else the SDK returns 406):** every `/mcp` POST must send
+    headers `Content-Type: application/json` AND `Accept: application/json, text/event-stream`
+    (SDK `webStandardStreamableHttp.js:377-380`). The `initialize` body is JSON-RPC 2.0:
+    `{ jsonrpc:"2.0", id:1, method:"initialize", params:{ protocolVersion:"2025-06-18",
+    capabilities:{}, clientInfo:{ name:"test", version:"0" } } }`. The transport replies as
+    `text/event-stream` by default — parse the SSE `data:` frame to read the JSON-RPC result.
+  - Case A (multi-session, the core regression): send **two** independent `initialize` POSTs
+    (no `mcp-session-id` header). Assert both succeed with a valid `initialize` result and that
+    **neither** body carries error code `-32600` ("Server already initialized"). RED against
+    the current stateful transport.
+  - Case B (shared RateLimiter guard): assert the `RateLimiter` is created once and shared —
+    e.g. two servers built from the same context reference the same `rateLimiter` instance
+    (referential equality). Guards against reintroducing a per-request `RateLimiter`.
+  - `/health` smoke assertion (200 `{status:"ok"}`) — locks the routing seam AND guards the
+    production Docker healthcheck (`docker-compose.production.yml:185`) that depends on `/health`.
+  - Coverage: add a `404` assertion for an unknown path (and exercise the `/mcp` error path) so
+    the extracted `createMcpHttpHandler` branches stay within the 70% coverage rule.
+  - Test hygiene: close the ephemeral `http.Server` in `afterEach`/`afterAll` (open handles
+    hang vitest). Use a supported `protocolVersion` — `SUPPORTED_PROTOCOL_VERSIONS` includes
+    `2025-06-18`; or import `LATEST_PROTOCOL_VERSION` from the SDK types.
+  - LOGGING: n/a (test); assert on structured JSON-RPC error **codes**, never message
+    substrings (project rule + patch `2026-06-30-11.27`).
+  - Files: `packages/mcp/src/__tests__/httpTransport.test.ts`
+
+- [x] Task 4: Implement stateless per-request transport (makes Task 3 green). (depends on 3)
+  - In the `/mcp` branch of `createMcpHttpHandler`, **per request** create
+    `transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined })` and
+    `server = createMcpServer(context)` (shared context), register
+    `res.on("close", () => { transport.close(); server.close(); })`, then
+    `await server.connect(transport); await transport.handleRequest(req, res)`.
+  - **Fresh transport per request is an SDK hard requirement, not a style choice:** a stateless
+    transport handles exactly one request — reusing one throws
+    (`webStandardStreamableHttp.js:137-139`, `if (!this.sessionIdGenerator && this._hasHandledRequest)`).
+    Do NOT hoist the transport out of the per-request path.
+  - Method handling: POST carries JSON-RPC. In stateless mode the SDK handles non-POST methods
+    on `/mcp` itself — a `GET /mcp` opens a standalone SSE stream and returns `200` (or `406`
+    if the `Accept` header omits `text/event-stream`), `DELETE /mcp` returns `200`, and only
+    genuinely unsupported methods (PUT/PATCH) hit the `405` `handleUnsupportedRequest` path
+    (`webStandardStreamableHttp.js:363`). No standalone SSE wiring is needed — server→client
+    events flow through the API broadcast endpoint, not MCP SSE. Optional: since no
+    session-scoped SSE is used, the `/mcp` branch may restrict itself to `POST` and return
+    `405` for other methods to avoid leaving dangling GET SSE streams open.
+  - Make the handler `async`; wrap the `/mcp` body in `try/catch` and return a structured
+    JSON-RPC 500 error on failure (don't leave the socket hanging). The current code does
+    **not** await `handleRequest` — the new code must await it.
+  - Remove the now-unused `import { randomUUID } from "node:crypto"`. Leave `startStdio` untouched.
+  - LOGGING (verbose): `DEBUG` on transport create + `res` "close"/teardown; `ERROR` with full
+    context in the `catch`.
+  - Files: `packages/mcp/src/server.ts`
+
+### Phase 3: Docs, validation & operational verification
+
+- [x] Task 5: Documentation checkpoint (mandatory — Docs: yes).
+  - Route through `/aif-docs`. **Primary target:** `docs/mcp-sync.md` → the
+    "HTTP — Docker / remote" section (~lines 48-62). Document that the Streamable HTTP transport
+    now supports **multiple concurrent clients/sessions** (stateless per-request), so several
+    Claude Code windows / remote clients can connect to `http://<host>:<MCP_PORT>/mcp` at once.
+    Note server→client events travel via the API broadcast endpoint, not the MCP transport.
+  - Mention that the Docker deployment (`docker-compose*.yml`, `MCP_TRANSPORT=http`) and the
+    web-UI-installed HTTP URL form (`POST /settings/mcp/install`) benefit directly; **no
+    `docker-compose` change is required** (same port/endpoint/transport).
+  - Secondary, only if `/aif-docs` finds drift: `docs/api.md`, `docs/configuration.md`.
+  - LOGGING: n/a (docs).
+  - Files: `docs/mcp-sync.md` (primary; others as `/aif-docs` determines)
+
+- [x] Task 6: Package checklist, validation & restart/verify.
+  - Run `packages/mcp/CHECKLIST.md` manually: `npm run lint` and `npm test` for `@aif/mcp`
+    (Zod validation + unit tests already covered; new HTTP test added in Task 3). Note
+    `ai:checklist` only prints a reminder — it does not run the checklist.
+  - Run `npm run ai:validate` (project rule — mandatory after implementation). The steps that
+    actually exercise `@aif/mcp` are `format:check`, `lint`, `test`, `coverage`, `build`;
+    `ai:perf` (@aif/web), `ai:load` (@aif/api), `ai:protocol` (@aif/runtime codex) are
+    unrelated to this change and may need their own running services.
+  - Restart the running MCP HTTP process so the fix takes effect: it auto-restarts if launched
+    via `npm run dev` (uses `--watch` in `packages/mcp/scripts/dev-http.mjs`); the currently
+    running process was started **without** `--watch`, so it needs a manual restart. Ensure the
+    registered port (`http://localhost:1234/mcp`) is free before restart.
+  - Verify: open two Claude Code windows and confirm the `handoff` MCP connects (initializes)
+    in **both** — no `-32600`.
+  - LOGGING: n/a (verification).
+  - Files: none (operational)
+
+## Commit Plan
+- **Commit 1** (after tasks 1-2): `refactor(mcp): extract import-safe server module with shared ToolContext and HTTP handler`
+- **Commit 2** (after tasks 3-4): `fix(mcp): stateless per-request HTTP transport for multi-session support`
+- **Commit 3** (after tasks 5-6): `docs(mcp): document multi-session HTTP transport`

--- a/.ai-factory/qa/feature-mcp-http-multi-session-2b3eae4a/change-summary.md
+++ b/.ai-factory/qa/feature-mcp-http-multi-session-2b3eae4a/change-summary.md
@@ -1,0 +1,71 @@
+## Change Summary
+
+**Commits:** 0 (uncommitted working-tree changes on `feature/mcp-http-multi-session`)
+**Changed files:** 4
+**Risk level:** 🟡 Medium
+
+> Note: the change is not yet committed; evidence is taken from the working tree and `git diff` against `main` plus the two new untracked files.
+
+---
+
+### What Changed
+
+Fixed the Handoff MCP HTTP transport so multiple clients (several Claude Code windows, or remote clients) can connect at the same time. Previously the HTTP server built a single shared **stateful** transport for the whole process, so only the first client could `initialize`; every later client received JSON-RPC `-32600 "Server already initialized"`. The MCP entry point was refactored into an import-safe module with a **stateless per-request** transport and a single shared rate limiter. The `stdio` transport (default for local Claude Code) is unchanged in behavior.
+
+---
+
+### Affected Areas
+
+| Component | Change type | Description |
+|-----------|-------------|-------------|
+| `packages/mcp/src/server.ts` | Added | Pure, import-safe factories `createToolContext` / `createMcpServer(context)` / `createMcpHttpHandler(env, context)`; stateless per-request HTTP transport (`sessionIdGenerator: undefined`). |
+| `packages/mcp/src/index.ts` | Changed | Reduced to a thin process entry (`startStdio` / `startHttp` / `main` + graceful shutdown) delegating to `server.ts`; `import "./stdioEnv.js"` kept as the first line. |
+| `packages/mcp/src/__tests__/httpTransport.test.ts` | Added | Integration tests: two independent `initialize` calls, `/health`, `404`, shared stateful `RateLimiter`. |
+| `docs/mcp-sync.md` | Changed | Documented concurrent multi-client support in the "HTTP — Docker / remote" section. |
+
+---
+
+### Evidence
+
+| Finding | Evidence |
+|---------|----------|
+| Root cause: one shared stateful transport | Old `startHttp` in `index.ts` (git diff): single `new StreamableHTTPServerTransport({ sessionIdGenerator: () => randomUUID() })`, every `/mcp` request routed into it; SDK returns `-32600` on the 2nd `initialize` (`webStandardStreamableHttp.js:421-427`). |
+| Fix: stateless per-request transport | `server.ts` `createMcpHttpHandler` — fresh `createMcpServer(context)` + `StreamableHTTPServerTransport({ sessionIdGenerator: undefined })` per `/mcp` request; SDK requires this (`webStandardStreamableHttp.js:138-140`). |
+| Shared rate limiter preserved | `createToolContext(env)` built once; `createMcpServer(context)` takes the injected shared context; `RateLimiter` holds an in-memory bucket `Map` (`rateLimit.ts:22`). |
+| stdio stdout hygiene | `index.ts:1` `import "./stdioEnv.js"` (sets `LOG_DESTINATION=stderr` before logger init). |
+| Green build | `@aif/mcp`: lint clean, `tsc` clean, 85 tests pass, coverage Functions 100% / Lines 94.69%. |
+
+---
+
+### Risks
+
+🔴 **Critical** (must verify):
+
+- **stdio transport regression.** stdio is the default local transport; the refactor changed `createMcpServer` to take an injected context. If `startStdio` wiring is wrong, local Claude Code loses the MCP entirely.
+- **HTTP multi-client.** Two or more clients must each `initialize` over HTTP without `-32600`.
+
+🟡 **Medium** (should verify):
+
+- **Docker `/health`.** The production compose healthcheck (`docker-compose.production.yml:185`) depends on `/health` returning `200`.
+- **Rate limiting still enforced.** The shared limiter must not reset per request (would silently disable throttling).
+- **Graceful shutdown.** `SIGINT`/`SIGTERM` must still free the port (tsx-watch reload / Ctrl+C).
+
+🟢 **Low** (nice to verify):
+
+- `404` for unknown paths; unsupported methods return `405`; missing `Accept` header returns `406`.
+- Per-request allocation of a fresh server/transport under load (no HTTP-layer connection cap).
+
+---
+
+### Testing Recommendations
+
+**First priority:**
+
+- [ ] Local `stdio` MCP still connects and tools work (`listTasks` / `getTask` / `createTask`).
+- [ ] Two Claude Code windows both connect over HTTP concurrently — no `-32600`.
+
+**Regression:**
+
+- [ ] Docker container healthcheck passes (`/health` → `200 {status:"ok"}`).
+- [ ] Rate limiting still triggers under a burst of read/write tool calls.
+- [ ] Ctrl+C / signal frees `MCP_PORT` (no "port already in use" on restart).

--- a/.ai-factory/qa/feature-mcp-http-multi-session-2b3eae4a/test-cases.md
+++ b/.ai-factory/qa/feature-mcp-http-multi-session-2b3eae4a/test-cases.md
@@ -1,0 +1,197 @@
+## Test Cases: Multi-Session MCP HTTP Transport
+
+---
+
+### TC-001: Two concurrent HTTP clients both initialize (core regression)
+
+**Priority:** High
+**Type:** Positive
+
+**Precondition:** MCP server running in HTTP mode (`MCP_TRANSPORT=http MCP_PORT=3100`), port `3100` reachable.
+
+**Steps:**
+
+1. Send a JSON-RPC `initialize` POST to `http://localhost:3100/mcp` with headers `Content-Type: application/json` and `Accept: application/json, text/event-stream` (client A).
+2. Without any shared session id, send a second, independent `initialize` POST to the same URL (client B).
+3. Read both responses.
+
+**Expected result:**
+
+Both requests return HTTP `200` with a valid `initialize` result (server capabilities). Neither response body contains error code `-32600 "Server already initialized"`.
+
+**Test data:**
+
+```
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"clientA","version":"0"}}}
+```
+
+---
+
+### TC-002: Two real Claude Code windows connect simultaneously
+
+**Priority:** High
+**Type:** Positive
+
+**Precondition:** `handoff` registered as HTTP MCP (`"url": "http://localhost:<port>/mcp"`); MCP process restarted after the fix.
+
+**Steps:**
+
+1. Open Claude Code window 1 and confirm the `handoff` MCP is connected (tools listed).
+2. Open Claude Code window 2 pointed at the same MCP URL.
+3. In each window, invoke a tool (e.g. `listTasks`).
+
+**Expected result:**
+
+Both windows show `handoff` connected; the second window does not fail with `-32600`. Tool calls succeed in both.
+
+---
+
+### TC-003: stdio transport still works (regression)
+
+**Priority:** High
+**Type:** Positive
+
+**Precondition:** `.mcp.json` uses the stdio entry (`MCP_TRANSPORT=stdio`, `tsx packages/mcp/src/index.ts`).
+
+**Steps:**
+
+1. Start Claude Code with the stdio-configured `handoff` MCP.
+2. Confirm the MCP connects (no handshake corruption on stdout).
+3. Call `getTask` / `listTasks`.
+
+**Expected result:**
+
+MCP connects; tools respond with valid JSON. No log lines leak onto stdout (logs go to stderr). No JSON-RPC handshake errors.
+
+---
+
+### TC-004: Tool call over HTTP returns a valid result
+
+**Priority:** High
+**Type:** Positive
+
+**Precondition:** HTTP MCP running; at least one project/task seeded.
+
+**Steps:**
+
+1. `initialize` over HTTP (headers as in TC-001).
+2. Send a `tools/call` for `listTasks` (or `listProjects`).
+
+**Expected result:**
+
+A valid JSON-RPC result is returned with the tool payload; no `-32600` / `-32603`.
+
+---
+
+### TC-005: `/health` endpoint (Docker healthcheck regression)
+
+**Priority:** High
+**Type:** Positive
+
+**Precondition:** HTTP MCP running (local or Docker container).
+
+**Steps:**
+
+1. `GET http://localhost:<port>/health`.
+2. (Docker) `docker inspect` the `mcp` service health status after startup.
+
+**Expected result:**
+
+`GET /health` → `200` with body `{"status":"ok"}`. Docker healthcheck reports `healthy`.
+
+---
+
+### TC-006: Shared rate limiter still enforced under burst
+
+**Priority:** Medium
+**Type:** Positive
+
+**Precondition:** HTTP MCP running with default limits (read burst `10`, `120` rpm).
+
+**Steps:**
+
+1. Fire more than `burst` read-tool calls in quick succession across separate HTTP requests.
+2. Observe responses / server logs.
+
+**Expected result:**
+
+After the burst is exhausted, further calls are rate-limited (rate-limit error / `Rate limit hit` log) rather than all succeeding. This proves the limiter is shared across per-request servers, not reset each request.
+
+---
+
+### TC-007: Graceful shutdown frees the port
+
+**Priority:** Medium
+**Type:** Positive
+
+**Precondition:** HTTP MCP running in the foreground.
+
+**Steps:**
+
+1. Send `SIGINT` (Ctrl+C) or `SIGTERM` to the process.
+2. Immediately restart the server on the same `MCP_PORT`.
+
+**Expected result:**
+
+Process logs "Shutdown signal received — exiting" and exits; the port is released; restart succeeds with no `EADDRINUSE`.
+
+---
+
+### TC-008: Unknown path returns 404
+
+**Priority:** Medium
+**Type:** Negative
+
+**Steps:**
+
+1. `GET http://localhost:<port>/unknown`.
+
+**Expected result:**
+
+HTTP `404` with body `Not found`.
+
+---
+
+### TC-009: POST /mcp without required Accept header
+
+**Priority:** Medium
+**Type:** Negative
+
+**Steps:**
+
+1. POST a JSON-RPC `initialize` to `/mcp` with `Content-Type: application/json` but **omit** `text/event-stream` from `Accept`.
+
+**Expected result:**
+
+HTTP `406` with JSON-RPC error `-32000 "Not Acceptable: Client must accept both application/json and text/event-stream"`. (Confirms the client-header contract; not a server bug.)
+
+---
+
+### TC-010: Unsupported HTTP method on /mcp
+
+**Priority:** Low
+**Type:** Negative
+
+**Steps:**
+
+1. Send `PUT` (or `PATCH`) to `http://localhost:<port>/mcp`.
+
+**Expected result:**
+
+HTTP `405` (method not allowed) from the SDK. `GET`/`DELETE` are handled by the SDK (SSE stream / `200`), only genuinely unsupported methods return `405`.
+
+---
+
+## Test Data (based on test design techniques)
+
+### Positive
+
+* Valid `initialize` with `Accept: application/json, text/event-stream`, `protocolVersion: 2025-06-18`.
+* Two independent clients (no shared `mcp-session-id`).
+* `MCP_PORT` default `3100` and a custom valid port (`1234`).
+
+### Negative
+
+* `initialize` POST missing `text/event-stream` in `Accept` → `406`.
+* `PUT /mcp` → `405`.
+* `GET /unknown` → `404`.

--- a/.ai-factory/qa/feature-mcp-http-multi-session-2b3eae4a/test-plan.md
+++ b/.ai-factory/qa/feature-mcp-http-multi-session-2b3eae4a/test-plan.md
@@ -1,0 +1,96 @@
+## Test Plan: Multi-Session MCP HTTP Transport
+
+**Date:** 2026-07-06
+**Branch / Version:** feature/mcp-http-multi-session
+**Environment:** local (stdio + HTTP) and Docker
+
+---
+
+### 1. Testing Goal
+
+Verify that the Handoff MCP server accepts **multiple concurrent HTTP clients** (fixing the `-32600 "Server already initialized"` collision) while the `stdio` transport, `/health` endpoint, rate limiting, and graceful shutdown keep working exactly as before.
+
+---
+
+### 2. Test Scope
+
+**In Scope** — we test:
+
+- HTTP transport: concurrent `initialize` from multiple clients, tool calls, `/health`, `404`, method/`Accept` handling.
+- `stdio` transport: local Claude Code connection and a basic tool round-trip.
+- Shared rate limiter behavior across requests.
+- Graceful shutdown / port release.
+- Docker deployment healthcheck.
+
+**Out of Scope** — we don't test:
+
+- The individual MCP tool business logic (unchanged; already covered by `tools.test.ts`).
+- The API broadcast / WebSocket push path (unchanged by this transport fix).
+- DB schema / migrations (untouched).
+
+---
+
+### 3. Test Types
+
+| Type | Priority | Area |
+|------|----------|------|
+| Functional | 🔴 High | Concurrent HTTP `initialize`; stdio connect; tool call over HTTP |
+| Regression | 🔴 High | stdio transport; `/health`; rate limiting; graceful shutdown |
+| Edge cases | 🟡 Medium | Missing `Accept` header (`406`); unsupported method (`405`); unknown path (`404`) |
+| Negative | 🟡 Medium | Malformed JSON body; second client while first is mid-request |
+| Security | 🟢 Low | DNS-rebinding protection not enabled (pre-existing; localhost/127.0.0.1 binding) |
+| Performance | 🟢 Low | Per-request server/transport allocation under a burst |
+
+---
+
+### 4. Test Data
+
+| Category | Data | Purpose |
+|----------|------|---------|
+| Valid data | JSON-RPC `initialize` with `Accept: application/json, text/event-stream` | Happy path |
+| Boundary values | `MCP_PORT=3100` (default) and a custom valid port (e.g. `1234`) | Port config |
+| Invalid data | POST `/mcp` without `Accept: text/event-stream`; `PUT /mcp` | Negative (`406` / `405`) |
+| Special cases | Two clients initializing at (near) the same time | Core regression |
+
+---
+
+### 5. Preconditions
+
+- [ ] `@aif/mcp` built (`npm run build --workspace=@aif/mcp`) or runnable via tsx.
+- [ ] For HTTP: `MCP_TRANSPORT=http` and a free `MCP_PORT`.
+- [ ] For Docker: image built, `docker compose up` for the `mcp` service.
+- [ ] Two Claude Code windows available for the concurrent-client check.
+
+---
+
+### 6. Acceptance Criteria
+
+- [ ] All 🔴 high-priority test cases pass (concurrent HTTP init; stdio still works; tool call works).
+- [ ] `/health` returns `200 {status:"ok"}` (Docker healthcheck green).
+- [ ] Rate limiting still triggers under burst (shared limiter, not reset per request).
+- [ ] `SIGINT`/`SIGTERM` frees the port; restart succeeds without "address in use".
+- [ ] No `-32600` for any client after the first.
+
+---
+
+### 7. Plan Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Uncommitted change — testing on working tree | Medium | Run automated suite (`npm test --workspace=@aif/mcp`) first; then manual two-window check |
+| SSE response may keep POST stream open | Low | Automated multi-session test already passes (stream closes after the single response) |
+| Full `ai:validate` not run (needs web/api/runtime services) | Low | MCP-scoped gates (format/lint/test/coverage/build) verified separately |
+
+### 8. Checklist
+
+| Check | Priority |
+|-------|----------|
+| Two HTTP clients `initialize` without `-32600` | High |
+| stdio transport connects and a tool responds | High |
+| Tool call over HTTP returns a valid result | High |
+| `/health` → `200 {status:"ok"}` | High |
+| Rate limit triggers under burst (shared limiter) | Medium |
+| `SIGINT`/`SIGTERM` frees the port | Medium |
+| Unknown path → `404` | Medium |
+| POST `/mcp` without `Accept: text/event-stream` → `406` | Medium |
+| Unsupported method (`PUT`/`PATCH`) → `405` | Low |

--- a/.env.example
+++ b/.env.example
@@ -202,6 +202,12 @@ AGENT_BYPASS_PERMISSIONS=true
 # MCP_TRANSPORT=stdio
 # HTTP port when MCP_TRANSPORT=http (default: 3100)
 # MCP_PORT=3100
+# Multi-session HTTP transport (opt-in, default off). When unset/false the HTTP
+# transport keeps the legacy single-session behavior (only one client can
+# initialize). Set to true/1/yes/on to let multiple clients — e.g. several
+# Claude Code windows — connect concurrently to the same /mcp endpoint.
+# Only used when MCP_TRANSPORT=http.
+# AIF_MCP_HTTP_MULTI_SESSION_ENABLED=false
 # Rate limits
 # MCP_RATE_LIMIT_READ_RPM=120
 # MCP_RATE_LIMIT_WRITE_RPM=30

--- a/docs/mcp-sync.md
+++ b/docs/mcp-sync.md
@@ -61,6 +61,8 @@ When running in Docker, or in local development with `MCP_PORT` set to a valid i
 
 The HTTP mode also exposes a `/health` endpoint for Docker healthchecks.
 
+The HTTP transport is **stateless** — each request is handled independently, so multiple clients (several Claude Code windows, or remote clients) can connect to the same `/mcp` endpoint concurrently. Every `initialize` gets its own short-lived server/transport with no shared session, so a second client no longer collides with the first (previously the second client received `-32600 "Server already initialized"`). Server→client events (task updates) are delivered out-of-band via the API broadcast endpoint, not through the MCP transport.
+
 When the web settings UI calls `POST /settings/mcp/install`, the API installs this HTTP URL form automatically whenever `MCP_PORT` is a valid integer port. If `MCP_PORT` is missing or invalid, it falls back to the local `stdio`/`npx tsx packages/mcp/src/index.ts` entry. Direct MCP HTTP startup (`packages/mcp`) is stricter: invalid `MCP_PORT` values fail fast during startup instead of silently coercing the port.
 
 ### Environment Variables

--- a/docs/mcp-sync.md
+++ b/docs/mcp-sync.md
@@ -61,7 +61,9 @@ When running in Docker, or in local development with `MCP_PORT` set to a valid i
 
 The HTTP mode also exposes a `/health` endpoint for Docker healthchecks.
 
-The HTTP transport is **stateless** — each request is handled independently, so multiple clients (several Claude Code windows, or remote clients) can connect to the same `/mcp` endpoint concurrently. Every `initialize` gets its own short-lived server/transport with no shared session, so a second client no longer collides with the first (previously the second client received `-32600 "Server already initialized"`). Server→client events (task updates) are delivered out-of-band via the API broadcast endpoint, not through the MCP transport.
+By default the HTTP transport runs in **single-session** mode: one shared server/transport for the whole process (the original behavior). Because that transport is stateful, only the first client can `initialize` — a second concurrent client (e.g. another Claude Code window) receives `-32600 "Server already initialized"`.
+
+Set `AIF_MCP_HTTP_MULTI_SESSION_ENABLED=true` to opt into **stateless multi-session** mode. Each request then gets its own short-lived server/transport with no shared session, so multiple clients (several Claude Code windows, or remote clients) can connect to the same `/mcp` endpoint concurrently and every `initialize` succeeds independently. The flag defaults to off so enabling concurrent clients is an intentional rollout rather than an unconditional transport change. The stateless path is `POST`-only: an optional `GET /mcp` SSE stream is answered with `405` (the SDK treats this as "server does not offer SSE"), because server→client events (task updates) are delivered out-of-band via the API broadcast endpoint, not through the MCP transport.
 
 When the web settings UI calls `POST /settings/mcp/install`, the API installs this HTTP URL form automatically whenever `MCP_PORT` is a valid integer port. If `MCP_PORT` is missing or invalid, it falls back to the local `stdio`/`npx tsx packages/mcp/src/index.ts` entry. Direct MCP HTTP startup (`packages/mcp`) is stricter: invalid `MCP_PORT` values fail fast during startup instead of silently coercing the port.
 
@@ -69,14 +71,15 @@ When the web settings UI calls `POST /settings/mcp/install`, the API installs th
 
 The MCP server uses the shared monorepo environment (`packages/shared/src/env.ts`) for database and API configuration. MCP-specific variables:
 
-| Variable                     | Default | Description                                                |
-| ---------------------------- | ------- | ---------------------------------------------------------- |
-| `MCP_TRANSPORT`              | `stdio` | Transport mode: `stdio` or `http`                          |
-| `MCP_PORT`                   | `3100`  | HTTP port (`1-65535`, only used when `MCP_TRANSPORT=http`) |
-| `MCP_RATE_LIMIT_READ_RPM`    | `120`   | Read tool rate limit (requests/minute)                     |
-| `MCP_RATE_LIMIT_READ_BURST`  | `10`    | Read tool burst capacity                                   |
-| `MCP_RATE_LIMIT_WRITE_RPM`   | `30`    | Write tool rate limit (requests/minute)                    |
-| `MCP_RATE_LIMIT_WRITE_BURST` | `5`     | Write tool burst capacity                                  |
+| Variable                             | Default | Description                                                                                                                                          |
+| ------------------------------------ | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MCP_TRANSPORT`                      | `stdio` | Transport mode: `stdio` or `http`                                                                                                                    |
+| `MCP_PORT`                           | `3100`  | HTTP port (`1-65535`, only used when `MCP_TRANSPORT=http`)                                                                                           |
+| `AIF_MCP_HTTP_MULTI_SESSION_ENABLED` | `false` | Opt into stateless multi-session HTTP transport so multiple clients connect concurrently (`1/true/yes/on` = on). Only used when `MCP_TRANSPORT=http` |
+| `MCP_RATE_LIMIT_READ_RPM`            | `120`   | Read tool rate limit (requests/minute)                                                                                                               |
+| `MCP_RATE_LIMIT_READ_BURST`          | `10`    | Read tool burst capacity                                                                                                                             |
+| `MCP_RATE_LIMIT_WRITE_RPM`           | `30`    | Write tool rate limit (requests/minute)                                                                                                              |
+| `MCP_RATE_LIMIT_WRITE_BURST`         | `5`     | Write tool burst capacity                                                                                                                            |
 
 Shared variables (from `@aif/shared`):
 

--- a/packages/mcp/src/__tests__/httpTransport.test.ts
+++ b/packages/mcp/src/__tests__/httpTransport.test.ts
@@ -38,10 +38,12 @@ const env = {
   rateLimitWriteRpm: 30,
   rateLimitReadBurst: 10,
   rateLimitWriteBurst: 5,
+  // Exercise the opt-in stateless multi-session path in the main suite.
+  httpMultiSession: true,
 };
 
-/** POST a JSON-RPC `initialize` with the headers the SDK requires (else 406). */
-function initialize(port: number): Promise<Response> {
+/** POST an arbitrary JSON-RPC message with the headers the SDK requires (else 406). */
+function postRpc(port: number, body: Record<string, unknown>): Promise<Response> {
   return fetch(`http://localhost:${port}/mcp`, {
     method: "POST",
     headers: {
@@ -49,16 +51,21 @@ function initialize(port: number): Promise<Response> {
       // The SDK returns 406 unless the client accepts BOTH content types.
       Accept: "application/json, text/event-stream",
     },
-    body: JSON.stringify({
-      jsonrpc: "2.0",
-      id: 1,
-      method: "initialize",
-      params: {
-        protocolVersion: "2025-06-18",
-        capabilities: {},
-        clientInfo: { name: "test-client", version: "0.0.0" },
-      },
-    }),
+    body: JSON.stringify(body),
+  });
+}
+
+/** POST a JSON-RPC `initialize` request. */
+function initialize(port: number): Promise<Response> {
+  return postRpc(port, {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-06-18",
+      capabilities: {},
+      clientInfo: { name: "test-client", version: "0.0.0" },
+    },
   });
 }
 
@@ -78,7 +85,7 @@ async function readJsonRpc(res: Response): Promise<Record<string, unknown> | nul
   return null;
 }
 
-describe("MCP HTTP transport", () => {
+describe("MCP HTTP transport — multi-session (opt-in)", () => {
   let server: Server;
   let port: number;
 
@@ -116,6 +123,44 @@ describe("MCP HTTP transport", () => {
     expect(body2?.result).toBeDefined();
   });
 
+  it("lets a client initialize then list tools through the stateless path", async () => {
+    // Proves real MCP usage works, not just the initialize handshake: a
+    // transport change that fixed init but broke tools/list would be caught
+    // here. Stateless per-request transports do not gate tools/list behind a
+    // prior initialize on the same connection, so a fresh POST lists tools.
+    const initRes = await initialize(port);
+    expect(initRes.status).toBe(200);
+    await readJsonRpc(initRes);
+
+    const listRes = await postRpc(port, {
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/list",
+      params: {},
+    });
+    const listBody = await readJsonRpc(listRes);
+
+    expect(listRes.status).toBe(200);
+    expect(listBody?.error).toBeUndefined();
+    const tools = (listBody?.result as { tools?: unknown[] } | undefined)?.tools;
+    expect(Array.isArray(tools)).toBe(true);
+    expect((tools as unknown[]).length).toBeGreaterThan(0);
+  });
+
+  it("rejects non-POST /mcp with 405 instead of opening an idle SSE stream", async () => {
+    // The SDK client opens an optional GET SSE stream after init and treats 405
+    // as "no server SSE". Since events are pushed out-of-band via the API
+    // broadcast endpoint, accepting GET would hold an idle server/transport per
+    // client for no benefit — so the stateless path is POST-only.
+    const res = await fetch(`http://localhost:${port}/mcp`, {
+      method: "GET",
+      headers: { Accept: "text/event-stream" },
+    });
+    expect(res.status).toBe(405);
+    expect(res.headers.get("allow")).toContain("POST");
+    await res.text();
+  });
+
   it("returns 404 for unknown paths", async () => {
     const res = await fetch(`http://localhost:${port}/unknown`);
     expect(res.status).toBe(404);
@@ -132,5 +177,36 @@ describe("MCP HTTP transport", () => {
       expect(context.rateLimiter.check("listTasks", "read")).toBe(true);
     }
     expect(context.rateLimiter.check("listTasks", "read")).toBe(false);
+  });
+});
+
+describe("MCP HTTP transport — legacy single-session (default, flag off)", () => {
+  const legacyEnv = { ...env, httpMultiSession: false };
+  let server: Server;
+  let port: number;
+
+  beforeAll(async () => {
+    const context = createToolContext(legacyEnv);
+    server = createServer(createMcpHttpHandler(legacyEnv, context));
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    port = (server.address() as AddressInfo).port;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it("preserves previous behavior: the 2nd client initialize collides with -32600", async () => {
+    // With the flag off, one shared stateful transport is reused across the
+    // process. The first client initializes, the second collides — the exact
+    // pre-fix behavior that AIF_MCP_HTTP_MULTI_SESSION_ENABLED gates.
+    const res1 = await initialize(port);
+    const body1 = await readJsonRpc(res1);
+    expect(res1.status).toBe(200);
+    expect(body1?.result).toBeDefined();
+
+    const res2 = await initialize(port);
+    const body2 = await readJsonRpc(res2);
+    expect((body2?.error as { code?: number } | undefined)?.code).toBe(-32600);
   });
 });

--- a/packages/mcp/src/__tests__/httpTransport.test.ts
+++ b/packages/mcp/src/__tests__/httpTransport.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { createTestDb } from "@aif/shared/server";
+
+// Set up an in-memory test DB before importing the server (tools reach the DB
+// through @aif/data → @aif/shared/server getDb).
+const testDb = { current: createTestDb() };
+vi.mock("@aif/shared/server", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@aif/shared/server")>();
+  return {
+    ...actual,
+    getDb: () => testDb.current,
+  };
+});
+
+// Mock env to avoid shared env validation.
+vi.mock("@aif/shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@aif/shared")>();
+  return {
+    ...actual,
+    getEnv: () => ({
+      API_BASE_URL: "http://localhost:3009",
+      DATABASE_URL: ":memory:",
+      PORT: 3009,
+    }),
+  };
+});
+
+// Import the handler from server.ts — NOT index.ts, which self-runs main().
+const { createMcpHttpHandler, createToolContext } = await import("../server.js");
+
+const env = {
+  apiUrl: "http://localhost:3009",
+  transport: "http" as const,
+  httpPort: 0,
+  rateLimitReadRpm: 120,
+  rateLimitWriteRpm: 30,
+  rateLimitReadBurst: 10,
+  rateLimitWriteBurst: 5,
+};
+
+/** POST a JSON-RPC `initialize` with the headers the SDK requires (else 406). */
+function initialize(port: number): Promise<Response> {
+  return fetch(`http://localhost:${port}/mcp`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      // The SDK returns 406 unless the client accepts BOTH content types.
+      Accept: "application/json, text/event-stream",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "test-client", version: "0.0.0" },
+      },
+    }),
+  });
+}
+
+/** Read a JSON-RPC payload from either a JSON or an SSE (`data:`) response. */
+async function readJsonRpc(res: Response): Promise<Record<string, unknown> | null> {
+  const text = await res.text();
+  const contentType = res.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    return text ? (JSON.parse(text) as Record<string, unknown>) : null;
+  }
+  for (const line of text.split(/\r?\n/)) {
+    if (line.startsWith("data:")) {
+      const payload = line.slice(5).trim();
+      if (payload) return JSON.parse(payload) as Record<string, unknown>;
+    }
+  }
+  return null;
+}
+
+describe("MCP HTTP transport", () => {
+  let server: Server;
+  let port: number;
+
+  beforeAll(async () => {
+    const context = createToolContext(env);
+    server = createServer(createMcpHttpHandler(env, context));
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    port = (server.address() as AddressInfo).port;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it("serves /health for Docker healthchecks", async () => {
+    const res = await fetch(`http://localhost:${port}/health`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: "ok" });
+  });
+
+  it("lets two independent clients initialize without -32600", async () => {
+    // The core regression: with a single shared stateful transport the second
+    // initialize returned -32600 "Server already initialized". Stateless
+    // per-request transports let every client initialize independently.
+    const res1 = await initialize(port);
+    const body1 = await readJsonRpc(res1);
+    const res2 = await initialize(port);
+    const body2 = await readJsonRpc(res2);
+
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
+    expect((body1?.error as { code?: number } | undefined)?.code).not.toBe(-32600);
+    expect((body2?.error as { code?: number } | undefined)?.code).not.toBe(-32600);
+    expect(body1?.result).toBeDefined();
+    expect(body2?.result).toBeDefined();
+  });
+
+  it("returns 404 for unknown paths", async () => {
+    const res = await fetch(`http://localhost:${port}/unknown`);
+    expect(res.status).toBe(404);
+    await res.text();
+  });
+
+  it("createToolContext builds one stateful, shared RateLimiter", () => {
+    // The handler closes over a single context, so every per-request server
+    // shares this limiter. If it were rebuilt per request the bucket would
+    // reset and rate limiting would silently break — so assert the bucket
+    // accumulates state across calls.
+    const context = createToolContext(env);
+    for (let i = 0; i < env.rateLimitReadBurst; i++) {
+      expect(context.rateLimiter.check("listTasks", "read")).toBe(true);
+    }
+    expect(context.rateLimiter.check("listTasks", "read")).toBe(false);
+  });
+});

--- a/packages/mcp/src/env.ts
+++ b/packages/mcp/src/env.ts
@@ -17,6 +17,26 @@ export interface McpEnv {
   rateLimitReadBurst: number;
   /** Rate limit: burst size for write tools */
   rateLimitWriteBurst: number;
+  /**
+   * Opt-in flag for the stateless multi-session HTTP transport. Defaults to
+   * `false` (legacy single-session behavior). Set
+   * `AIF_MCP_HTTP_MULTI_SESSION_ENABLED` to 1/true/yes/on to let multiple
+   * clients (e.g. several Claude Code windows) connect concurrently to the same
+   * `/mcp` endpoint. Only relevant when `transport` is `http`.
+   */
+  httpMultiSession: boolean;
+}
+
+const BOOLEAN_TRUE_VALUES = new Set(["1", "true", "yes", "on"]);
+
+/**
+ * Parse an opt-in boolean env flag. Defaults to `false` unless the value is one
+ * of 1/true/yes/on (case-insensitive) — matches `@aif/shared` env boolean
+ * semantics so operators get consistent behavior across packages.
+ */
+function parseBooleanFlag(value: string | undefined): boolean {
+  if (!value) return false;
+  return BOOLEAN_TRUE_VALUES.has(value.trim().toLowerCase());
 }
 
 function resolveMcpPort(value: string | undefined, transport: McpEnv["transport"]): number {
@@ -65,12 +85,14 @@ export function loadMcpEnv(): McpEnv {
     rateLimitWriteRpm: parseInt(process.env.MCP_RATE_LIMIT_WRITE_RPM || "30", 10),
     rateLimitReadBurst: parseInt(process.env.MCP_RATE_LIMIT_READ_BURST || "10", 10),
     rateLimitWriteBurst: parseInt(process.env.MCP_RATE_LIMIT_WRITE_BURST || "5", 10),
+    httpMultiSession: parseBooleanFlag(process.env.AIF_MCP_HTTP_MULTI_SESSION_ENABLED),
   };
 
   log.info(
     {
       transport: env.transport,
       httpPort: env.httpPort,
+      httpMultiSession: env.httpMultiSession,
     },
     "MCP environment loaded",
   );

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,94 +1,26 @@
+// stdioEnv MUST be imported first — it forces logs to stderr before the
+// @aif/shared logger initialises, keeping stdout clean for stdio JSON-RPC.
 import "./stdioEnv.js";
 import { createServer } from "node:http";
-import { randomUUID } from "node:crypto";
 import { logger } from "@aif/shared";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { loadMcpEnv } from "./env.js";
-import { RateLimiter } from "./middleware/rateLimit.js";
-import type { ToolContext } from "./tools/index.js";
-import { register as registerListTasks } from "./tools/listTasks.js";
-import { register as registerGetTask } from "./tools/getTask.js";
-import { register as registerSearchTasks } from "./tools/searchTasks.js";
-import { register as registerListProjects } from "./tools/listProjects.js";
-import { register as registerCreateTask } from "./tools/createTask.js";
-import { register as registerUpdateTask } from "./tools/updateTask.js";
-import { register as registerSyncStatus } from "./tools/syncStatus.js";
-import { register as registerPushPlan } from "./tools/pushPlan.js";
-import { register as registerAnnotatePlan } from "./tools/annotatePlan.js";
+import type { McpEnv } from "./env.js";
+import { createToolContext, createMcpServer, createMcpHttpHandler } from "./server.js";
 
 const log = logger("mcp");
 
-function createMcpServer(env: ReturnType<typeof loadMcpEnv>): McpServer {
-  const server = new McpServer(
-    {
-      name: "handoff-mcp",
-      version: "0.1.0",
-    },
-    {
-      capabilities: {
-        tools: {},
-      },
-    },
-  );
-
-  const rateLimiter = new RateLimiter(
-    { rpm: env.rateLimitReadRpm, burst: env.rateLimitReadBurst },
-    { rpm: env.rateLimitWriteRpm, burst: env.rateLimitWriteBurst },
-  );
-
-  const context: ToolContext = { rateLimiter };
-
-  // Register read-only tools
-  registerListTasks(server, context);
-  registerGetTask(server, context);
-  registerSearchTasks(server, context);
-  registerListProjects(server, context);
-
-  // Register write tools
-  registerCreateTask(server, context);
-  registerUpdateTask(server, context);
-  registerSyncStatus(server, context);
-  registerPushPlan(server, context);
-  registerAnnotatePlan(server, context);
-
-  return server;
-}
-
-async function startStdio(env: ReturnType<typeof loadMcpEnv>) {
-  const server = createMcpServer(env);
+async function startStdio(env: McpEnv) {
+  const context = createToolContext(env);
+  const server = createMcpServer(context);
   const transport = new StdioServerTransport();
   await server.connect(transport);
   log.info("MCP server connected via stdio transport");
 }
 
-async function startHttp(env: ReturnType<typeof loadMcpEnv>) {
-  const server = createMcpServer(env);
-
-  const transport = new StreamableHTTPServerTransport({
-    sessionIdGenerator: () => randomUUID(),
-  });
-
-  await server.connect(transport);
-
-  const httpServer = createServer((req, res) => {
-    const url = new URL(req.url ?? "/", `http://localhost:${env.httpPort}`);
-
-    if (url.pathname === "/health") {
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ status: "ok" }));
-      return;
-    }
-
-    if (url.pathname === "/mcp") {
-      transport.handleRequest(req, res);
-      return;
-    }
-
-    res.writeHead(404);
-    res.end("Not found");
-  });
+async function startHttp(env: McpEnv) {
+  const context = createToolContext(env);
+  const httpServer = createServer(createMcpHttpHandler(env, context));
 
   httpServer.listen(env.httpPort, () => {
     log.info(
@@ -138,7 +70,6 @@ main().catch((error) => {
   process.exit(1);
 });
 
-export { loadMcpEnv } from "./env.js";
-export { RateLimiter } from "./middleware/rateLimit.js";
-export { toMcpError, rateLimitError, validationError } from "./middleware/errorHandler.js";
-export type { ToolContext, ToolRegistrar } from "./tools/index.js";
+// Public surface for consumers of the @aif/mcp package.
+export { loadMcpEnv, RateLimiter, toMcpError, rateLimitError, validationError } from "./server.js";
+export type { ToolContext, ToolRegistrar } from "./server.js";

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,0 +1,144 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { logger } from "@aif/shared";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import type { McpEnv } from "./env.js";
+import { RateLimiter } from "./middleware/rateLimit.js";
+import type { ToolContext } from "./tools/index.js";
+import { register as registerListTasks } from "./tools/listTasks.js";
+import { register as registerGetTask } from "./tools/getTask.js";
+import { register as registerSearchTasks } from "./tools/searchTasks.js";
+import { register as registerListProjects } from "./tools/listProjects.js";
+import { register as registerCreateTask } from "./tools/createTask.js";
+import { register as registerUpdateTask } from "./tools/updateTask.js";
+import { register as registerSyncStatus } from "./tools/syncStatus.js";
+import { register as registerPushPlan } from "./tools/pushPlan.js";
+import { register as registerAnnotatePlan } from "./tools/annotatePlan.js";
+
+const log = logger("mcp");
+
+/**
+ * Build the shared tool context (rate limiter) once at startup.
+ *
+ * In HTTP mode a fresh {@link McpServer} is created per request, but every
+ * request MUST share this context: the {@link RateLimiter} keeps stateful
+ * in-memory token buckets, so rebuilding it per request would reset the buckets
+ * and silently disable rate limiting.
+ */
+export function createToolContext(env: McpEnv): ToolContext {
+  const rateLimiter = new RateLimiter(
+    { rpm: env.rateLimitReadRpm, burst: env.rateLimitReadBurst },
+    { rpm: env.rateLimitWriteRpm, burst: env.rateLimitWriteBurst },
+  );
+
+  log.debug(
+    {
+      read: { rpm: env.rateLimitReadRpm, burst: env.rateLimitReadBurst },
+      write: { rpm: env.rateLimitWriteRpm, burst: env.rateLimitWriteBurst },
+    },
+    "Shared tool context created",
+  );
+
+  return { rateLimiter };
+}
+
+/**
+ * Create an {@link McpServer} and register all tools against the shared context.
+ * Cheap to call — safe to invoke per request in stateless HTTP mode.
+ */
+export function createMcpServer(context: ToolContext): McpServer {
+  const server = new McpServer(
+    {
+      name: "handoff-mcp",
+      version: "0.1.0",
+    },
+    {
+      capabilities: {
+        tools: {},
+      },
+    },
+  );
+
+  // Register read-only tools
+  registerListTasks(server, context);
+  registerGetTask(server, context);
+  registerSearchTasks(server, context);
+  registerListProjects(server, context);
+
+  // Register write tools
+  registerCreateTask(server, context);
+  registerUpdateTask(server, context);
+  registerSyncStatus(server, context);
+  registerPushPlan(server, context);
+  registerAnnotatePlan(server, context);
+
+  return server;
+}
+
+/**
+ * Build the Node HTTP request handler. Exposed (with the factories above) for
+ * tests so routing + transport wiring can be exercised without binding a port
+ * or importing the process entry (`index.ts` self-runs `main()` on import).
+ */
+export function createMcpHttpHandler(env: McpEnv, context: ToolContext) {
+  return async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
+    const url = new URL(req.url ?? "/", `http://localhost:${env.httpPort}`);
+
+    if (url.pathname === "/health") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ status: "ok" }));
+      return;
+    }
+
+    if (url.pathname === "/mcp") {
+      log.debug({ method: req.method }, "MCP request received");
+
+      // Stateless mode: a StreamableHTTPServerTransport with no sessionIdGenerator
+      // handles exactly ONE request, so a fresh server + transport is created per
+      // request. This lets every client (each Claude Code window) initialize
+      // independently instead of colliding on a single shared stateful session
+      // (which returned -32600 "Server already initialized" for the 2nd client).
+      // Server->client events do not travel through this transport — they are
+      // pushed via the API broadcast endpoint — so no session tracking is needed.
+      const server = createMcpServer(context);
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+      });
+
+      res.on("close", () => {
+        log.debug("MCP request closed — tearing down per-request server/transport");
+        void transport.close();
+        void server.close();
+      });
+
+      try {
+        await server.connect(transport);
+        await transport.handleRequest(req, res);
+      } catch (error) {
+        log.error(
+          { error: error instanceof Error ? error.message : String(error) },
+          "MCP request handling failed",
+        );
+        if (!res.headersSent) {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              error: { code: -32603, message: "Internal server error" },
+              id: null,
+            }),
+          );
+        }
+      }
+      return;
+    }
+
+    res.writeHead(404);
+    res.end("Not found");
+  };
+}
+
+export { loadMcpEnv } from "./env.js";
+export { RateLimiter } from "./middleware/rateLimit.js";
+export { toMcpError, rateLimitError, validationError } from "./middleware/errorHandler.js";
+export type { ToolContext, ToolRegistrar } from "./tools/index.js";

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { randomUUID } from "node:crypto";
 import { logger } from "@aif/shared";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
@@ -75,12 +76,25 @@ export function createMcpServer(context: ToolContext): McpServer {
   return server;
 }
 
+type McpDispatcher = (req: IncomingMessage, res: ServerResponse) => Promise<void>;
+
 /**
  * Build the Node HTTP request handler. Exposed (with the factories above) for
  * tests so routing + transport wiring can be exercised without binding a port
  * or importing the process entry (`index.ts` self-runs `main()` on import).
+ *
+ * Routing (`/health`, `/mcp`, 404) is shared; the `/mcp` behavior is selected
+ * ONCE, at handler-build time, by `env.httpMultiSession`:
+ *  - `true`  → stateless per-request server/transport (multiple clients connect
+ *              concurrently — see {@link createStatelessMcpDispatcher}).
+ *  - `false` → legacy single shared stateful transport, preserving the previous
+ *              behavior (see {@link createSingleSessionMcpDispatcher}).
  */
 export function createMcpHttpHandler(env: McpEnv, context: ToolContext) {
+  const handleMcp = env.httpMultiSession
+    ? createStatelessMcpDispatcher(context)
+    : createSingleSessionMcpDispatcher(context);
+
   return async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
     const url = new URL(req.url ?? "/", `http://localhost:${env.httpPort}`);
 
@@ -91,51 +105,110 @@ export function createMcpHttpHandler(env: McpEnv, context: ToolContext) {
     }
 
     if (url.pathname === "/mcp") {
-      log.debug({ method: req.method }, "MCP request received");
-
-      // Stateless mode: a StreamableHTTPServerTransport with no sessionIdGenerator
-      // handles exactly ONE request, so a fresh server + transport is created per
-      // request. This lets every client (each Claude Code window) initialize
-      // independently instead of colliding on a single shared stateful session
-      // (which returned -32600 "Server already initialized" for the 2nd client).
-      // Server->client events do not travel through this transport — they are
-      // pushed via the API broadcast endpoint — so no session tracking is needed.
-      const server = createMcpServer(context);
-      const transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: undefined,
-      });
-
-      res.on("close", () => {
-        log.debug("MCP request closed — tearing down per-request server/transport");
-        void transport.close();
-        void server.close();
-      });
-
-      try {
-        await server.connect(transport);
-        await transport.handleRequest(req, res);
-      } catch (error) {
-        log.error(
-          { error: error instanceof Error ? error.message : String(error) },
-          "MCP request handling failed",
-        );
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              jsonrpc: "2.0",
-              error: { code: -32603, message: "Internal server error" },
-              id: null,
-            }),
-          );
-        }
-      }
+      await handleMcp(req, res);
       return;
     }
 
     res.writeHead(404);
     res.end("Not found");
   };
+}
+
+/**
+ * Multi-session transport (opt-in via `AIF_MCP_HTTP_MULTI_SESSION_ENABLED`).
+ *
+ * A {@link StreamableHTTPServerTransport} with no `sessionIdGenerator` handles
+ * exactly ONE request, so a fresh server + transport is created per POST. This
+ * lets every client (each Claude Code window) initialize independently instead
+ * of colliding on a single shared stateful session (which returned -32600
+ * "Server already initialized" for the 2nd client). Server->client events do not
+ * travel through this transport — they are pushed via the API broadcast
+ * endpoint — so no session tracking is needed.
+ *
+ * The stateless path is request/response only: it accepts `POST` and rejects
+ * other methods with `405`. The SDK client opens an optional `GET /mcp` SSE
+ * stream after initialization and treats `405` as "server does not offer SSE";
+ * refusing it avoids holding an idle server/transport open per connected client
+ * for events we never push through this transport.
+ */
+function createStatelessMcpDispatcher(context: ToolContext): McpDispatcher {
+  return async (req, res) => {
+    log.debug({ method: req.method, mode: "multi-session" }, "MCP request received");
+
+    if (req.method !== "POST") {
+      res.writeHead(405, { Allow: "POST" });
+      res.end("Method Not Allowed");
+      return;
+    }
+
+    const server = createMcpServer(context);
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+    });
+
+    res.on("close", () => {
+      log.debug("MCP request closed — tearing down per-request server/transport");
+      void transport.close();
+      void server.close();
+    });
+
+    try {
+      await server.connect(transport);
+      await transport.handleRequest(req, res);
+    } catch (error) {
+      log.error(
+        { error: error instanceof Error ? error.message : String(error) },
+        "MCP request handling failed",
+      );
+      respondInternalError(res);
+    }
+  };
+}
+
+/**
+ * Legacy single-session transport (default, off-by-default flag).
+ *
+ * ONE server + ONE stateful transport shared across the whole process, connected
+ * once (lazily) on the first request. This preserves the pre-multi-session
+ * behavior: a second client's `initialize` still returns -32600 "Server already
+ * initialized". Kept behind `AIF_MCP_HTTP_MULTI_SESSION_ENABLED` so enabling
+ * concurrent clients is an explicit, intentional rollout rather than an
+ * unconditional change to the external MCP transport contract.
+ */
+function createSingleSessionMcpDispatcher(context: ToolContext): McpDispatcher {
+  const server = createMcpServer(context);
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: () => randomUUID(),
+  });
+  let connected: Promise<void> | null = null;
+
+  return async (req, res) => {
+    log.debug({ method: req.method, mode: "single-session" }, "MCP request received");
+    try {
+      connected ??= server.connect(transport);
+      await connected;
+      await transport.handleRequest(req, res);
+    } catch (error) {
+      log.error(
+        { error: error instanceof Error ? error.message : String(error) },
+        "MCP request handling failed",
+      );
+      respondInternalError(res);
+    }
+  };
+}
+
+/** Send a JSON-RPC internal-error response unless headers were already sent. */
+function respondInternalError(res: ServerResponse): void {
+  if (res.headersSent) return;
+  res.writeHead(500, { "Content-Type": "application/json" });
+  res.end(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      error: { code: -32603, message: "Internal server error" },
+      id: null,
+    }),
+  );
 }
 
 export { loadMcpEnv } from "./env.js";


### PR DESCRIPTION
## Summary

Fixes the Handoff MCP **HTTP transport** so multiple clients can connect concurrently. Previously only one client could ever `initialize`; any second client (a second Claude Code window, or a remote client) was rejected with JSON-RPC `-32600 "Server already initialized"`.

## The bug

**Symptom:** With the `handoff` MCP registered over HTTP (`http://localhost:<MCP_PORT>/mcp`), the first Claude Code window connects fine, but every other window fails to initialize the MCP — only one active session works at a time.

**Root cause:** `startHttp()` in `packages/mcp/src/index.ts` created **one** `McpServer` and **one** `StreamableHTTPServerTransport({ sessionIdGenerator: () => randomUUID() })` for the whole process, and routed every `/mcp` request into that single transport.

Passing a `sessionIdGenerator` puts the transport in **stateful mode**, which is built for a single session:

- Window 1 sends `initialize` → the transport marks `_initialized = true`.
- Window 2 sends `initialize` into the same transport → the SDK returns `-32600 "Server already initialized"` (`@modelcontextprotocol/sdk` `server/webStandardStreamableHttp.js`).

So only the first client ever completes the handshake.

## The fix

Switch the HTTP path to a **stateless per-request transport** (`sessionIdGenerator: undefined`): each `POST /mcp` builds a fresh `McpServer` + `StreamableHTTPServerTransport`, connects, handles the single request, and tears down on response close. Every client initializes independently. The SDK explicitly requires a fresh transport per request in stateless mode.

This is safe because server→client events do **not** travel through the MCP transport — task updates are pushed via the API broadcast endpoint (`/tasks/:id/broadcast`), so no session-scoped SSE or session tracking is needed (a `Map<sessionId, transport>` would be unnecessary).

**Key detail:** the shared `RateLimiter`/`ToolContext` is **hoisted to startup scope** and injected into every per-request server. `RateLimiter` holds stateful in-memory token buckets; rebuilding it per request would reset the buckets and silently disable rate limiting.

## Refactor

- **New** `packages/mcp/src/server.ts` — pure, import-safe factories (`createToolContext`, `createMcpServer(context)`, `createMcpHttpHandler(env, context)`).
- `packages/mcp/src/index.ts` — thin process bootstrap (`startStdio` / `startHttp` / `main` + graceful shutdown) delegating to `server.ts`; `import "./stdioEnv.js"` kept as the first line so stdio stdout stays clean for JSON-RPC.
- The `stdio` transport (default for local Claude Code) is unchanged.

## Tests

New `packages/mcp/src/__tests__/httpTransport.test.ts`:

- **two independent `initialize` calls both succeed with no `-32600`** (the core regression);
- `/health` returns `200 {"status":"ok"}` (Docker healthcheck contract);
- unknown path → `404`;
- shared, stateful `RateLimiter` (guards against a per-request limiter reset).

`@aif/mcp`: 85 tests pass, `tsc` clean, ESLint clean, coverage Functions 100% (≥ 70% threshold).

## Docs

`docs/mcp-sync.md` → "HTTP — Docker / remote" now documents concurrent multi-client support.

## Verification note

The automated multi-session test covers the core regression at the handler level. End-to-end confirmation additionally benefits from restarting the running MCP process (it was launched without `--watch`) and opening two Claude Code windows, both connecting without `-32600`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
