### PR TITLE
feat: organize project picker

### DIFF
--- a/.ai-factory/patches/2026-07-11-14.45.md
+++ b/.ai-factory/patches/2026-07-11-14.45.md
@@ -1,0 +1,44 @@
+# Project picker organization did not scale beyond a short project list
+
+**Date:** 2026-07-11 14:45
+**Files:** `packages/shared/src/schema.ts`, `packages/shared/src/db.ts`, `packages/shared/src/types.ts`, `packages/data/src/index.ts`, `packages/api/src/routes/projects.ts`, `packages/web/src/components/project/ProjectSelector.tsx`, `packages/web/src/components/project/ProjectsOverview.tsx`
+**Severity:** medium
+
+## Problem
+
+Projects were returned in SQLite insertion order and rendered in an unbounded,
+mouse-only picker. Larger installations could not reliably find a project,
+navigate the list with a keyboard, pin important projects, group related
+projects, or sort by real task activity.
+
+## Root Cause
+
+The data boundary exposed SQLite's implicit row order instead of defining a
+stable project ordering contract. The picker was originally designed as a
+small CRUD list, so it had no search state, active option, bounded scrolling,
+or persisted organization metadata. Project activity was also unavailable to
+the UI because the overview aggregate did not retain `MAX(tasks.updated_at)`.
+
+## Solution
+
+Added deterministic case-insensitive ordering with an ID tie-breaker, a v25
+append-only migration for `pinned_at` and `group_name`, and a dedicated
+validated organization PATCH endpoint. The existing overview aggregate now
+returns `lastActivityAt`. The picker reuses existing UI primitives for search,
+bounded scrolling, keyboard navigation, pinning, and flat group sections;
+both picker and overview can sort by name, last activity, or active task count.
+
+## Prevention
+
+- Database list functions must define a total order when consumers depend on a
+  stable visual sequence.
+- Large dropdown regressions should cover search, focus, keyboard selection,
+  empty results, and a bounded scroll region.
+- Persist cross-browser organization metadata at the data/API boundary rather
+  than in browser-local storage.
+- Activity sorting must use task activity aggregates, not project settings
+  timestamps.
+
+## Tags
+
+`#projects` `#ordering` `#react` `#accessibility` `#sqlite` `#migration` `#api`

--- a/.ai-factory/patches/2026-07-15-12.09.md
+++ b/.ai-factory/patches/2026-07-15-12.09.md
@@ -1,0 +1,29 @@
+# Project picker navigation and accessibility review fixes
+
+**Date:** 2026-07-15 12:09
+**Files:** packages/web/src/components/project/ProjectSelector.tsx, packages/web/src/__tests__/ProjectSelector.test.tsx
+**Severity:** medium
+
+## Problem
+
+The grouped project picker navigated the pre-grouping project array instead of the rendered section order. Saving a changed group for the selected project invoked `onSelect` twice and produced duplicate browser-history entries. The listbox lacked a complete active-descendant focus model, and user groups named `Pinned` or `Other` collided with built-in React section keys.
+
+## Root Cause
+
+The picker derived rendering and interaction from two different collections: `projectSections` for the DOM and `filteredProjects` for keyboard indices. Section identity was coupled to display labels, even though user labels share the same namespace. Edit success paths independently invoked the navigation callback before and after the organization mutation. Accessibility state also conflated the temporary keyboard highlight with the persisted project selection.
+
+## Solution
+
+Flattened rendered sections into a single `visibleProjects` interaction source, introduced namespaced structural keys, and linked the search combobox to stable listbox option IDs through `aria-activedescendant`. `aria-selected` now reflects `selectedId`, and Escape restores trigger focus from every picker control. The edit callbacks are mutually exclusive when a group changes, so only the final organized project is selected once. Added regression tests for grouped navigation, reserved labels, browser history, ARIA state, and Escape focus restoration.
+
+## Prevention
+
+- Derive keyboard order and DOM rendering from the same final collection.
+- Keep React structural identity separate from user-facing labels.
+- Treat selection callbacks as navigation events and make asynchronous success paths mutually exclusive.
+- Test composite widgets through their focus ownership, active descendant, persisted selection, and Escape behavior.
+- Include user-provided values that match built-in labels in key-collision regression fixtures.
+
+## Tags
+
+`#react` `#accessibility` `#keyboard-navigation` `#browser-history` `#testing`

--- a/.ai-factory/patches/2026-07-16-12.53.md
+++ b/.ai-factory/patches/2026-07-16-12.53.md
@@ -1,0 +1,29 @@
+# Project picker edit callbacks navigated and active indexes drifted
+
+**Date:** 2026-07-16 12:53
+**Files:** packages/web/src/components/project/ProjectSelector.tsx, packages/web/src/__tests__/ProjectSelector.test.tsx
+**Severity:** medium
+
+## Problem
+
+Saving edits to the currently selected project still invoked `onSelect`, which always pushes a browser-history entry. A delayed organization update could also navigate back to the edited project after the user had selected another project. Separately, the combobox stored its active option as an array index, so an asynchronous list reorder could silently change `aria-activedescendant` and the project selected by Enter.
+
+## Root Cause
+
+The edit flow retained a selection callback from an older state model even though the application now derives the selected project from `selectedProjectId` and the invalidated projects query. The delayed callback captured stale selection props, turning a data-update completion into navigation. The combobox also treated a position as option identity even though pinning, grouping, sorting, filtering, and overview refreshes can all reorder the visible array.
+
+## Solution
+
+Removed navigation callbacks from both edit-success paths while retaining query invalidation and contextual `[FIX:pr-150]` organization logs. Replaced the numeric active index state with `activeProjectId`, deriving the current index from the rendered project order. Reordering now preserves option identity, while a missing active ID resets to the first visible project before commit. Added regression tests for zero-history edits, delayed organization responses, unchanged-group edits, and active-option preservation across reorder.
+
+## Prevention
+
+- Keep data-update callbacks separate from navigation callbacks.
+- Never let delayed mutation completion navigate based on captured selection state.
+- Store identity, not position, for active items in asynchronously reordered collections.
+- Test both immediate history effects and late-response races.
+- Reorder a rendered list after keyboard activation when testing `aria-activedescendant` and Enter behavior.
+
+## Tags
+
+`#react` `#combobox` `#async-race` `#browser-history` `#keyboard-navigation` `#testing`

--- a/docs/api.md
+++ b/docs/api.md
@@ -133,6 +133,8 @@ GET /projects
     "planCheckerMaxBudgetUsd": 2,
     "implementerMaxBudgetUsd": 15,
     "reviewSidecarMaxBudgetUsd": 2,
+    "pinnedAt": "2026-01-02T00:00:00.000Z",
+    "groupName": "Platform",
     "createdAt": "2026-01-01T00:00:00.000Z",
     "updatedAt": "2026-01-01T00:00:00.000Z"
   }
