### PR TITLE
fix(web): bound Kanban columns and prioritize recent terminal tasks

### DIFF
--- a/.ai-factory/patches/2026-07-16-17.46.md
+++ b/.ai-factory/patches/2026-07-16-17.46.md
@@ -1,0 +1,36 @@
+# Kanban scroll chaining and terminal ordering review fixes
+
+**Date:** 2026-07-16 17:46
+**Files:** packages/web/src/components/kanban/Board.tsx, packages/web/src/components/kanban/Column.tsx, packages/web/src/__tests__/Board.test.tsx, packages/web/e2e/kanban-horizontal-scroll.spec.ts, packages/web/e2e/README.md
+**Severity:** medium
+
+## Problem
+
+PR #151 introduced two user-visible/correctness regressions and a weak test assertion:
+
+- `overscroll-contain` on each vertical card list blocked horizontal wheel and trackpad gestures from chaining to the Kanban board.
+- Terminal tasks with malformed `updatedAt` values could participate in a non-transitive comparator, producing input-order-dependent results.
+- Ordering tests used `textContent.indexOf()`, which could pass when the expected first card was missing.
+
+## Root Cause
+
+The card list applied overscroll containment to both axes even though it owns only vertical scrolling and the parent board owns horizontal scrolling. The terminal comparator also switched between timestamp and position ordering on a pair-by-pair basis whenever either timestamp was malformed, so it did not define a consistent total order.
+
+## Solution
+
+- Replaced `overscroll-contain` with `overscroll-y-contain` so vertical boundary containment remains while horizontal gestures chain to the board.
+- Added a deterministic terminal comparator ordered by timestamp validity, timestamp descending, position ascending, then ID.
+- Replaced string-index assertions with element lookup plus DOM-position comparisons.
+- Added a database-independent Playwright regression using native Chromium wheel input over a genuinely scrollable card list.
+- Removed temporary sorting debug output from the render-time memoization path.
+
+## Prevention
+
+- Scope `overscroll-*` containment to the axis owned by the component when a parent owns the other scroll axis.
+- Define sort comparators lexicographically so every input pair follows the same ordering dimensions.
+- Resolve both expected DOM elements before comparing their order.
+- Use trusted browser input (`page.mouse.wheel`) for scroll-chaining regressions; synthetic DOM wheel events do not exercise native browser scrolling.
+
+## Tags
+
+`#kanban` `#scroll-chaining` `#playwright` `#sorting` `#typescript` `#code-review`

--- a/packages/web/e2e/README.md
+++ b/packages/web/e2e/README.md
@@ -1,8 +1,8 @@
-# Browser performance suite
+# Browser E2E suite
 
-Playwright-driven synthetic perf tests. These exercise the real web stack
-(API + web bundle) against a running dev server and enforce latency budgets
-so regressions fail the suite instead of shipping.
+Playwright-driven browser tests. The suite exercises the real web stack
+(API + web bundle) against a running dev server, covers browser-only interaction
+regressions, and enforces latency budgets.
 
 ## Run
 
@@ -21,6 +21,8 @@ dev shell). Set `AIF_SKIP_DEV_SERVER=1` to bypass the auto-launch entirely and
 
 ## What each spec measures
 
+- `kanban-horizontal-scroll.spec.ts` — verifies horizontal wheel gestures over
+  a vertically scrollable card list still scroll the Kanban board.
 - `perf/dashboard-load.spec.ts` — cold kanban render. Asserts DOM-ready and
   LCP budgets after the first column paints.
 - `perf/runtime-profiles-endpoint.spec.ts` — cold + warm `/runtime-profiles`

