### PR TITLE
fix(agent): ship jq/python3/gh and a node-owned npm cache in the agent image

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -120,7 +120,15 @@ COPY --chown=node:node --from=build /app/packages/runtime ./packages/runtime
 COPY --chown=node:node --from=build /app/packages/agent ./packages/agent
 COPY --chown=node:node package.json .
 COPY --chown=node:node .docker/docker-entrypoint.sh /usr/local/bin/
-RUN install -d -o node -g node /app /data /home/www
+# /home/node/.npm is created ROOT-owned by the `npm i -g` above (that RUN executes as root
+# while HOME=/home/node). The agent process runs as `node` (uid 1000), so every later npx
+# invocation fails with EACCES on /home/node/.npm/_cacache/tmp — which is how a consumer's
+# commit-time gates break: `npx markdownlint-cli2` cannot spawn, pre-commit still reports
+# "markdownlint violations", and the rejection reason is npm cache permissions rather than
+# any real lint finding. Observed live 2026-07-23 by a parity audit run inside this image;
+# the agent had to work around it per-commit with npm_config_cache=/tmp/npmcache.
+RUN install -d -o node -g node /app /data /home/www \
+    && chown -R node:node /home/node/.npm
 EXPOSE 3010
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["npx", "tsx", "packages/agent/src/index.ts"]

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -105,7 +105,13 @@ ENV NODE_ENV=production \
     HOME=/home/node \
     CODEX_CLI_PATH=/app/node_modules/.bin/codex \
     PATH=/app/node_modules/.bin:${PATH}
-RUN apt-install ca-certificates gosu git curl \
+# jq / python3 / gh back the consumer repo's edit-time and commit-time gates that run
+# inside this container: jq parses the hook stdin payload (nearly every PostToolUse hook
+# shells out to it), python3 backs the pre-commit JSON + YAML validity checks, and gh
+# backs spec validation. When absent, those gates do not fail — they SKIP, staying
+# registered while enforcing nothing, which reads as a pass in any settings audit.
+# Diagnosed 2026-07-23 by a parity audit run live inside this image.
+RUN apt-install ca-certificates gosu git curl jq python3 gh \
     && npm i -g @anthropic-ai/claude-code
 COPY --chown=node:node --from=deps /app/node_modules ./node_modules
 COPY --chown=node:node --from=build /app/packages/shared ./packages/shared


### PR DESCRIPTION
## Summary

- The agent container runs the **consumer repository's own** hooks and pre-commit gates, but the image ships neither `jq`, `python3` nor `gh` — and those gates do not fail without them, they **SKIP**. A skipped check is indistinguishable from a passing one: the hook stays registered in `.claude/settings.json`, so any audit of the configuration reports it as active while it enforces nothing.
- `/home/node/.npm` is created **root-owned** by the `npm i -g` in the agent stage, so `npx` fails with `EACCES` for the `node` user the agent actually runs as.

## Changes

Two commits, both touching only the `agent` stage — `api`/`mcp`/`web` run no consumer gates.

**1. Install `jq`, `python3`, `gh`** (one added argument to the existing `apt-install` wrapper).

Why each is needed inside this image: `jq` parses the hook stdin payload (nearly every `PostToolUse` hook shells out to it), `python3` backs the pre-commit JSON + YAML validity checks, `gh` backs spec validation. All three are in the base image's own Debian bookworm repositories, so no external apt repository or keyring setup is required.

**2. `chown -R node:node /home/node/.npm`** (folded into the existing `install -d` line).

Without it, a consumer's pre-commit hook prints `markdownlint violations — fix before commit` on *every* commit touching `*.md`, because `npx markdownlint-cli2` cannot spawn — the rejection reason is npm cache permissions, not any lint finding. An agent that does not know the workaround is permanently blocked on noise.

**How this was found:** a mechanism-parity audit run live *inside* this image on 2026-07-23 (one dispatched task auditing its own container) reported `jq/gh/python3: MISSING`, and a deliberately violating edit produced total silence from the gate that should have caught it.

## AI Model

- [x] Claude Opus (latest) — authored the npm-cache commit, the verification runs and this description
- [x] Claude Fable (latest) — earlier analysis in the same session that produced the dependency commit

## Test Plan

- [ ] ~~Tests pass (`npm test`)~~ — **N/A**: the diff is `.docker/Dockerfile` only, no JS/TS is touched, so the workspace suite does not cover this change.
- [ ] ~~Lint passes (`npm run lint`)~~ — **N/A**: same reason.
- [x] Documentation updated (if applicable) — the rationale for each package is inline in the Dockerfile, where the next reader of that `RUN` line will see it.
- [x] Manually verified the change works as expected:

The exact install line was run through the real `.docker/apt-install.sh` wrapper in a clean `node:22-slim`:

```
apt-install rc=0
jq:      jq-1.6
python3: Python 3.11.2
gh:      gh version 2.23.0 (2023-02-27 Debian 2.23.0+dfsg1-1)
git:     git version 2.39.5
gosu:    1.14
```

Then the agent image was rebuilt and the container recreated. Inside the new container:

```
jq       jq-1.6
gh       gh version 2.23.0
python3  Python 3.11.2
node     v22.23.1
--- npm cache owner ---
drwxr-xr-x 1 node node 4096 Jul 24 00:08 /home/node/.npm
```

Before the change, the same commands reported `jq: MISSING`, `gh: MISSING`, `python3: MISSING` and `drwxr-xr-x 1 root root ... /home/node/.npm`.

## Note on scope

This is an outside contribution from a downstream user of `aif-handoff`; the fix is already running locally. Happy to split the two commits, drop either one, or close this if the packages are deliberately excluded from the agent image for size reasons — in that case a documented note about the skipping gates would be just as valuable.