@@ -154,6 +156,7 @@ This endpoint does not return full task rows.
 [
   {
     "projectId": "uuid",
+    "lastActivityAt": "2026-01-03T12:00:00.000Z",
     "totalTasks": 12,
     "completedTasks": 2,
     "verifiedTasks": 0,
@@ -195,7 +198,8 @@ This endpoint does not return full task rows.
 that is not `backlog`, `done`, or `verified`. `blockedTasks` counts
 `blocked_external`. `statusPreviews` lists are small (bounded in SQL) and
 include only task id/title pairs — never plan text, logs, or other detail-only
-fields.
+fields. `lastActivityAt` is the latest task `updatedAt` timestamp for the
+project, or `null` when the project has no tasks.
 
 ### Create Project
 
@@ -228,6 +232,30 @@ PUT /projects/:id
 **Body:** Same as Create Project.
 
 **Response:** `200 OK` — the updated project object.
+
+### Update Project Organization
+
+```
+PATCH /projects/:id/organization
+```
+
+Updates picker-only organization metadata without requiring the project's name
+or root path.
+
+**Body:**
+
+| Field       | Type         | Required | Description                                                             |
+| ----------- | ------------ | -------- | ----------------------------------------------------------------------- |
+| `pinned`    | boolean      | no       | Pin or unpin the project. Pinning preserves the original pin timestamp. |
+| `groupName` | string\|null | no       | Flat picker group (max 100 chars); `null` or an empty string clears it. |
+
+At least one field is required.
+
+**Response:** `200 OK` — the updated project object. Returns `404` when the
+project does not exist.
+
+**WebSocket event:** `project:organization_updated` with the full project
+object.
 
 Parallel auto-queue with `git.create_branches=true` requires
 `AIF_TASK_WORKTREES_ENABLED=true`. With the default `false`, the API rejects
@@ -1283,6 +1311,7 @@ All events are JSON with this structure:
 | Event                             | Payload                                                                                            | Triggered By                                                                         |
 | --------------------------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
 | `project:created`                 | Full project object                                                                                | `POST /projects`                                                                     |
+| `project:organization_updated`    | Full project object                                                                                | `PATCH /projects/:id/organization`                                                   |
 | `task:created`                    | Full task object                                                                                   | `POST /tasks`, `POST /projects/:id/roadmap/import`                                   |
 | `task:updated`                    | Full task object                                                                                   | `PUT /tasks/:id`, `PATCH /tasks/:id/position`, `POST /tasks/:id/events` (`fast_fix`) |
 | `task:moved`                      | Full task object                                                                                   | `POST /tasks/:id/events`                                                             |

--- a/packages/api/src/__tests__/projects.test.ts
+++ b/packages/api/src/__tests__/projects.test.ts
@@ -154,6 +154,7 @@ describe("projects API", () => {
           tokenOutput: 20,
           tokenTotal: 30,
           costUsd: 0.25,
+          updatedAt: "2026-01-01T10:00:00.000Z",
         },
         {
           id: "task-a-2",
@@ -161,6 +162,7 @@ describe("projects API", () => {
           title: "Done item",
           status: "done",
           retryCount: 2,
+          updatedAt: "2026-01-03T10:00:00.000Z",
         },
         {
           id: "task-b-1",
@@ -188,6 +190,7 @@ describe("projects API", () => {
       totalTokenOutput: 20,
       totalTokenTotal: 30,
       totalCostUsd: 0.25,
+      lastActivityAt: "2026-01-03T10:00:00.000Z",
     });
     expect(overviewA.statusCounts.backlog).toBe(1);
     expect(overviewA.statusCounts.done).toBe(1);
@@ -227,6 +230,48 @@ describe("projects API", () => {
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.error).toBeDefined();
+  });
+
+  it("updates project pinning and grouping", async () => {
+    testDb.current
+      .insert(projects)
+      .values({ id: "organized", name: "Organized", rootPath: "/tmp/organized" })
+      .run();
+
+    const res = await app.request("/projects/organized/organization", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ pinned: true, groupName: "Platform" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      id: "organized",
+      groupName: "Platform",
+    });
+    expect(mockBroadcast).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "project:organization_updated" }),
+    );
+  });
+
+  it("returns 404 when organizing a missing project", async () => {
+    const res = await app.request("/projects/missing/organization", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ pinned: true }),
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects an empty project organization patch", async () => {
+    const res = await app.request("/projects/missing/organization", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(400);
   });
 
   it("maps Docker host project paths to the container project mount on create", async () => {

--- a/packages/api/src/repositories/projects.ts
+++ b/packages/api/src/repositories/projects.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { isAbsolute, posix, relative, resolve, sep, win32 } from "node:path";
 import { initProject } from "@aif/runtime";
 import { validateProjectRootPath, logger } from "@aif/shared";
+import type { UpdateProjectOrganizationInput } from "@aif/shared";
 import { getApiRuntimeRegistry } from "../services/runtime.js";
 import {
   createProject as createProjectRecord,
@@ -11,6 +12,7 @@ import {
   listProjects,
   type ProjectRow,
   updateProject as updateProjectRecord,
+  updateProjectOrganization as updateProjectOrganizationRecord,
 } from "@aif/data";
 
 const log = logger("projects-repo");
@@ -141,6 +143,13 @@ export function updateProject(
 
 export function deleteProject(id: string): void {
   deleteProjectRecord(id);
+}
+
+export function updateProjectOrganization(
+  id: string,
+  input: UpdateProjectOrganizationInput,
+): ProjectRow | undefined {
+  return updateProjectOrganizationRecord(id, input);
 }
 
 export function getProjectMcpServers(projectId: string): Record<string, unknown> {

--- a/packages/api/src/routes/projects.ts
+++ b/packages/api/src/routes/projects.ts
@@ -22,6 +22,7 @@ import {
   broadcastProjectSchema,
   autoQueueModeSchema,
   warmupCreateSchema,
+  updateProjectOrganizationSchema,
 } from "../schemas.js";
 import { getAutoQueueMode, setAutoQueueMode } from "@aif/data";
 import { broadcast } from "../ws.js";
@@ -31,6 +32,7 @@ import {
   findProjectById,
   createProject,
   updateProject,
+  updateProjectOrganization,
   deleteProject,
   getProjectMcpServers,
 } from "../repositories/projects.js";
@@ -273,6 +275,25 @@ projectsRouter.put("/:id", jsonValidator(createProjectSchema), async (c) => {
   log.debug({ projectId: id }, "Project updated");
   return c.json(updated);
 });
+
+// PATCH /projects/:id/organization - update picker organization metadata
+projectsRouter.patch(
+  "/:id/organization",
+  jsonValidator(updateProjectOrganizationSchema),
+  async (c) => {
+    const { id } = c.req.param();
+    const body = c.req.valid("json");
+    const updated = updateProjectOrganization(id, body);
+    if (!updated) return c.json({ error: "Project not found" }, 404);
+
+    log.debug(
+      { projectId: id, pinned: updated.pinnedAt != null, groupName: updated.groupName },
+      "[FIX:147] Project organization updated",
+    );
+    broadcast({ type: "project:organization_updated", payload: updated });
+    return c.json(updated);
+  },
+);
 
 // GET /projects/:id/mcp — read .mcp.json from project directory
 projectsRouter.get("/:id/mcp", (c) => {

--- a/packages/api/src/schemas.ts
+++ b/packages/api/src/schemas.ts
@@ -45,6 +45,15 @@ export const createProjectSchema = z.object({
   defaultChatRuntimeProfileId: z.string().min(1).nullable().optional(),
 });
 
+export const updateProjectOrganizationSchema = z
+  .object({
+    pinned: z.boolean().optional(),
+    groupName: z.string().trim().max(100).nullable().optional(),
+  })
+  .refine((value) => value.pinned !== undefined || value.groupName !== undefined, {
+    message: "At least one organization field is required",
+  });
+
 export const createTaskSchema = z.object({
   projectId: z.string().min(1, "Project ID is required"),
   title: z.string().min(1, "Title is required").max(500),

--- a/packages/data/src/__tests__/index.test.ts
+++ b/packages/data/src/__tests__/index.test.ts
@@ -41,6 +41,7 @@ const {
   findProjectById,
   createProject,
   updateProject,
+  updateProjectOrganization,
   deleteProject,
   findProjectByTaskId,
   appendTaskActivityLog,
@@ -313,6 +314,23 @@ describe("data layer", () => {
       ]);
       expect(proj1.statusPreviews.done).toEqual([{ id: done.id, title: "Done B" }]);
       expect(proj2.totalTasks).toBe(1);
+    });
+
+    it("returns the latest task activity timestamp per project", () => {
+      const older = createTask({ projectId: "proj-1", title: "Older", description: "D" })!;
+      const newer = createTask({ projectId: "proj-1", title: "Newer", description: "D" })!;
+      testDb.current
+        .update(tasks)
+        .set({ updatedAt: "2026-01-01T10:00:00.000Z" })
+        .where(eq(tasks.id, older.id))
+        .run();
+      testDb.current
+        .update(tasks)
+        .set({ updatedAt: "2026-01-02T10:00:00.000Z" })
+        .where(eq(tasks.id, newer.id))
+        .run();
+
+      expect(listProjectTaskOverviews()[0]?.lastActivityAt).toBe("2026-01-02T10:00:00.000Z");
     });
   });
 
@@ -648,6 +666,24 @@ describe("data layer", () => {
       expect(listProjects()).toHaveLength(1);
     });
 
+    it("listProjects returns projects in deterministic case-insensitive name order", () => {
+      testDb.current.delete(projects).run();
+      testDb.current
+        .insert(projects)
+        .values([
+          { id: "zulu-2", name: "zulu", rootPath: "/tmp/zulu-2" },
+          { id: "alpha", name: "Alpha", rootPath: "/tmp/alpha" },
+          { id: "zulu-1", name: "Zulu", rootPath: "/tmp/zulu-1" },
+        ])
+        .run();
+
+      expect(listProjects().map((project) => project.id)).toEqual([
+        "alpha",
+        "zulu-1",
+        "zulu-2",
+      ]);
+    });
+
     it("findProjectById returns project", () => {
       expect(findProjectById("proj-1")).toBeDefined();
     });
@@ -674,6 +710,32 @@ describe("data layer", () => {
       const updated = updateProject(p!.id, { name: "Updated", rootPath: "/tmp/updated" });
       expect(updated!.name).toBe("Updated");
       expect(updated!.rootPath).toBe("/tmp/updated");
+    });
+
+    it("updates project pin and group organization without changing core fields", () => {
+      const pinned = updateProjectOrganization("proj-1", {
+        pinned: true,
+        groupName: "  Platform  ",
+      });
+
+      expect(pinned).toMatchObject({
+        id: "proj-1",
+        name: "Test",
+        rootPath: "/tmp/test",
+        groupName: "Platform",
+      });
+      expect(pinned?.pinnedAt).toBeTruthy();
+
+      const pinnedAgain = updateProjectOrganization("proj-1", { pinned: true });
+      expect(pinnedAgain?.pinnedAt).toBe(pinned?.pinnedAt);
+
+      const cleared = updateProjectOrganization("proj-1", { pinned: false, groupName: "" });
+      expect(cleared?.pinnedAt).toBeNull();
+      expect(cleared?.groupName).toBeNull();
+    });
+
+    it("returns undefined when organizing a missing project", () => {
+      expect(updateProjectOrganization("missing", { pinned: true })).toBeUndefined();
     });
 
     it("updateProject preserves omitted runtime defaults and clears explicit nulls", () => {

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -62,6 +62,7 @@ import {
   type TaskListItem,
   type TaskStatus,
   type ProjectTaskOverview,
+  type UpdateProjectOrganizationInput,
   resolveRuntimeLimitFutureHint,
   sanitizeRuntimeLimitSnapshotForExposure,
   selectViolatedWindowForExactThreshold,
@@ -1307,7 +1308,16 @@ export function getAppDefaultRuntimeProfileId(
 }
 
 export function listProjects(): ProjectRow[] {
-  return getDb().select().from(projects).all();
+  return getDb()
+    .select()
+    .from(projects)
+    .orderBy(
+      sql`case when ${projects.pinnedAt} is null then 1 else 0 end`,
+      asc(projects.pinnedAt),
+      sql`${projects.name} collate nocase`,
+      asc(projects.id),
+    )
+    .all();
 }
 
 function emptyStatusCounts(): Record<TaskStatus, number> {
@@ -1329,6 +1339,7 @@ function emptyStatusPreviews(): ProjectTaskOverview["statusPreviews"] {
 function emptyProjectTaskOverview(projectId: string): ProjectTaskOverview {
   return {
     projectId,
+    lastActivityAt: null,
     totalTasks: 0,
     completedTasks: 0,
     verifiedTasks: 0,
@@ -1380,6 +1391,7 @@ export function listProjectTaskOverviews(previewLimit = 3): ProjectTaskOverview[
       totalTokenOutput: sql<number>`coalesce(sum(${tasks.tokenOutput}), 0)`,
       totalTokenTotal: sql<number>`coalesce(sum(${tasks.tokenTotal}), 0)`,
       totalCostUsd: sql<number>`coalesce(sum(${tasks.costUsd}), 0)`,
+      lastActivityAt: max(tasks.updatedAt),
     })
     .from(tasks)
     .groupBy(tasks.projectId, tasks.status)
@@ -1400,6 +1412,12 @@ export function listProjectTaskOverviews(previewLimit = 3): ProjectTaskOverview[
     overview.totalTokenOutput += toFiniteNumber(row.totalTokenOutput);
     overview.totalTokenTotal += toFiniteNumber(row.totalTokenTotal);
     overview.totalCostUsd += toFiniteNumber(row.totalCostUsd);
+    if (
+      row.lastActivityAt &&
+      (!overview.lastActivityAt || row.lastActivityAt > overview.lastActivityAt)
+    ) {
+      overview.lastActivityAt = row.lastActivityAt;
+    }
 
     if (status === "done" || status === "verified") {
       overview.completedTasks += taskCount;
@@ -1563,6 +1581,38 @@ export function updateProject(
     .where(eq(projects.id, id))
     .run();
   return findProjectById(id);
+}
+
+export function updateProjectOrganization(
+  id: string,
+  input: UpdateProjectOrganizationInput,
+): ProjectRow | undefined {
+  const existing = findProjectById(id);
+  if (!existing) return undefined;
+
+  const patch: Partial<ProjectRow> = { updatedAt: new Date().toISOString() };
+  if (input.pinned !== undefined) {
+    patch.pinnedAt = input.pinned ? (existing.pinnedAt ?? new Date().toISOString()) : null;
+  }
+  if (input.groupName !== undefined) {
+    patch.groupName = input.groupName?.trim() || null;
+  }
+
+  log.debug(
+    {
+      projectId: id,
+      pinned: patch.pinnedAt != null,
+      groupName: patch.groupName,
+    },
+    "[FIX:147] Updating project organization",
+  );
+  getDb().update(projects).set(patch).where(eq(projects.id, id)).run();
+  const updated = findProjectById(id);
+  log.debug(
+    { projectId: id, updated: updated != null },
+    "[FIX:147] Project organization updated",
+  );
+  return updated;
 }
 
 export function deleteProject(id: string): void {

--- a/packages/shared/src/__tests__/db.test.ts
+++ b/packages/shared/src/__tests__/db.test.ts
@@ -7,7 +7,7 @@ import { eq } from "drizzle-orm";
 import { chatSessions } from "../schema.js";
 import { closeDb, createTestDb, getDb } from "../db.js";
 
-const CURRENT_SCHEMA_VERSION = 24;
+const CURRENT_SCHEMA_VERSION = 25;
 
 function removeSqliteArtifacts(dbPath: string): void {
   for (const path of [dbPath, `${dbPath}-wal`, `${dbPath}-shm`]) {
@@ -82,6 +82,41 @@ describe("db", () => {
     const db2 = createTestDb();
     expect(db1).toBeDefined();
     expect(db2).toBeDefined();
+  });
+
+  it("migrates v24 project tables with pinning and grouping columns", () => {
+    closeDb();
+    const dbPath = join(tmpdir(), `aif-shared-project-org-${Date.now()}-${Math.random()}.sqlite`);
+    const sqlite = new Database(dbPath);
+    sqlite.exec(`
+      CREATE TABLE projects (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        root_path TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )
+    `);
+    sqlite.pragma("user_version = 24");
+    sqlite.close();
+
+    try {
+      getDb(dbPath);
+      closeDb();
+
+      const migrated = new Database(dbPath, { readonly: true });
+      const columns = migrated.pragma("table_info(projects)") as Array<{ name: string }>;
+      const userVersion = migrated.pragma("user_version", { simple: true }) as number;
+      migrated.close();
+
+      expect(columns.map((column) => column.name)).toEqual(
+        expect.arrayContaining(["pinned_at", "group_name"]),
+      );
+      expect(userVersion).toBe(CURRENT_SCHEMA_VERSION);
+    } finally {
+      closeDb();
+      removeSqliteArtifacts(dbPath);
+    }
   });
 
   it("creates and seeds a singleton app_settings row", () => {

--- a/packages/shared/src/browser.ts
+++ b/packages/shared/src/browser.ts
@@ -10,6 +10,7 @@ export {
   type AutoReviewFinding,
   type AutoReviewState,
   type Project,
+  type UpdateProjectOrganizationInput,
   type CreateProjectInput,
   type AppSettings,
   type UpdateAppSettingsInput,

--- a/packages/shared/src/db.ts
+++ b/packages/shared/src/db.ts
@@ -48,6 +48,8 @@ function ensureTables(sqlite: Database.Database): void {
       plan_checker_max_budget_usd REAL,
       implementer_max_budget_usd REAL,
       review_sidecar_max_budget_usd REAL,
+      pinned_at TEXT,
+      group_name TEXT,
       parallel_enabled INTEGER NOT NULL DEFAULT 0,
       auto_queue_mode INTEGER NOT NULL DEFAULT 0,
       default_task_runtime_profile_id TEXT,
@@ -730,6 +732,14 @@ const MIGRATIONS: Migration[] = [
     sql: `
       ALTER TABLE tasks ADD COLUMN run_plan_improve INTEGER NOT NULL DEFAULT 0;
       ALTER TABLE tasks ADD COLUMN run_post_verify INTEGER NOT NULL DEFAULT 0;
+    `,
+  },
+  {
+    version: 25,
+    description: "Add project pinning and flat grouping",
+    sql: `
+      ALTER TABLE projects ADD COLUMN pinned_at TEXT;
+      ALTER TABLE projects ADD COLUMN group_name TEXT;
     `,
   },
 ];

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -58,6 +58,7 @@ export {
   type AutoReviewFinding,
   type AutoReviewState,
   type Project,
+  type UpdateProjectOrganizationInput,
   type CreateProjectInput,
   type AppSettings,
   type UpdateAppSettingsInput,

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -12,6 +12,8 @@ export const projects = sqliteTable("projects", {
   planCheckerMaxBudgetUsd: real("plan_checker_max_budget_usd"),
   implementerMaxBudgetUsd: real("implementer_max_budget_usd"),
   reviewSidecarMaxBudgetUsd: real("review_sidecar_max_budget_usd"),
+  pinnedAt: text("pinned_at"),
+  groupName: text("group_name"),
   parallelEnabled: integer("parallel_enabled", { mode: "boolean" }).notNull().default(false),
   autoQueueMode: integer("auto_queue_mode", { mode: "boolean" }).notNull().default(false),
   defaultTaskRuntimeProfileId: text("default_task_runtime_profile_id"),

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -45,6 +45,8 @@ export interface Project {
   planCheckerMaxBudgetUsd: number | null;
   implementerMaxBudgetUsd: number | null;
   reviewSidecarMaxBudgetUsd: number | null;
+  pinnedAt: string | null;
+  groupName: string | null;
   parallelEnabled: boolean;
   autoQueueMode: boolean;
   defaultTaskRuntimeProfileId?: string | null;
@@ -73,6 +75,11 @@ export interface CreateProjectInput {
   defaultPlanRuntimeProfileId?: string | null;
   defaultReviewRuntimeProfileId?: string | null;
   defaultChatRuntimeProfileId?: string | null;
+}
+
+export interface UpdateProjectOrganizationInput {
+  pinned?: boolean;
+  groupName?: string | null;
 }
 
 export interface AppSettings {
@@ -204,6 +211,7 @@ export interface ProjectTaskPreview {
 
 export interface ProjectTaskOverview {
   projectId: string;
+  lastActivityAt: string | null;
   totalTasks: number;
   completedTasks: number;
   verifiedTasks: number;
@@ -355,6 +363,7 @@ export interface ReorderTaskInput {
 /** WebSocket event types */
 export type WsEventType =
   | "project:created"
+  | "project:organization_updated"
   | "task:created"
   | "task:updated"
   | "task:deleted"

--- a/packages/web/src/__tests__/Header.test.tsx
+++ b/packages/web/src/__tests__/Header.test.tsx
@@ -86,6 +86,8 @@ const project: Project = {
   planCheckerMaxBudgetUsd: null,
   implementerMaxBudgetUsd: null,
   reviewSidecarMaxBudgetUsd: null,
+  pinnedAt: null,
+  groupName: null,
   parallelEnabled: false,
   autoQueueMode: true,
   createdAt: "2026-01-01T00:00:00.000Z",

--- a/packages/web/src/__tests__/MetricsDialog.test.tsx
+++ b/packages/web/src/__tests__/MetricsDialog.test.tsx
@@ -36,6 +36,8 @@ function makeProject(overrides: Partial<Project> = {}): Project {
     planCheckerMaxBudgetUsd: null,
     implementerMaxBudgetUsd: null,
     reviewSidecarMaxBudgetUsd: null,
+    pinnedAt: null,
+    groupName: null,
     parallelEnabled: false,
     autoQueueMode: false,
     createdAt: "2026-04-16T00:00:00Z",

--- a/packages/web/src/__tests__/ProjectRuntimeSettings.test.tsx
+++ b/packages/web/src/__tests__/ProjectRuntimeSettings.test.tsx
@@ -114,6 +114,8 @@ const project: Project = {
   planCheckerMaxBudgetUsd: null,
   implementerMaxBudgetUsd: null,
   reviewSidecarMaxBudgetUsd: null,
+  pinnedAt: null,
+  groupName: null,
   parallelEnabled: false,
   autoQueueMode: false,
   defaultTaskRuntimeProfileId: "project-1",

--- a/packages/web/src/__tests__/ProjectSelector.test.tsx
+++ b/packages/web/src/__tests__/ProjectSelector.test.tsx
@@ -1,12 +1,28 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 const mockUseQuery = vi.fn();
 const mutateCreateProject = vi.fn();
 const mutateUpdateProject = vi.fn();
 const mutateDeleteProject = vi.fn();
 const mutateSetAutoQueue = vi.fn();
+const mutateUpdateOrganization = vi.fn();
 const mockToast = vi.fn();
+let mockProjects = [
+  {
+    id: "p-1",
+    name: "Alpha",
+    rootPath: "/tmp/alpha",
+    plannerMaxBudgetUsd: null,
+    planCheckerMaxBudgetUsd: null,
+    implementerMaxBudgetUsd: null,
+    reviewSidecarMaxBudgetUsd: null,
+    pinnedAt: null,
+    groupName: null,
+  },
+];
+
+Element.prototype.scrollIntoView = vi.fn();
 
 vi.mock("@tanstack/react-query", () => ({
   useQuery: (options: unknown) => mockUseQuery(options),
@@ -14,18 +30,9 @@ vi.mock("@tanstack/react-query", () => ({
 
 vi.mock("@/hooks/useProjects", () => ({
   useProjects: () => ({
-    data: [
-      {
-        id: "p-1",
-        name: "Alpha",
-        rootPath: "/tmp/alpha",
-        plannerMaxBudgetUsd: null,
-        planCheckerMaxBudgetUsd: null,
-        implementerMaxBudgetUsd: null,
-        reviewSidecarMaxBudgetUsd: null,
-      },
-    ],
+    data: mockProjects,
   }),
+  useProjectTaskOverviews: () => ({ data: [], isLoading: false }),
   useCreateProject: () => ({
     mutate: mutateCreateProject,
     isPending: false,
@@ -39,6 +46,10 @@ vi.mock("@/hooks/useProjects", () => ({
   }),
   useSetAutoQueueMode: () => ({
     mutate: mutateSetAutoQueue,
+    isPending: false,
+  }),
+  useUpdateProjectOrganization: () => ({
+    mutate: mutateUpdateOrganization,
     isPending: false,
   }),
 }));
@@ -57,7 +68,98 @@ describe("ProjectSelector", () => {
     mutateUpdateProject.mockReset();
     mutateDeleteProject.mockReset();
     mutateSetAutoQueue.mockReset();
+    mutateUpdateOrganization.mockReset();
     mockToast.mockReset();
+    mockProjects = [
+      {
+        id: "p-1",
+        name: "Alpha",
+        rootPath: "/tmp/alpha",
+        plannerMaxBudgetUsd: null,
+        planCheckerMaxBudgetUsd: null,
+        implementerMaxBudgetUsd: null,
+        reviewSidecarMaxBudgetUsd: null,
+        pinnedAt: null,
+        groupName: null,
+      },
+    ];
+  });
+
+  it("searches projects by name and root path in a bounded dropdown", async () => {
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+    mockProjects = [
+      ...mockProjects,
+      {
+        ...mockProjects[0],
+        id: "p-2",
+        name: "Translator Android",
+        rootPath: "/workspace/mobile/android",
+      },
+      {
+        ...mockProjects[0],
+        id: "p-3",
+        name: "Storage Radar",
+        rootPath: "/workspace/storage/mac",
+      },
+    ];
+
+    render(<ProjectSelector selectedId="p-1" onSelect={() => {}} onDeselect={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: /alpha/i }));
+
+    const search = screen.getByRole("textbox", { name: "Search projects" });
+    await waitFor(() => expect(document.activeElement).toBe(search));
+    expect(screen.getByRole("listbox").parentElement?.className).toContain("max-h-[60vh]");
+    expect(screen.getByRole("listbox").parentElement?.className).toContain("overflow-y-auto");
+
+    fireEvent.change(search, { target: { value: "translator" } });
+    expect(screen.getByText("Translator Android")).toBeDefined();
+    expect(screen.queryByText("Storage Radar")).toBeNull();
+
+    fireEvent.change(search, { target: { value: "/storage/mac" } });
+    expect(screen.getByText("Storage Radar")).toBeDefined();
+    expect(screen.queryByText("Translator Android")).toBeNull();
+  });
+
+  it("selects filtered projects with arrow keys and Enter, and closes with Escape", () => {
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+    mockProjects = [
+      ...mockProjects,
+      {
+        ...mockProjects[0],
+        id: "p-2",
+        name: "Beta",
+        rootPath: "/tmp/beta",
+      },
+    ];
+    const onSelect = vi.fn();
+
+    render(<ProjectSelector selectedId="p-1" onSelect={onSelect} onDeselect={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: /alpha/i }));
+    const search = screen.getByRole("textbox", { name: "Search projects" });
+
+    fireEvent.keyDown(search, { key: "ArrowDown" });
+    fireEvent.keyDown(search, { key: "Enter" });
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ id: "p-2" }));
+    expect(screen.queryByRole("textbox", { name: "Search projects" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /alpha/i }));
+    fireEvent.keyDown(screen.getByRole("textbox", { name: "Search projects" }), {
+      key: "Escape",
+    });
+    expect(screen.queryByRole("textbox", { name: "Search projects" })).toBeNull();
+  });
+
+  it("pins a project from the picker", () => {
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+
+    render(<ProjectSelector selectedId="p-1" onSelect={() => {}} onDeselect={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: /alpha/i }));
+    fireEvent.click(screen.getByTitle("Pin"));
+
+    expect(mutateUpdateOrganization).toHaveBeenCalledWith(
+      { id: "p-1", input: { pinned: true } },
+      expect.objectContaining({ onError: expect.any(Function) }),
+    );
   });
 
   it("shows MCP servers in edit modal", () => {

--- a/packages/web/src/__tests__/ProjectSelector.test.tsx
+++ b/packages/web/src/__tests__/ProjectSelector.test.tsx
@@ -259,6 +259,43 @@ describe("ProjectSelector", () => {
     expect(betaOption).toHaveAttribute("aria-selected", "false");
   });
 
+  it("preserves the active project when the visible list reorders", () => {
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+    mockProjects = [
+      ...mockProjects,
+      {
+        ...mockProjects[0],
+        id: "p-2",
+        name: "Beta",
+        rootPath: "/tmp/beta",
+      },
+    ];
+    const onSelect = vi.fn();
+    const { rerender } = render(
+      <ProjectSelector selectedId="p-1" onSelect={onSelect} onDeselect={() => {}} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /alpha/i }));
+
+    const search = screen.getByRole("combobox", { name: "Search projects" });
+    fireEvent.keyDown(search, { key: "ArrowDown" });
+    const betaOptionId = screen.getByRole("option", { name: /beta/i }).id;
+    expect(search).toHaveAttribute("aria-activedescendant", betaOptionId);
+
+    mockProjects = mockProjects.map((project) =>
+      project.id === "p-2" ? { ...project, pinnedAt: "2026-07-16T00:00:00.000Z" } : project,
+    );
+    rerender(<ProjectSelector selectedId="p-1" onSelect={onSelect} onDeselect={() => {}} />);
+
+    expect(screen.getAllByRole("option").map((option) => option.textContent)).toEqual([
+      "Beta/tmp/beta",
+      "Alpha/tmp/alpha",
+    ]);
+    expect(search).toHaveAttribute("aria-activedescendant", betaOptionId);
+
+    fireEvent.keyDown(search, { key: "Enter" });
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ id: "p-2" }));
+  });
+
   it("closes the picker with Escape from its action controls and restores trigger focus", () => {
     mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
 
@@ -274,7 +311,7 @@ describe("ProjectSelector", () => {
     expect(document.activeElement).toBe(trigger);
   });
 
-  it("pushes one history entry when saving a group for the selected project", () => {
+  it("does not push history when saving a group for the selected project", () => {
     mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
     mutateUpdateProject.mockImplementation(
       (
@@ -306,11 +343,75 @@ describe("ProjectSelector", () => {
         { id: "p-1", input: { groupName: "Platform" } },
         expect.objectContaining({ onSuccess: expect.any(Function) }),
       );
-      expect(pushState).toHaveBeenCalledTimes(1);
-      expect(pushState).toHaveBeenCalledWith(null, "", "/project/p-1");
+      expect(pushState).not.toHaveBeenCalled();
     } finally {
       pushState.mockRestore();
     }
+  });
+
+  it("does not navigate when a delayed group update finishes after selection changes", () => {
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+    mockProjects = [
+      ...mockProjects,
+      {
+        ...mockProjects[0],
+        id: "p-2",
+        name: "Beta",
+        rootPath: "/tmp/beta",
+      },
+    ];
+    mutateUpdateProject.mockImplementation(
+      (
+        _input: unknown,
+        options: { onSuccess?: (project: (typeof mockProjects)[number]) => void },
+      ) => options.onSuccess?.(mockProjects[0]),
+    );
+    let finishOrganizationUpdate: ((project: (typeof mockProjects)[number]) => void) | undefined;
+    mutateUpdateOrganization.mockImplementation(
+      (
+        _input: unknown,
+        options: { onSuccess?: (project: (typeof mockProjects)[number]) => void },
+      ) => {
+        finishOrganizationUpdate = options.onSuccess;
+      },
+    );
+    const onSelect = vi.fn();
+    const { rerender } = render(
+      <ProjectSelector selectedId="p-1" onSelect={onSelect} onDeselect={() => {}} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /alpha/i }));
+    fireEvent.click(screen.getAllByTitle("Edit")[0]);
+    fireEvent.change(screen.getByPlaceholderText("Optional product or team"), {
+      target: { value: "Platform" },
+    });
+    fireEvent.click(screen.getByText("Save"));
+
+    expect(finishOrganizationUpdate).toEqual(expect.any(Function));
+    expect(onSelect).not.toHaveBeenCalled();
+
+    rerender(<ProjectSelector selectedId="p-2" onSelect={onSelect} onDeselect={() => {}} />);
+    finishOrganizationUpdate?.({ ...mockProjects[0], groupName: "Platform" });
+
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("does not navigate after saving an edit without an organization change", () => {
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+    mutateUpdateProject.mockImplementation(
+      (
+        _input: unknown,
+        options: { onSuccess?: (project: (typeof mockProjects)[number]) => void },
+      ) => options.onSuccess?.(mockProjects[0]),
+    );
+    const onSelect = vi.fn();
+
+    render(<ProjectSelector selectedId="p-1" onSelect={onSelect} onDeselect={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: /alpha/i }));
+    fireEvent.click(screen.getByTitle("Edit"));
+    fireEvent.click(screen.getByText("Save"));
+
+    expect(mutateUpdateOrganization).not.toHaveBeenCalled();
+    expect(onSelect).not.toHaveBeenCalled();
   });
 
   it("pins a project from the picker", () => {

--- a/packages/web/src/__tests__/ProjectSelector.test.tsx
+++ b/packages/web/src/__tests__/ProjectSelector.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { Project } from "@aif/shared/browser";
 
 const mockUseQuery = vi.fn();
 const mutateCreateProject = vi.fn();
@@ -17,8 +18,8 @@ let mockProjects = [
     planCheckerMaxBudgetUsd: null,
     implementerMaxBudgetUsd: null,
     reviewSidecarMaxBudgetUsd: null,
-    pinnedAt: null,
-    groupName: null,
+    pinnedAt: null as string | null,
+    groupName: null as string | null,
   },
 ];
 
@@ -79,8 +80,8 @@ describe("ProjectSelector", () => {
         planCheckerMaxBudgetUsd: null,
         implementerMaxBudgetUsd: null,
         reviewSidecarMaxBudgetUsd: null,
-        pinnedAt: null,
-        groupName: null,
+        pinnedAt: null as string | null,
+        groupName: null as string | null,
       },
     ];
   });
@@ -106,7 +107,7 @@ describe("ProjectSelector", () => {
     render(<ProjectSelector selectedId="p-1" onSelect={() => {}} onDeselect={() => {}} />);
     fireEvent.click(screen.getByRole("button", { name: /alpha/i }));
 
-    const search = screen.getByRole("textbox", { name: "Search projects" });
+    const search = screen.getByRole("combobox", { name: "Search projects" });
     await waitFor(() => expect(document.activeElement).toBe(search));
     expect(screen.getByRole("listbox").parentElement?.className).toContain("max-h-[60vh]");
     expect(screen.getByRole("listbox").parentElement?.className).toContain("overflow-y-auto");
@@ -135,18 +136,181 @@ describe("ProjectSelector", () => {
 
     render(<ProjectSelector selectedId="p-1" onSelect={onSelect} onDeselect={() => {}} />);
     fireEvent.click(screen.getByRole("button", { name: /alpha/i }));
-    const search = screen.getByRole("textbox", { name: "Search projects" });
+    const search = screen.getByRole("combobox", { name: "Search projects" });
 
     fireEvent.keyDown(search, { key: "ArrowDown" });
     fireEvent.keyDown(search, { key: "Enter" });
     expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ id: "p-2" }));
-    expect(screen.queryByRole("textbox", { name: "Search projects" })).toBeNull();
+    expect(screen.queryByRole("combobox", { name: "Search projects" })).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: /alpha/i }));
-    fireEvent.keyDown(screen.getByRole("textbox", { name: "Search projects" }), {
+    fireEvent.keyDown(screen.getByRole("combobox", { name: "Search projects" }), {
       key: "Escape",
     });
-    expect(screen.queryByRole("textbox", { name: "Search projects" })).toBeNull();
+    expect(screen.queryByRole("combobox", { name: "Search projects" })).toBeNull();
+  });
+
+  it("navigates projects in their rendered group order", () => {
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+    mockProjects = [
+      {
+        ...mockProjects[0],
+        groupName: "Zulu",
+      },
+      {
+        ...mockProjects[0],
+        id: "p-2",
+        name: "Beta",
+        rootPath: "/tmp/beta",
+        groupName: "Alpha",
+      },
+    ];
+    const onSelect = vi.fn();
+
+    render(<ProjectSelector selectedId={null} onSelect={onSelect} onDeselect={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: /select project/i }));
+
+    const search = screen.getByRole("combobox", { name: "Search projects" });
+    expect(screen.getAllByRole("option").map((option) => option.textContent)).toEqual([
+      "Beta/tmp/beta",
+      "Alpha/tmp/alpha",
+    ]);
+
+    fireEvent.keyDown(search, { key: "ArrowDown" });
+    fireEvent.keyDown(search, { key: "Enter" });
+
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ id: "p-1" }));
+  });
+
+  it("uses collision-free section keys for groups named after built-in sections", () => {
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+    mockProjects = [
+      {
+        ...mockProjects[0],
+        pinnedAt: "2026-07-15T00:00:00.000Z",
+      },
+      {
+        ...mockProjects[0],
+        id: "p-2",
+        name: "Beta",
+        rootPath: "/tmp/beta",
+        groupName: "Pinned",
+      },
+      {
+        ...mockProjects[0],
+        id: "p-3",
+        name: "Gamma",
+        rootPath: "/tmp/gamma",
+        groupName: "Other",
+      },
+      {
+        ...mockProjects[0],
+        id: "p-4",
+        name: "Delta",
+        rootPath: "/tmp/delta",
+      },
+    ];
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      render(<ProjectSelector selectedId="p-1" onSelect={() => {}} onDeselect={() => {}} />);
+      fireEvent.click(screen.getByRole("button", { name: /alpha/i }));
+
+      expect(screen.getAllByText("Pinned")).toHaveLength(2);
+      expect(screen.getAllByText("Other")).toHaveLength(2);
+      expect(
+        consoleError.mock.calls.some((call) =>
+          call.some((argument) => String(argument).includes("same key")),
+        ),
+      ).toBe(false);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("exposes an active descendant while preserving the actual selected option", () => {
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+    mockProjects = [
+      ...mockProjects,
+      {
+        ...mockProjects[0],
+        id: "p-2",
+        name: "Beta",
+        rootPath: "/tmp/beta",
+      },
+    ];
+
+    render(<ProjectSelector selectedId="p-1" onSelect={() => {}} onDeselect={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: /alpha/i }));
+
+    const search = screen.getByRole("combobox", { name: "Search projects" });
+    const listbox = screen.getByRole("listbox", { name: "Projects" });
+    const alphaOption = screen.getByRole("option", { name: /alpha/i });
+    const betaOption = screen.getByRole("option", { name: /beta/i });
+
+    expect(search).toHaveAttribute("aria-controls", listbox.id);
+    expect(search).toHaveAttribute("aria-activedescendant", alphaOption.id);
+    expect(alphaOption).toHaveAttribute("aria-selected", "true");
+
+    fireEvent.keyDown(search, { key: "ArrowDown" });
+
+    expect(search).toHaveAttribute("aria-activedescendant", betaOption.id);
+    expect(alphaOption).toHaveAttribute("aria-selected", "true");
+    expect(betaOption).toHaveAttribute("aria-selected", "false");
+  });
+
+  it("closes the picker with Escape from its action controls and restores trigger focus", () => {
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+
+    render(<ProjectSelector selectedId="p-1" onSelect={() => {}} onDeselect={() => {}} />);
+    const trigger = screen.getByRole("button", { name: /alpha/i });
+    fireEvent.click(trigger);
+    const pinButton = screen.getByTitle("Pin");
+    pinButton.focus();
+
+    fireEvent.keyDown(pinButton, { key: "Escape" });
+
+    expect(screen.queryByRole("combobox", { name: "Search projects" })).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("pushes one history entry when saving a group for the selected project", () => {
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+    mutateUpdateProject.mockImplementation(
+      (
+        _input: unknown,
+        options: { onSuccess?: (project: (typeof mockProjects)[number]) => void },
+      ) => options.onSuccess?.(mockProjects[0]),
+    );
+    mutateUpdateOrganization.mockImplementation(
+      (
+        _input: unknown,
+        options: { onSuccess?: (project: (typeof mockProjects)[number]) => void },
+      ) => options.onSuccess?.({ ...mockProjects[0], groupName: "Platform" }),
+    );
+    const pushState = vi.spyOn(window.history, "pushState").mockImplementation(() => {});
+    const onSelect = (project: Project) => {
+      window.history.pushState(null, "", `/project/${project.id}`);
+    };
+
+    try {
+      render(<ProjectSelector selectedId="p-1" onSelect={onSelect} onDeselect={() => {}} />);
+      fireEvent.click(screen.getByRole("button", { name: /alpha/i }));
+      fireEvent.click(screen.getByTitle("Edit"));
+      fireEvent.change(screen.getByPlaceholderText("Optional product or team"), {
+        target: { value: "Platform" },
+      });
+      fireEvent.click(screen.getByText("Save"));
+
+      expect(mutateUpdateOrganization).toHaveBeenCalledWith(
+        { id: "p-1", input: { groupName: "Platform" } },
+        expect.objectContaining({ onSuccess: expect.any(Function) }),
+      );
+      expect(pushState).toHaveBeenCalledTimes(1);
+      expect(pushState).toHaveBeenCalledWith(null, "", "/project/p-1");
+    } finally {
+      pushState.mockRestore();
+    }
   });
 
   it("pins a project from the picker", () => {

--- a/packages/web/src/__tests__/ProjectsOverview.test.tsx
+++ b/packages/web/src/__tests__/ProjectsOverview.test.tsx
@@ -17,6 +17,8 @@ const emptyProject: Project = {
   planCheckerMaxBudgetUsd: null,
   implementerMaxBudgetUsd: null,
   reviewSidecarMaxBudgetUsd: null,
+  pinnedAt: null,
+  groupName: null,
   autoQueueMode: false,
   parallelEnabled: false,
   defaultTaskRuntimeProfileId: null,
@@ -33,6 +35,7 @@ const emptyProject: Project = {
 
 const emptyOverview: ProjectTaskOverview = {
   projectId: "proj-empty",
+  lastActivityAt: null,
   totalTasks: 0,
   completedTasks: 0,
   verifiedTasks: 0,

--- a/packages/web/src/__tests__/WarmupDialog.test.tsx
+++ b/packages/web/src/__tests__/WarmupDialog.test.tsx
@@ -26,6 +26,8 @@ const project: Project = {
   planCheckerMaxBudgetUsd: null,
   implementerMaxBudgetUsd: null,
   reviewSidecarMaxBudgetUsd: null,
+  pinnedAt: null,
+  groupName: null,
   parallelEnabled: false,
   autoQueueMode: true,
   createdAt: "2026-01-01T00:00:00.000Z",

--- a/packages/web/src/__tests__/api.test.ts
+++ b/packages/web/src/__tests__/api.test.ts
@@ -36,4 +36,13 @@ describe("api client", () => {
     const [url] = fetchMock.mock.calls[0];
     expect(String(url)).toContain("/projects/overview");
   });
+
+  it("updates project organization with PATCH", async () => {
+    await api.updateProjectOrganization("project 1", { pinned: true, groupName: "Platform" });
+
+    const fetchMock = vi.mocked(fetch);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain("/projects/project%201/organization");
+    expect(init?.method).toBe("PATCH");
+  });
 });

--- a/packages/web/src/__tests__/projectSorting.test.ts
+++ b/packages/web/src/__tests__/projectSorting.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import type { Project, ProjectTaskOverview, TaskStatus } from "@aif/shared/browser";
+import { sortProjects } from "@/lib/projectSorting";
+
+const statuses: TaskStatus[] = [
+  "backlog",
+  "planning",
+  "improve",
+  "plan_ready",
+  "implementing",
+  "review",
+  "verify",
+  "blocked_external",
+  "done",
+  "verified",
+];
+
+function project(id: string, name: string, pinnedAt: string | null = null): Project {
+  return {
+    id,
+    name,
+    rootPath: `/tmp/${id}`,
+    plannerMaxBudgetUsd: null,
+    planCheckerMaxBudgetUsd: null,
+    implementerMaxBudgetUsd: null,
+    reviewSidecarMaxBudgetUsd: null,
+    pinnedAt,
+    groupName: null,
+    parallelEnabled: false,
+    autoQueueMode: false,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function overview(
+  projectId: string,
+  lastActivityAt: string | null,
+  activeTasks: number,
+): ProjectTaskOverview {
+  return {
+    projectId,
+    lastActivityAt,
+    totalTasks: activeTasks,
+    completedTasks: 0,
+    verifiedTasks: 0,
+    backlogTasks: 0,
+    activeTasks,
+    blockedTasks: 0,
+    autoModeTasks: 0,
+    fixTasks: 0,
+    totalRetries: 0,
+    totalTokenInput: 0,
+    totalTokenOutput: 0,
+    totalTokenTotal: 0,
+    totalCostUsd: 0,
+    statusCounts: Object.fromEntries(statuses.map((status) => [status, 0])) as Record<
+      TaskStatus,
+      number
+    >,
+    statusPreviews: Object.fromEntries(statuses.map((status) => [status, []])) as Record<
+      TaskStatus,
+      []
+    >,
+  };
+}
+
+describe("sortProjects", () => {
+  const projects = [
+    project("alpha", "Alpha"),
+    project("beta", "Beta"),
+    project("pinned", "Zulu", "2026-01-01T00:00:00.000Z"),
+  ];
+  const overviews = new Map([
+    ["alpha", overview("alpha", "2026-01-03T00:00:00.000Z", 1)],
+    ["beta", overview("beta", "2026-01-02T00:00:00.000Z", 5)],
+    ["pinned", overview("pinned", "2025-01-01T00:00:00.000Z", 0)],
+  ]);
+
+  it("keeps pinned projects first and sorts by last activity", () => {
+    expect(sortProjects(projects, "lastActivity", overviews).map(({ id }) => id)).toEqual([
+      "pinned",
+      "alpha",
+      "beta",
+    ]);
+  });
+
+  it("keeps pinned projects first and sorts by active task count", () => {
+    expect(sortProjects(projects, "activeTasks", overviews).map(({ id }) => id)).toEqual([
+      "pinned",
+      "beta",
+      "alpha",
+    ]);
+  });
+});

--- a/packages/web/src/components/project/ProjectSelector.tsx
+++ b/packages/web/src/components/project/ProjectSelector.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react";
 import { useOutsideClick } from "@/hooks/useOutsideClick";
 import { useQuery } from "@tanstack/react-query";
 import { FolderOpen, Plus, ChevronDown, Pencil, Trash2, Plug, Pin } from "lucide-react";
@@ -70,6 +78,7 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
   const triggerRef = useRef<HTMLButtonElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const projectItemRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const listboxId = useId();
 
   const selected = projects?.find((p) => p.id === selectedId);
   const { data: projectTaskOverviews } = useProjectTaskOverviews(dropdownOpen);
@@ -103,21 +112,37 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
     }
 
     return [
-      ...(pinned.length > 0 ? [{ label: "Pinned", projects: pinned }] : []),
+      ...(pinned.length > 0 ? [{ key: "system:pinned", label: "Pinned", projects: pinned }] : []),
       ...[...grouped.entries()]
         .sort(([left], [right]) => left.localeCompare(right, undefined, { sensitivity: "base" }))
-        .map(([label, groupProjects]) => ({ label, projects: groupProjects })),
+        .map(([label, groupProjects]) => ({
+          key: `group:${label}`,
+          label,
+          projects: groupProjects,
+        })),
       ...(ungrouped.length > 0
-        ? [{ label: grouped.size > 0 ? "Other" : null, projects: ungrouped }]
+        ? [
+            {
+              key: "system:ungrouped",
+              label: grouped.size > 0 ? "Other" : null,
+              projects: ungrouped,
+            },
+          ]
         : []),
     ];
   }, [filteredProjects]);
+  const visibleProjects = useMemo(
+    () => projectSections.flatMap((section) => section.projects),
+    [projectSections],
+  );
   const projectIndexById = useMemo(
-    () => new Map(filteredProjects.map((project, index) => [project.id, index])),
-    [filteredProjects],
+    () => new Map(visibleProjects.map((project, index) => [project.id, index])),
+    [visibleProjects],
   );
   const boundedSelectedProjectIndex =
-    filteredProjects.length === 0 ? 0 : Math.min(selectedProjectIndex, filteredProjects.length - 1);
+    visibleProjects.length === 0 ? 0 : Math.min(selectedProjectIndex, visibleProjects.length - 1);
+  const activeProject = visibleProjects[boundedSelectedProjectIndex];
+  const projectOptionId = (projectId: string) => `${listboxId}-option-${projectId}`;
   const isEditDialogOpen = dialogOpen && dialogMode === "edit" && !!editingId;
   const { data: mcpData, isLoading: isMcpLoading } = useQuery({
     queryKey: ["project-mcp", editingId],
@@ -268,14 +293,28 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
             const normalizedGroupName = groupName.trim() || null;
             const groupChanged = normalizedGroupName !== (editingProject?.groupName ?? null);
             if (groupChanged) {
+              console.debug("[FIX:pr-150] Updating project group", {
+                projectId: editingId,
+                groupName: normalizedGroupName,
+              });
               updateOrganization.mutate(
                 { id: editingId, input: { groupName: normalizedGroupName } },
                 {
                   onSuccess: (organizedProject) => {
+                    console.debug("[FIX:pr-150] Project group updated", {
+                      projectId: editingId,
+                      groupName: normalizedGroupName,
+                    });
                     if (selectedId === editingId) onSelect(organizedProject);
                   },
-                  onError: (error) =>
-                    showMutationError(error, "Project saved, but its group could not be updated"),
+                  onError: (error) => {
+                    console.error("[FIX:pr-150] Failed to update project group", {
+                      projectId: editingId,
+                      groupName: normalizedGroupName,
+                      error,
+                    });
+                    showMutationError(error, "Project saved, but its group could not be updated");
+                  },
                 },
               );
             }
@@ -287,7 +326,7 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
                 },
               );
             }
-            if (selectedId === editingId) onSelect(project);
+            if (selectedId === editingId && !groupChanged) onSelect(project);
             setDialogOpen(false);
           },
           onError: (error) => {
@@ -308,6 +347,11 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
   }, []);
   useOutsideClick(selectorRef, closeDropdown, dropdownOpen);
 
+  const closeDropdownAndRestoreFocus = useCallback(() => {
+    closeDropdown();
+    triggerRef.current?.focus();
+  }, [closeDropdown]);
+
   useEffect(() => {
     if (!dropdownOpen) return;
     const frame = requestAnimationFrame(() => searchInputRef.current?.focus());
@@ -327,25 +371,32 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
   const handleProjectSearchKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key === "Escape") {
       event.preventDefault();
-      closeDropdown();
-      triggerRef.current?.focus();
+      event.stopPropagation();
+      closeDropdownAndRestoreFocus();
       return;
     }
-    if (filteredProjects.length === 0) return;
+    if (visibleProjects.length === 0) return;
 
     if (event.key === "ArrowDown") {
       event.preventDefault();
-      setSelectedProjectIndex((boundedSelectedProjectIndex + 1) % filteredProjects.length);
+      setSelectedProjectIndex((boundedSelectedProjectIndex + 1) % visibleProjects.length);
     } else if (event.key === "ArrowUp") {
       event.preventDefault();
       setSelectedProjectIndex(
-        (boundedSelectedProjectIndex - 1 + filteredProjects.length) % filteredProjects.length,
+        (boundedSelectedProjectIndex - 1 + visibleProjects.length) % visibleProjects.length,
       );
     } else if (event.key === "Enter") {
       event.preventDefault();
-      const project = filteredProjects[boundedSelectedProjectIndex];
+      const project = visibleProjects[boundedSelectedProjectIndex];
       if (project) selectProject(project);
     }
+  };
+
+  const handleDropdownKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "Escape") return;
+    event.preventDefault();
+    event.stopPropagation();
+    closeDropdownAndRestoreFocus();
   };
 
   return (
@@ -369,7 +420,10 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
         </Button>
 
         {dropdownOpen && (
-          <div className="absolute left-0 top-full z-dropdown mt-2 w-[360px] max-w-[calc(100vw-2rem)] border border-border bg-popover p-1.5 text-popover-foreground">
+          <div
+            className="absolute left-0 top-full z-dropdown mt-2 w-[360px] max-w-[calc(100vw-2rem)] border border-border bg-popover p-1.5 text-popover-foreground"
+            onKeyDown={handleDropdownKeyDown}
+          >
             <div className="space-y-1.5 p-1">
               <Input
                 ref={searchInputRef}
@@ -380,7 +434,14 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
                 }}
                 onKeyDown={handleProjectSearchKeyDown}
                 placeholder="Search projects or paths..."
+                role="combobox"
                 aria-label="Search projects"
+                aria-autocomplete="list"
+                aria-controls={listboxId}
+                aria-expanded={dropdownOpen}
+                aria-activedescendant={
+                  activeProject ? projectOptionId(activeProject.id) : undefined
+                }
                 inputSize="sm"
               />
               <Select
@@ -396,9 +457,9 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
             </div>
 
             <ScrollableContainer maxHeight="max-h-[60vh]" className="mt-1">
-              <div role="listbox">
+              <div id={listboxId} role="listbox" aria-label="Projects">
                 {projectSections.map((section) => (
-                  <div key={section.label ?? "projects"}>
+                  <div key={section.key}>
                     {section.label && (
                       <div className="px-3 pb-1 pt-2 text-3xs font-semibold uppercase tracking-wider text-muted-foreground">
                         {section.label}
@@ -415,6 +476,7 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
                           }`}
                         >
                           <ListButton
+                            id={projectOptionId(project.id)}
                             ref={(element) => {
                               projectItemRefs.current[projectIndex] = element;
                             }}
@@ -422,7 +484,8 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
                             className="min-w-0 flex-1 flex-col items-start px-3 py-2"
                             onClick={() => selectProject(project)}
                             role="option"
-                            aria-selected={isKeyboardSelected}
+                            aria-selected={project.id === selectedId}
+                            tabIndex={-1}
                           >
                             <div className="flex w-full items-center gap-1.5">
                               {project.pinnedAt && <Pin className="h-3 w-3 shrink-0" />}

--- a/packages/web/src/components/project/ProjectSelector.tsx
+++ b/packages/web/src/components/project/ProjectSelector.tsx
@@ -1,12 +1,14 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
 import { useOutsideClick } from "@/hooks/useOutsideClick";
 import { useQuery } from "@tanstack/react-query";
-import { FolderOpen, Plus, ChevronDown, Pencil, Trash2, Plug } from "lucide-react";
+import { FolderOpen, Plus, ChevronDown, Pencil, Trash2, Plug, Pin } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { Badge } from "@/components/ui/badge";
 import { ListButton } from "@/components/ui/list-button";
+import { ScrollableContainer } from "@/components/ui/scrollable-container";
+import { Select } from "@/components/ui/select";
 import {
   Dialog,
   DialogClose,
@@ -20,10 +22,13 @@ import {
   useUpdateProject,
   useDeleteProject,
   useSetAutoQueueMode,
+  useProjectTaskOverviews,
+  useUpdateProjectOrganization,
 } from "@/hooks/useProjects";
 import { useToast } from "@/components/ui/toast";
 import { api } from "@/lib/api";
 import type { Project } from "@aif/shared/browser";
+import { PROJECT_SORT_OPTIONS, sortProjects, type ProjectSort } from "@/lib/projectSorting";
 
 interface Props {
   selectedId: string | null;
@@ -39,6 +44,7 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
   const updateProject = useUpdateProject();
   const deleteProject = useDeleteProject();
   const setAutoQueue = useSetAutoQueueMode();
+  const updateOrganization = useUpdateProjectOrganization();
   const { toast } = useToast();
 
   const showMutationError = (error: unknown, fallback: string) => {
@@ -48,8 +54,12 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
   const [dialogMode, setDialogMode] = useState<DialogMode>("create");
   const [editingId, setEditingId] = useState<string | null>(null);
   const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [projectQuery, setProjectQuery] = useState("");
+  const [projectSort, setProjectSort] = useState<ProjectSort>("name");
+  const [selectedProjectIndex, setSelectedProjectIndex] = useState(0);
   const [name, setName] = useState("");
   const [rootPath, setRootPath] = useState("");
+  const [groupName, setGroupName] = useState("");
   const [plannerMaxBudgetUsd, setPlannerMaxBudgetUsd] = useState("");
   const [planCheckerMaxBudgetUsd, setPlanCheckerMaxBudgetUsd] = useState("");
   const [implementerMaxBudgetUsd, setImplementerMaxBudgetUsd] = useState("");
@@ -57,8 +67,57 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
   const [parallelEnabled, setParallelEnabled] = useState(false);
   const [autoQueueMode, setAutoQueueModeState] = useState(false);
   const selectorRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const projectItemRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   const selected = projects?.find((p) => p.id === selectedId);
+  const { data: projectTaskOverviews } = useProjectTaskOverviews(dropdownOpen);
+  const overviewByProjectId = useMemo(
+    () => new Map((projectTaskOverviews ?? []).map((overview) => [overview.projectId, overview])),
+    [projectTaskOverviews],
+  );
+  const filteredProjects = useMemo(() => {
+    const normalizedQuery = projectQuery.trim().toLocaleLowerCase();
+    const matchingProjects = normalizedQuery
+      ? (projects ?? []).filter((project) =>
+          `${project.name} ${project.rootPath}`.toLocaleLowerCase().includes(normalizedQuery),
+        )
+      : (projects ?? []);
+    return sortProjects(matchingProjects, projectSort, overviewByProjectId);
+  }, [overviewByProjectId, projectQuery, projectSort, projects]);
+  const projectSections = useMemo(() => {
+    const pinned = filteredProjects.filter((project) => project.pinnedAt != null);
+    const unpinned = filteredProjects.filter((project) => project.pinnedAt == null);
+    const grouped = new Map<string, Project[]>();
+    const ungrouped: Project[] = [];
+    for (const project of unpinned) {
+      const normalizedGroup = project.groupName?.trim();
+      if (!normalizedGroup) {
+        ungrouped.push(project);
+        continue;
+      }
+      const group = grouped.get(normalizedGroup) ?? [];
+      group.push(project);
+      grouped.set(normalizedGroup, group);
+    }
+
+    return [
+      ...(pinned.length > 0 ? [{ label: "Pinned", projects: pinned }] : []),
+      ...[...grouped.entries()]
+        .sort(([left], [right]) => left.localeCompare(right, undefined, { sensitivity: "base" }))
+        .map(([label, groupProjects]) => ({ label, projects: groupProjects })),
+      ...(ungrouped.length > 0
+        ? [{ label: grouped.size > 0 ? "Other" : null, projects: ungrouped }]
+        : []),
+    ];
+  }, [filteredProjects]);
+  const projectIndexById = useMemo(
+    () => new Map(filteredProjects.map((project, index) => [project.id, index])),
+    [filteredProjects],
+  );
+  const boundedSelectedProjectIndex =
+    filteredProjects.length === 0 ? 0 : Math.min(selectedProjectIndex, filteredProjects.length - 1);
   const isEditDialogOpen = dialogOpen && dialogMode === "edit" && !!editingId;
   const { data: mcpData, isLoading: isMcpLoading } = useQuery({
     queryKey: ["project-mcp", editingId],
@@ -73,6 +132,7 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
     setEditingId(null);
     setName("");
     setRootPath("");
+    setGroupName("");
     setPlannerMaxBudgetUsd("");
     setPlanCheckerMaxBudgetUsd("");
     setImplementerMaxBudgetUsd("");
@@ -80,6 +140,8 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
     setParallelEnabled(false);
     setAutoQueueModeState(false);
     setDropdownOpen(false);
+    setProjectQuery("");
+    setSelectedProjectIndex(0);
     setDialogOpen(true);
   };
 
@@ -89,6 +151,7 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
     setEditingId(p.id);
     setName(p.name);
     setRootPath(p.rootPath);
+    setGroupName(p.groupName ?? "");
     setPlannerMaxBudgetUsd(p.plannerMaxBudgetUsd == null ? "" : String(p.plannerMaxBudgetUsd));
     setPlanCheckerMaxBudgetUsd(
       p.planCheckerMaxBudgetUsd == null ? "" : String(p.planCheckerMaxBudgetUsd),
@@ -102,6 +165,8 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
     setParallelEnabled(p.parallelEnabled ?? false);
     setAutoQueueModeState(p.autoQueueMode ?? false);
     setDropdownOpen(false);
+    setProjectQuery("");
+    setSelectedProjectIndex(0);
     setDialogOpen(true);
   };
 
@@ -113,6 +178,16 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
         if (selectedId === p.id) onDeselect();
       },
     });
+  };
+
+  const handlePin = (project: Project, event: React.MouseEvent) => {
+    event.stopPropagation();
+    updateOrganization.mutate(
+      { id: project.id, input: { pinned: project.pinnedAt == null } },
+      {
+        onError: (error) => showMutationError(error, "Failed to update project pin"),
+      },
+    );
   };
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -190,6 +265,20 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
         },
         {
           onSuccess: (project) => {
+            const normalizedGroupName = groupName.trim() || null;
+            const groupChanged = normalizedGroupName !== (editingProject?.groupName ?? null);
+            if (groupChanged) {
+              updateOrganization.mutate(
+                { id: editingId, input: { groupName: normalizedGroupName } },
+                {
+                  onSuccess: (organizedProject) => {
+                    if (selectedId === editingId) onSelect(organizedProject);
+                  },
+                  onError: (error) =>
+                    showMutationError(error, "Project saved, but its group could not be updated"),
+                },
+              );
+            }
             if (autoQueueMode !== previousAutoQueue) {
               setAutoQueue.mutate(
                 { id: editingId, enabled: autoQueueMode },
@@ -209,19 +298,70 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
     }
   };
 
-  const isPending = createProject.isPending || updateProject.isPending;
+  const isPending =
+    createProject.isPending || updateProject.isPending || updateOrganization.isPending;
 
-  const closeDropdown = useCallback(() => setDropdownOpen(false), []);
+  const closeDropdown = useCallback(() => {
+    setDropdownOpen(false);
+    setProjectQuery("");
+    setSelectedProjectIndex(0);
+  }, []);
   useOutsideClick(selectorRef, closeDropdown, dropdownOpen);
+
+  useEffect(() => {
+    if (!dropdownOpen) return;
+    const frame = requestAnimationFrame(() => searchInputRef.current?.focus());
+    return () => cancelAnimationFrame(frame);
+  }, [dropdownOpen]);
+
+  useEffect(() => {
+    if (!dropdownOpen) return;
+    projectItemRefs.current[boundedSelectedProjectIndex]?.scrollIntoView({ block: "nearest" });
+  }, [boundedSelectedProjectIndex, dropdownOpen]);
+
+  const selectProject = (project: Project) => {
+    onSelect(project);
+    closeDropdown();
+  };
+
+  const handleProjectSearchKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closeDropdown();
+      triggerRef.current?.focus();
+      return;
+    }
+    if (filteredProjects.length === 0) return;
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setSelectedProjectIndex((boundedSelectedProjectIndex + 1) % filteredProjects.length);
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setSelectedProjectIndex(
+        (boundedSelectedProjectIndex - 1 + filteredProjects.length) % filteredProjects.length,
+      );
+    } else if (event.key === "Enter") {
+      event.preventDefault();
+      const project = filteredProjects[boundedSelectedProjectIndex];
+      if (project) selectProject(project);
+    }
+  };
 
   return (
     <>
       <div className="relative" ref={selectorRef}>
         <Button
+          ref={triggerRef}
           variant="outline"
           size="sm"
           className="gap-2 border-border bg-card/80 hover:bg-accent/60"
-          onClick={() => setDropdownOpen(!dropdownOpen)}
+          aria-expanded={dropdownOpen}
+          aria-haspopup="listbox"
+          onClick={() => {
+            if (dropdownOpen) closeDropdown();
+            else setDropdownOpen(true);
+          }}
         >
           <FolderOpen className="h-4 w-4" />
           {selected?.name ?? "Select project"}
@@ -229,49 +369,116 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
         </Button>
 
         {dropdownOpen && (
-          <div className="absolute left-0 top-full z-dropdown mt-2 min-w-[280px] border border-border bg-popover p-1.5">
-            {projects?.map((p) => (
-              <div
-                key={p.id}
-                className={`group flex items-center gap-1 text-sm hover:bg-accent ${
-                  p.id === selectedId ? "bg-accent" : ""
-                }`}
-              >
-                <ListButton
-                  active={p.id === selectedId}
-                  className="flex-1 flex-col items-start px-3 py-2"
-                  onClick={() => {
-                    onSelect(p);
-                    setDropdownOpen(false);
-                  }}
-                >
-                  <div className="font-medium tracking-tight">{p.name}</div>
-                  <div className="truncate text-2xs text-muted-foreground">{p.rootPath}</div>
-                </ListButton>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-6 w-6 border-0 opacity-0 group-hover:opacity-70 hover:!opacity-100"
-                  onClick={(e) => openEdit(p, e)}
-                  title="Edit"
-                >
-                  <Pencil className="h-3 w-3" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-6 w-6 border-0 text-destructive opacity-0 group-hover:opacity-70 hover:!opacity-100"
-                  onClick={(e) => handleDelete(p, e)}
-                  title="Delete"
-                >
-                  <Trash2 className="h-3 w-3" />
-                </Button>
-              </div>
-            ))}
+          <div className="absolute left-0 top-full z-dropdown mt-2 w-[360px] max-w-[calc(100vw-2rem)] border border-border bg-popover p-1.5 text-popover-foreground">
+            <div className="space-y-1.5 p-1">
+              <Input
+                ref={searchInputRef}
+                value={projectQuery}
+                onChange={(event) => {
+                  setProjectQuery(event.target.value);
+                  setSelectedProjectIndex(0);
+                }}
+                onKeyDown={handleProjectSearchKeyDown}
+                placeholder="Search projects or paths..."
+                aria-label="Search projects"
+                inputSize="sm"
+              />
+              <Select
+                value={projectSort}
+                options={[...PROJECT_SORT_OPTIONS]}
+                onChange={(event) => {
+                  setProjectSort(event.target.value as ProjectSort);
+                  setSelectedProjectIndex(0);
+                }}
+                selectSize="sm"
+                className="w-full"
+              />
+            </div>
 
-            {projects?.length === 0 && (
-              <div className="px-3 py-2 text-sm text-muted-foreground">// no projects yet</div>
-            )}
+            <ScrollableContainer maxHeight="max-h-[60vh]" className="mt-1">
+              <div role="listbox">
+                {projectSections.map((section) => (
+                  <div key={section.label ?? "projects"}>
+                    {section.label && (
+                      <div className="px-3 pb-1 pt-2 text-3xs font-semibold uppercase tracking-wider text-muted-foreground">
+                        {section.label}
+                      </div>
+                    )}
+                    {section.projects.map((project) => {
+                      const projectIndex = projectIndexById.get(project.id) ?? 0;
+                      const isKeyboardSelected = projectIndex === boundedSelectedProjectIndex;
+                      return (
+                        <div
+                          key={project.id}
+                          className={`group flex items-center gap-1 text-sm hover:bg-accent ${
+                            project.id === selectedId ? "bg-accent" : ""
+                          }`}
+                        >
+                          <ListButton
+                            ref={(element) => {
+                              projectItemRefs.current[projectIndex] = element;
+                            }}
+                            active={project.id === selectedId || isKeyboardSelected}
+                            className="min-w-0 flex-1 flex-col items-start px-3 py-2"
+                            onClick={() => selectProject(project)}
+                            role="option"
+                            aria-selected={isKeyboardSelected}
+                          >
+                            <div className="flex w-full items-center gap-1.5">
+                              {project.pinnedAt && <Pin className="h-3 w-3 shrink-0" />}
+                              <span className="truncate font-medium tracking-tight">
+                                {project.name}
+                              </span>
+                            </div>
+                            <div className="w-full truncate text-2xs text-muted-foreground">
+                              {project.rootPath}
+                            </div>
+                          </ListButton>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className={`h-6 w-6 border-0 hover:!opacity-100 ${
+                              project.pinnedAt
+                                ? "opacity-70"
+                                : "opacity-0 group-hover:opacity-70 group-focus-within:opacity-70"
+                            }`}
+                            onClick={(event) => handlePin(project, event)}
+                            title={project.pinnedAt ? "Unpin" : "Pin"}
+                            aria-pressed={project.pinnedAt != null}
+                          >
+                            <Pin className="h-3 w-3" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-6 w-6 border-0 opacity-0 group-hover:opacity-70 group-focus-within:opacity-70 hover:!opacity-100"
+                            onClick={(event) => openEdit(project, event)}
+                            title="Edit"
+                          >
+                            <Pencil className="h-3 w-3" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-6 w-6 border-0 text-destructive opacity-0 group-hover:opacity-70 group-focus-within:opacity-70 hover:!opacity-100"
+                            onClick={(event) => handleDelete(project, event)}
+                            title="Delete"
+                          >
+                            <Trash2 className="h-3 w-3" />
+                          </Button>
+                        </div>
+                      );
+                    })}
+                  </div>
+                ))}
+
+                {filteredProjects.length === 0 && (
+                  <div className="px-3 py-3 text-sm text-muted-foreground">
+                    {projects?.length === 0 ? "// no projects yet" : "No matching projects"}
+                  </div>
+                )}
+              </div>
+            </ScrollableContainer>
 
             <div className="mt-1 border-t border-border pt-1">
               <ListButton onClick={openCreate} className="gap-2 px-3 py-2">
@@ -312,6 +519,20 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
                 PROJECTS_DIR are saved as the mounted container path.
               </p>
             </div>
+            {dialogMode === "edit" && (
+              <div>
+                <label className="text-sm font-medium">Group</label>
+                <Input
+                  placeholder="Optional product or team"
+                  value={groupName}
+                  maxLength={100}
+                  onChange={(event) => setGroupName(event.target.value)}
+                />
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Projects with the same group appear together in the picker.
+                </p>
+              </div>
+            )}
             <div>
               <label className="text-sm font-medium">Planner Budget (USD)</label>
               <Input

--- a/packages/web/src/components/project/ProjectSelector.tsx
+++ b/packages/web/src/components/project/ProjectSelector.tsx
@@ -64,7 +64,7 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [projectQuery, setProjectQuery] = useState("");
   const [projectSort, setProjectSort] = useState<ProjectSort>("name");
-  const [selectedProjectIndex, setSelectedProjectIndex] = useState(0);
+  const [activeProjectId, setActiveProjectId] = useState<string | null>(null);
   const [name, setName] = useState("");
   const [rootPath, setRootPath] = useState("");
   const [groupName, setGroupName] = useState("");
@@ -139,9 +139,14 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
     () => new Map(visibleProjects.map((project, index) => [project.id, index])),
     [visibleProjects],
   );
-  const boundedSelectedProjectIndex =
-    visibleProjects.length === 0 ? 0 : Math.min(selectedProjectIndex, visibleProjects.length - 1);
-  const activeProject = visibleProjects[boundedSelectedProjectIndex];
+  const storedActiveProjectIndex =
+    activeProjectId == null ? undefined : projectIndexById.get(activeProjectId);
+  const fallbackActiveProjectId = visibleProjects[0]?.id ?? null;
+  const activeProjectIndex = storedActiveProjectIndex ?? (visibleProjects.length > 0 ? 0 : -1);
+  const activeProject = activeProjectIndex >= 0 ? visibleProjects[activeProjectIndex] : undefined;
+  if (activeProjectId !== null && storedActiveProjectIndex === undefined) {
+    setActiveProjectId(fallbackActiveProjectId);
+  }
   const projectOptionId = (projectId: string) => `${listboxId}-option-${projectId}`;
   const isEditDialogOpen = dialogOpen && dialogMode === "edit" && !!editingId;
   const { data: mcpData, isLoading: isMcpLoading } = useQuery({
@@ -166,7 +171,7 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
     setAutoQueueModeState(false);
     setDropdownOpen(false);
     setProjectQuery("");
-    setSelectedProjectIndex(0);
+    setActiveProjectId(null);
     setDialogOpen(true);
   };
 
@@ -191,7 +196,7 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
     setAutoQueueModeState(p.autoQueueMode ?? false);
     setDropdownOpen(false);
     setProjectQuery("");
-    setSelectedProjectIndex(0);
+    setActiveProjectId(null);
     setDialogOpen(true);
   };
 
@@ -289,7 +294,7 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
           },
         },
         {
-          onSuccess: (project) => {
+          onSuccess: () => {
             const normalizedGroupName = groupName.trim() || null;
             const groupChanged = normalizedGroupName !== (editingProject?.groupName ?? null);
             if (groupChanged) {
@@ -300,12 +305,11 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
               updateOrganization.mutate(
                 { id: editingId, input: { groupName: normalizedGroupName } },
                 {
-                  onSuccess: (organizedProject) => {
-                    console.debug("[FIX:pr-150] Project group updated", {
+                  onSuccess: () => {
+                    console.debug("[FIX:pr-150] Project group updated without navigation", {
                       projectId: editingId,
                       groupName: normalizedGroupName,
                     });
-                    if (selectedId === editingId) onSelect(organizedProject);
                   },
                   onError: (error) => {
                     console.error("[FIX:pr-150] Failed to update project group", {
@@ -326,7 +330,6 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
                 },
               );
             }
-            if (selectedId === editingId && !groupChanged) onSelect(project);
             setDialogOpen(false);
           },
           onError: (error) => {
@@ -343,7 +346,7 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
   const closeDropdown = useCallback(() => {
     setDropdownOpen(false);
     setProjectQuery("");
-    setSelectedProjectIndex(0);
+    setActiveProjectId(null);
   }, []);
   useOutsideClick(selectorRef, closeDropdown, dropdownOpen);
 
@@ -359,9 +362,9 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
   }, [dropdownOpen]);
 
   useEffect(() => {
-    if (!dropdownOpen) return;
-    projectItemRefs.current[boundedSelectedProjectIndex]?.scrollIntoView({ block: "nearest" });
-  }, [boundedSelectedProjectIndex, dropdownOpen]);
+    if (!dropdownOpen || activeProjectIndex < 0) return;
+    projectItemRefs.current[activeProjectIndex]?.scrollIntoView({ block: "nearest" });
+  }, [activeProject?.id, activeProjectIndex, dropdownOpen]);
 
   const selectProject = (project: Project) => {
     onSelect(project);
@@ -379,16 +382,16 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
 
     if (event.key === "ArrowDown") {
       event.preventDefault();
-      setSelectedProjectIndex((boundedSelectedProjectIndex + 1) % visibleProjects.length);
+      const nextProject = visibleProjects[(activeProjectIndex + 1) % visibleProjects.length];
+      setActiveProjectId(nextProject.id);
     } else if (event.key === "ArrowUp") {
       event.preventDefault();
-      setSelectedProjectIndex(
-        (boundedSelectedProjectIndex - 1 + visibleProjects.length) % visibleProjects.length,
-      );
+      const previousIndex =
+        (activeProjectIndex - 1 + visibleProjects.length) % visibleProjects.length;
+      setActiveProjectId(visibleProjects[previousIndex].id);
     } else if (event.key === "Enter") {
       event.preventDefault();
-      const project = visibleProjects[boundedSelectedProjectIndex];
-      if (project) selectProject(project);
+      if (activeProject) selectProject(activeProject);
     }
   };
 
@@ -430,7 +433,6 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
                 value={projectQuery}
                 onChange={(event) => {
                   setProjectQuery(event.target.value);
-                  setSelectedProjectIndex(0);
                 }}
                 onKeyDown={handleProjectSearchKeyDown}
                 placeholder="Search projects or paths..."
@@ -449,7 +451,6 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
                 options={[...PROJECT_SORT_OPTIONS]}
                 onChange={(event) => {
                   setProjectSort(event.target.value as ProjectSort);
-                  setSelectedProjectIndex(0);
                 }}
                 selectSize="sm"
                 className="w-full"
@@ -467,7 +468,7 @@ export function ProjectSelector({ selectedId, onSelect, onDeselect }: Props) {
                     )}
                     {section.projects.map((project) => {
                       const projectIndex = projectIndexById.get(project.id) ?? 0;
-                      const isKeyboardSelected = projectIndex === boundedSelectedProjectIndex;
+                      const isKeyboardSelected = project.id === activeProject?.id;
                       return (
                         <div
                           key={project.id}

--- a/packages/web/src/components/project/ProjectsOverview.tsx
+++ b/packages/web/src/components/project/ProjectsOverview.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import type { Project, ProjectTaskOverview, TaskStatus } from "@aif/shared/browser";
 import { STATUS_CONFIG } from "@aif/shared/browser";
 import { Card } from "@/components/ui/card";
@@ -9,8 +9,10 @@ import { ProgressBar } from "@/components/ui/progress-bar";
 import { StatusDot } from "@/components/ui/status-dot";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Metric } from "@/components/ui/metric";
+import { Select } from "@/components/ui/select";
 import { useProjectTaskOverviews } from "@/hooks/useProjects";
 import { calculateProjectOverviewMetrics } from "@/lib/taskMetrics";
+import { PROJECT_SORT_OPTIONS, sortProjects, type ProjectSort } from "@/lib/projectSorting";
 
 const integerFmt = new Intl.NumberFormat("en-US");
 const usdFmt = new Intl.NumberFormat("en-US", {
@@ -46,6 +48,7 @@ const OVERVIEW_STATUSES: TaskStatus[] = [
 const PREVIEW_LIMIT = 3;
 
 export function ProjectsOverview({ projects, onSelectProject }: ProjectsOverviewProps) {
+  const [projectSort, setProjectSort] = useState<ProjectSort>("name");
   const { data: projectTaskOverviews, isLoading } = useProjectTaskOverviews(projects.length > 0);
   const overviewByProjectId = useMemo(() => {
     const map = new Map<string, ProjectTaskOverview>();
@@ -54,6 +57,10 @@ export function ProjectsOverview({ projects, onSelectProject }: ProjectsOverview
     }
     return map;
   }, [projectTaskOverviews]);
+  const sortedProjects = useMemo(
+    () => sortProjects(projects, projectSort, overviewByProjectId),
+    [overviewByProjectId, projectSort, projects],
+  );
 
   if (!projects.length) {
     return (
@@ -69,9 +76,18 @@ export function ProjectsOverview({ projects, onSelectProject }: ProjectsOverview
       <SectionHeader
         className="mb-4"
         action={
-          <Badge variant="outline" size="sm">
-            {projects.length} project{projects.length === 1 ? "" : "s"}
-          </Badge>
+          <div className="flex items-center gap-2">
+            <Select
+              value={projectSort}
+              options={[...PROJECT_SORT_OPTIONS]}
+              onChange={(event) => setProjectSort(event.target.value as ProjectSort)}
+              selectSize="sm"
+              className="w-36"
+            />
+            <Badge variant="outline" size="sm">
+              {projects.length} project{projects.length === 1 ? "" : "s"}
+            </Badge>
+          </div>
         }
       >
         Projects overview
@@ -79,13 +95,13 @@ export function ProjectsOverview({ projects, onSelectProject }: ProjectsOverview
 
       {isLoading ? (
         <div className="grid grid-cols-1 gap-4">
-          {projects.map((p) => (
+          {sortedProjects.map((p) => (
             <Skeleton key={p.id} className="h-44 w-full" />
           ))}
         </div>
       ) : (
         <div className="grid grid-cols-1 gap-4">
-          {projects.map((project) => {
+          {sortedProjects.map((project) => {
             const overview = overviewByProjectId.get(project.id);
             const metrics = calculateProjectOverviewMetrics(overview);
             const progress = Math.round(metrics.completionRate);

--- a/packages/web/src/components/ui/select.tsx
+++ b/packages/web/src/components/ui/select.tsx
@@ -106,7 +106,7 @@ const Select = React.forwardRef<HTMLDivElement, SelectProps>(
         </button>
 
         {open && (
-          <div className="absolute z-50 mt-1 w-full border border-border bg-popover py-1 shadow-md">
+          <div className="absolute z-50 mt-1 w-full border border-border bg-popover py-1">
             {searchable && (
               <div className="px-2 pb-1">
                 <input

--- a/packages/web/src/hooks/useProjects.ts
+++ b/packages/web/src/hooks/useProjects.ts
@@ -1,5 +1,10 @@
 import { useQuery, useMutation, useQueryClient, type QueryClient } from "@tanstack/react-query";
-import type { Project, CreateProjectInput, ProjectTaskOverview } from "@aif/shared/browser";
+import type {
+  Project,
+  CreateProjectInput,
+  ProjectTaskOverview,
+  UpdateProjectOrganizationInput,
+} from "@aif/shared/browser";
 import { api, ApiError } from "../lib/api.js";
 import { invalidateProjectWarmupQueries } from "./useProjectWarmup.js";
 
@@ -62,6 +67,17 @@ export function useUpdateProject() {
       queryClient.invalidateQueries({ queryKey: ["effectiveChatRuntime"] });
       queryClient.invalidateQueries({ queryKey: ["effectiveTaskRuntime"] });
       invalidateProjectWarmupQueries(queryClient, id);
+    },
+  });
+}
+
+export function useUpdateProjectOrganization() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, input }: { id: string; input: UpdateProjectOrganizationInput }) =>
+      api.updateProjectOrganization(id, input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["projects"] });
     },
   });
 }

--- a/packages/web/src/hooks/useWebSocket.ts
+++ b/packages/web/src/hooks/useWebSocket.ts
@@ -221,6 +221,11 @@ export function useWebSocket() {
         return;
       }
 
+      if (data.type === "project:organization_updated") {
+        queryClient.invalidateQueries({ queryKey: ["projects"] });
+        return;
+      }
+
       if (data.type === "project:runtime_limit_updated" && hasRuntimeLimitPayload(data.payload)) {
         invalidateRuntimeLimitQueries(queryClient, data.payload);
         if (typeof data.payload.taskId === "string" && data.payload.taskId.length > 0) {

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -10,6 +10,7 @@ import type {
   Project,
   ProjectTaskOverview,
   CreateProjectInput,
+  UpdateProjectOrganizationInput,
   ChatRequest,
   ChatSession,
   CreateChatSessionInput,
@@ -312,6 +313,14 @@ export const api = {
     console.debug("[api] PUT /projects/%s", id, input);
     return request<Project>(`/projects/${id}`, {
       method: "PUT",
+      body: JSON.stringify(input),
+    });
+  },
+
+  updateProjectOrganization(id: string, input: UpdateProjectOrganizationInput): Promise<Project> {
+    console.debug("[api] PATCH /projects/%s/organization", id, input);
+    return request<Project>(`/projects/${encodeURIComponent(id)}/organization`, {
+      method: "PATCH",
       body: JSON.stringify(input),
     });
   },

--- a/packages/web/src/lib/projectSorting.ts
+++ b/packages/web/src/lib/projectSorting.ts
@@ -1,0 +1,54 @@
+import type { Project, ProjectTaskOverview } from "@aif/shared/browser";
+
+export type ProjectSort = "name" | "lastActivity" | "activeTasks";
+
+export const PROJECT_SORT_OPTIONS = [
+  { value: "name", label: "Name" },
+  { value: "lastActivity", label: "Last activity" },
+  { value: "activeTasks", label: "Active tasks" },
+] satisfies { value: ProjectSort; label: string }[];
+
+const projectNameCollator = new Intl.Collator(undefined, {
+  sensitivity: "base",
+  numeric: true,
+});
+
+function compareNullableDescending(left: string | null, right: string | null): number {
+  if (left === right) return 0;
+  if (left == null) return 1;
+  if (right == null) return -1;
+  return right.localeCompare(left);
+}
+
+export function sortProjects(
+  projects: Project[],
+  sort: ProjectSort,
+  overviewByProjectId: ReadonlyMap<string, ProjectTaskOverview>,
+): Project[] {
+  return [...projects].sort((left, right) => {
+    const leftPinned = left.pinnedAt != null;
+    const rightPinned = right.pinnedAt != null;
+    if (leftPinned !== rightPinned) return leftPinned ? -1 : 1;
+    if (leftPinned && rightPinned && left.pinnedAt !== right.pinnedAt) {
+      return (left.pinnedAt ?? "").localeCompare(right.pinnedAt ?? "");
+    }
+
+    if (sort === "lastActivity") {
+      const activityOrder = compareNullableDescending(
+        overviewByProjectId.get(left.id)?.lastActivityAt ?? null,
+        overviewByProjectId.get(right.id)?.lastActivityAt ?? null,
+      );
+      if (activityOrder !== 0) return activityOrder;
+    }
+
+    if (sort === "activeTasks") {
+      const activeTaskOrder =
+        (overviewByProjectId.get(right.id)?.activeTasks ?? 0) -
+        (overviewByProjectId.get(left.id)?.activeTasks ?? 0);
+      if (activeTaskOrder !== 0) return activeTaskOrder;
+    }
+
+    const nameOrder = projectNameCollator.compare(left.name, right.name);
+    return nameOrder !== 0 ? nameOrder : left.id.localeCompare(right.id);
+  });
+}


### PR DESCRIPTION
## Summary

- return projects in a deterministic case-insensitive order with pinned projects first
- add project search, bounded scrolling, keyboard navigation, pin controls, and flat group sections to the picker
- expose real task activity and add Name, Last activity, and Active tasks sorting to the picker and overview
- persist pin and group metadata through append-only migration v25 and a validated organization endpoint
- broadcast organization updates so other connected clients refresh their project list

## Scope note

The optional archived_at proposal is intentionally deferred. listProjects is also consumed by the coordinator and indexers, so archive semantics need a separate operational design to avoid silently disabling active projects.

## Validation

- npm run ai:validate
- regression test reproduced unordered SQLite results before the fix
- targeted data, shared migration, API, and web component tests
- full monorepo coverage gate, production build, Playwright performance checks, k6 load thresholds, and Codex protocol sync

Closes #147