--- a/packages/web/e2e/kanban-horizontal-scroll.spec.ts
+++ b/packages/web/e2e/kanban-horizontal-scroll.spec.ts
@@ -1,0 +1,118 @@
+import { expect, test } from "@playwright/test";
+
+const PROJECT_ID = "00000000-0000-4000-8000-000000000151";
+
+function makeTask(index: number) {
+  return {
+    id: `scroll-task-${index}`,
+    projectId: PROJECT_ID,
+    title: `Horizontal wheel target ${index}`,
+    description: "Horizontal gestures should reach the board",
+    autoMode: true,
+    isFix: false,
+    status: "backlog",
+    priority: 1,
+    position: index * 1000,
+    blockedReason: null,
+    blockedFromStatus: null,
+    retryAfter: null,
+    retryCount: 0,
+    tokenInput: 0,
+    tokenOutput: 0,
+    tokenTotal: 0,
+    costUsd: 0,
+    roadmapAlias: null,
+    tags: [],
+    reworkRequested: false,
+    reviewIterationCount: 0,
+    maxReviewIterations: 3,
+    manualReviewRequired: false,
+    paused: false,
+    lastSyncedAt: null,
+    runtimeProfileId: null,
+    modelOverride: null,
+    runtimeLimitSnapshot: null,
+    runtimeLimitUpdatedAt: null,
+    scheduledAt: null,
+    hasPlan: false,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+test("horizontal wheel gestures over a card list scroll the kanban board", async ({ page }) => {
+  await page.route(
+    (url) => url.pathname === "/projects",
+    async (route) => {
+      await route.fulfill({
+        json: [
+          {
+            id: PROJECT_ID,
+            name: "Scroll regression project",
+            rootPath: "/tmp/scroll-regression",
+            createdAt: "2026-01-01T00:00:00.000Z",
+            updatedAt: "2026-01-01T00:00:00.000Z",
+          },
+        ],
+      });
+    },
+  );
+  await page.route(
+    (url) => url.pathname === "/tasks" && url.searchParams.get("projectId") === PROJECT_ID,
+    async (route) => {
+      await route.fulfill({
+        json: Array.from({ length: 12 }, (_, index) => makeTask(index + 1)),
+      });
+    },
+  );
+  await page.route("**/settings", async (route) => {
+    await route.fulfill({
+      json: {
+        useSubagents: false,
+        maxReviewIterations: 3,
+        autoReviewStrategy: "full_re_review",
+        usageLimitsEnabled: false,
+        warmupEnabled: false,
+        qaPipelineEnabled: false,
+        runtimeReadiness: {
+          availableRuntimeCount: 0,
+          runtimeProfileCount: 0,
+          enabledRuntimeProfileCount: 0,
+        },
+        runtimeDefaults: {
+          modules: [],
+          openAiBaseUrlConfigured: false,
+          codexCliPathConfigured: false,
+          app: {},
+        },
+      },
+    });
+  });
+  await page.route("**/runtime-profiles/effective/chat/*", async (route) => {
+    await route.fulfill({ json: { profile: null, resolved: null } });
+  });
+
+  await page.setViewportSize({ width: 800, height: 720 });
+  await page.goto(`/project/${PROJECT_ID}`);
+
+  const board = page.getByTestId("kanban-board");
+  const card = page.getByText("Horizontal wheel target 1", { exact: true });
+  const cardList = card.locator(
+    "xpath=ancestor::*[contains(concat(' ', normalize-space(@class), ' '), ' overflow-y-auto ')][1]",
+  );
+
+  await expect(board).toBeVisible();
+  await expect(card).toBeVisible();
+  await expect
+    .poll(() => board.evaluate((element) => element.scrollWidth > element.clientWidth))
+    .toBe(true);
+  await expect
+    .poll(() => cardList.evaluate((element) => element.scrollHeight > element.clientHeight))
+    .toBe(true);
+  await expect.poll(() => board.evaluate((element) => element.scrollLeft)).toBe(0);
+
+  await card.hover();
+  await page.mouse.wheel(400, 0);
+
+  await expect.poll(() => board.evaluate((element) => element.scrollLeft)).toBeGreaterThan(0);
+});

--- a/packages/web/src/__tests__/Board.test.tsx
+++ b/packages/web/src/__tests__/Board.test.tsx
@@ -75,6 +75,13 @@ function Wrapper({ children }: { children: React.ReactNode }) {
   return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
 }
 
+function getColumn(label: string): HTMLElement {
+  const heading = screen.getByRole("heading", { name: label });
+  const column = heading.parentElement?.parentElement?.parentElement;
+  if (!column) throw new Error(`Could not find column for ${label}`);
+  return column;
+}
+
 describe("Board", () => {
   it("should render status columns", () => {
     render(<Board projectId="test-project" onTaskClick={vi.fn()} density="comfortable" />, {
@@ -98,6 +105,95 @@ describe("Board", () => {
 
     expect(screen.getByText("Test Task 1")).toBeDefined();
     expect(screen.getByText("Test Task 2")).toBeDefined();
+  });
+
+  it("should bound every card list to the viewport with independent vertical scrolling", () => {
+    render(<Board projectId="test-project" onTaskClick={vi.fn()} density="comfortable" />, {
+      wrapper: Wrapper,
+    });
+
+    for (const label of [
+      "Backlog",
+      "Planning",
+      "Improve",
+      "Plan Ready",
+      "Implementing",
+      "Verify",
+      "Review",
+      "Blocked",
+      "Done",
+      "Verified",
+    ]) {
+      const taskList = getColumn(label).lastElementChild;
+      expect(taskList?.className).toContain("max-h-[calc(100vh-");
+      expect(taskList?.className).toContain("overflow-y-auto");
+    }
+  });
+
+  it("should show newest terminal tasks first while preserving position order elsewhere", () => {
+    const originalLength = mockTasks.length;
+    mockTasks.push(
+      makeTask({
+        id: "verified-newer",
+        title: "Verified Newer",
+        status: "verified",
+        position: 3000,
+        updatedAt: "2026-03-01T00:00:00.000Z",
+      }),
+      makeTask({
+        id: "verified-older",
+        title: "Verified Older",
+        status: "verified",
+        position: 1000,
+        updatedAt: "2026-02-01T00:00:00.000Z",
+      }),
+      makeTask({
+        id: "done-newer",
+        title: "Done Newer",
+        status: "done",
+        position: 3000,
+        updatedAt: "2026-03-01T00:00:00.000Z",
+      }),
+      makeTask({
+        id: "done-older",
+        title: "Done Older",
+        status: "done",
+        position: 1000,
+        updatedAt: "2026-02-01T00:00:00.000Z",
+      }),
+      makeTask({
+        id: "planning-later-position",
+        title: "Planning Later Position",
+        status: "planning",
+        position: 3000,
+        updatedAt: "2026-04-01T00:00:00.000Z",
+      }),
+      makeTask({
+        id: "planning-earlier-position",
+        title: "Planning Earlier Position",
+        status: "planning",
+        position: 2000,
+        updatedAt: "2026-05-01T00:00:00.000Z",
+      }),
+    );
+
+    render(<Board projectId="test-project" onTaskClick={vi.fn()} density="comfortable" />, {
+      wrapper: Wrapper,
+    });
+    mockTasks.splice(originalLength);
+
+    const verifiedText = getColumn("Verified").textContent ?? "";
+    expect(verifiedText.indexOf("Verified Newer")).toBeLessThan(
+      verifiedText.indexOf("Verified Older"),
+    );
+
+    const doneText = getColumn("Done").textContent ?? "";
+    expect(doneText.indexOf("Done Newer")).toBeLessThan(doneText.indexOf("Done Older"));
+
+    const planningText = getColumn("Planning").textContent ?? "";
+    expect(planningText.indexOf("Planning Earlier Position")).toBeLessThan(
+      planningText.indexOf("Planning Later Position"),
+    );
   });
 
   it("should render ownership badges", () => {

--- a/packages/web/src/__tests__/Board.test.tsx
+++ b/packages/web/src/__tests__/Board.test.tsx
@@ -82,6 +82,15 @@ function getColumn(label: string): HTMLElement {
   return column;
 }
 
+function expectTaskBefore(column: HTMLElement, firstTitle: string, secondTitle: string): void {
+  const firstTask = within(column).getByText(firstTitle);
+  const secondTask = within(column).getByText(secondTitle);
+
+  expect(firstTask.compareDocumentPosition(secondTask) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+    Node.DOCUMENT_POSITION_FOLLOWING,
+  );
+}
+
 describe("Board", () => {
   it("should render status columns", () => {
     render(<Board projectId="test-project" onTaskClick={vi.fn()} density="comfortable" />, {
@@ -127,6 +136,7 @@ describe("Board", () => {
       const taskList = getColumn(label).lastElementChild;
       expect(taskList?.className).toContain("max-h-[calc(100vh-");
       expect(taskList?.className).toContain("overflow-y-auto");
+      expect(taskList?.className).toContain("overscroll-y-contain");
     }
   });
 
@@ -155,11 +165,25 @@ describe("Board", () => {
         updatedAt: "2026-03-01T00:00:00.000Z",
       }),
       makeTask({
+        id: "done-invalid-later-position",
+        title: "Done Invalid Later Position",
+        status: "done",
+        position: 2000,
+        updatedAt: "not-a-date",
+      }),
+      makeTask({
         id: "done-older",
         title: "Done Older",
         status: "done",
         position: 1000,
         updatedAt: "2026-02-01T00:00:00.000Z",
+      }),
+      makeTask({
+        id: "done-invalid-earlier-position",
+        title: "Done Invalid Earlier Position",
+        status: "done",
+        position: 1500,
+        updatedAt: "also-not-a-date",
       }),
       makeTask({
         id: "planning-later-position",
@@ -182,18 +206,14 @@ describe("Board", () => {
     });
     mockTasks.splice(originalLength);
 
-    const verifiedText = getColumn("Verified").textContent ?? "";
-    expect(verifiedText.indexOf("Verified Newer")).toBeLessThan(
-      verifiedText.indexOf("Verified Older"),
-    );
+    expectTaskBefore(getColumn("Verified"), "Verified Newer", "Verified Older");
 
-    const doneText = getColumn("Done").textContent ?? "";
-    expect(doneText.indexOf("Done Newer")).toBeLessThan(doneText.indexOf("Done Older"));
+    const doneColumn = getColumn("Done");
+    expectTaskBefore(doneColumn, "Done Newer", "Done Older");
+    expectTaskBefore(doneColumn, "Done Older", "Done Invalid Earlier Position");
+    expectTaskBefore(doneColumn, "Done Invalid Earlier Position", "Done Invalid Later Position");
 
-    const planningText = getColumn("Planning").textContent ?? "";
-    expect(planningText.indexOf("Planning Earlier Position")).toBeLessThan(
-      planningText.indexOf("Planning Later Position"),
-    );
+    expectTaskBefore(getColumn("Planning"), "Planning Earlier Position", "Planning Later Position");
   });
 
   it("should render ownership badges", () => {

--- a/packages/web/src/components/kanban/Board.tsx
+++ b/packages/web/src/components/kanban/Board.tsx
@@ -34,6 +34,29 @@ const STATUS_ORDER = Object.fromEntries(
   ORDERED_STATUSES.map((status, idx) => [status, idx]),
 ) as Record<TaskStatus, number>;
 
+function compareByPositionThenId(a: TaskListItem, b: TaskListItem): number {
+  const positionDiff = a.position - b.position;
+  return positionDiff !== 0 ? positionDiff : a.id.localeCompare(b.id);
+}
+
+function compareTerminalTasks(a: TaskListItem, b: TaskListItem): number {
+  const aUpdatedAt = new Date(a.updatedAt).getTime();
+  const bUpdatedAt = new Date(b.updatedAt).getTime();
+  const hasValidAUpdatedAt = Number.isFinite(aUpdatedAt);
+  const hasValidBUpdatedAt = Number.isFinite(bUpdatedAt);
+
+  if (hasValidAUpdatedAt !== hasValidBUpdatedAt) {
+    return hasValidAUpdatedAt ? -1 : 1;
+  }
+
+  if (hasValidAUpdatedAt && hasValidBUpdatedAt) {
+    const updatedAtDiff = bUpdatedAt - aUpdatedAt;
+    if (updatedAtDiff !== 0) return updatedAtDiff;
+  }
+
+  return compareByPositionThenId(a, b);
+}
+
 export function Board({ projectId, onTaskClick, density, viewMode = "kanban" }: BoardProps) {
   const { data: tasks, isLoading } = useTasks(projectId);
   const isCompact = density === "compact";
@@ -130,23 +153,9 @@ export function Board({ projectId, onTaskClick, density, viewMode = "kanban" }: 
     }
 
     for (const status of ORDERED_STATUSES) {
-      grouped[status].sort((a, b) => {
-        if (TERMINAL_STATUSES.has(status)) {
-          const updatedAtDiff = new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
-          if (Number.isFinite(updatedAtDiff) && updatedAtDiff !== 0) return updatedAtDiff;
-        }
-
-        const positionDiff = a.position - b.position;
-        return positionDiff !== 0 ? positionDiff : a.id.localeCompare(b.id);
-      });
-
-      if (import.meta.env.DEV && TERMINAL_STATUSES.has(status) && grouped[status].length > 0) {
-        console.debug("[FIX:148] Sorted terminal column by recency", {
-          status,
-          taskCount: grouped[status].length,
-          newestTaskId: grouped[status][0]?.id,
-        });
-      }
+      grouped[status].sort(
+        TERMINAL_STATUSES.has(status) ? compareTerminalTasks : compareByPositionThenId,
+      );
     }
 
     return grouped;
@@ -254,7 +263,7 @@ export function Board({ projectId, onTaskClick, density, viewMode = "kanban" }: 
       )}
 
       {viewMode === "kanban" ? (
-        <div className="flex gap-4 overflow-x-auto pb-6">
+        <div data-testid="kanban-board" className="flex gap-4 overflow-x-auto pb-6">
           {ORDERED_STATUSES.map((status) => (
             <Column
               key={status}

--- a/packages/web/src/components/kanban/Board.tsx
+++ b/packages/web/src/components/kanban/Board.tsx
@@ -28,6 +28,7 @@ interface BoardProps {
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 const RECENT_CUTOFF_REFERENCE_TS = Date.now();
+const TERMINAL_STATUSES = new Set<TaskStatus>(["done", "verified"]);
 
 const STATUS_ORDER = Object.fromEntries(
   ORDERED_STATUSES.map((status, idx) => [status, idx]),
@@ -129,7 +130,23 @@ export function Board({ projectId, onTaskClick, density, viewMode = "kanban" }: 
     }
 
     for (const status of ORDERED_STATUSES) {
-      grouped[status].sort((a, b) => a.position - b.position);
+      grouped[status].sort((a, b) => {
+        if (TERMINAL_STATUSES.has(status)) {
+          const updatedAtDiff = new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+          if (Number.isFinite(updatedAtDiff) && updatedAtDiff !== 0) return updatedAtDiff;
+        }
+
+        const positionDiff = a.position - b.position;
+        return positionDiff !== 0 ? positionDiff : a.id.localeCompare(b.id);
+      });
+
+      if (import.meta.env.DEV && TERMINAL_STATUSES.has(status) && grouped[status].length > 0) {
+        console.debug("[FIX:148] Sorted terminal column by recency", {
+          status,
+          taskCount: grouped[status].length,
+          newestTaskId: grouped[status][0]?.id,
+        });
+      }
     }
 
     return grouped;

--- a/packages/web/src/components/kanban/Column.tsx
+++ b/packages/web/src/components/kanban/Column.tsx
@@ -146,7 +146,7 @@ export function Column({
 
       <ScrollableContainer
         maxHeight="max-h-[calc(100vh-18rem)]"
-        className={`min-h-[100px] overscroll-contain pr-1 ${density === "compact" ? "space-y-1.5" : "space-y-2"}`}
+        className={`min-h-[100px] overscroll-y-contain pr-1 ${density === "compact" ? "space-y-1.5" : "space-y-2"}`}
       >
         {tasks.map((task, idx) => {
           const reorderProps =

--- a/packages/web/src/components/kanban/Column.tsx
+++ b/packages/web/src/components/kanban/Column.tsx
@@ -3,6 +3,7 @@ import { STATUS_CONFIG } from "@aif/shared/browser";
 import { TaskCard } from "./TaskCard";
 import { AddTaskForm } from "./AddTaskForm";
 import { useReorderTask, useUpdateTask } from "@/hooks/useTasks";
+import { ScrollableContainer } from "@/components/ui/scrollable-container";
 
 interface ColumnProps {
   status: TaskStatus;
@@ -143,7 +144,10 @@ export function Column({
         </div>
       )}
 
-      <div className={`min-h-[100px] ${density === "compact" ? "space-y-1.5" : "space-y-2"}`}>
+      <ScrollableContainer
+        maxHeight="max-h-[calc(100vh-18rem)]"
+        className={`min-h-[100px] overscroll-contain pr-1 ${density === "compact" ? "space-y-1.5" : "space-y-2"}`}
+      >
         {tasks.map((task, idx) => {
           const reorderProps =
             status === "backlog"
@@ -172,7 +176,7 @@ export function Column({
             {hasActiveFilters ? "// no tasks for current filters" : "// no tasks"}
           </div>
         )}
-      </div>
+      </ScrollableContainer>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- bound every Kanban card list to the viewport and give each column independent vertical scrolling
- sort done and verified tasks by updatedAt descending while preserving position ordering for active columns
- add regression coverage for all scrollable columns and terminal/non-terminal ordering

## Problem confirmation

The report was reproducible on main. Card lists only had a minimum height, so the tallest column controlled the page height. Board grouping also sorted every status by position, causing newly completed tasks to appear among older terminal tasks.

The new regression tests failed before the implementation and pass with this change.

## Scope

This PR implements the immediate bugfix split proposed in the issue: options 1 and 4. Collapsible columns, render caps, server-side pagination, and archival remain separate feature work.

## Validation

- npm test --workspace @aif/web -- Board.test.tsx: 11 passed
- npm test --workspace @aif/web: 677 passed
- npm run lint --workspace @aif/web: passed
- web coverage: 90.53% statements, 92.62% lines
- npm run ai:validate: passed
- existing Playwright performance suite: 3 passed

## Playwright MCP verification

A dedicated Playwright MCP scenario expanded the Verified column from 2 to 102 cards in the browser DOM and verified real layout behavior:

- computed overflow-y: auto
- computed max-height: 580px at an 868px viewport
- list client height: 580px
- list scroll height: 12,345px
- independent list scrolling reached scrollTop 11,765px
- document height stayed unchanged at 961px before and after expansion
- rendered Verified order matched updatedAt descending from the API
- no browser console errors

Fixes #148