### PR TITLE
feat: add fail-closed thread-first pilot

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -116,7 +116,7 @@ services:
     environment:
       - DATABASE_URL=/data/aif.sqlite
       - API_BASE_URL=http://api:3009
-      - AGENT_BYPASS_PERMISSIONS=true
+      - AGENT_BYPASS_PERMISSIONS=false
       - LOG_LEVEL=info
       - PROJECTS_MOUNT=${PROJECTS_MOUNT:-/home/www}
       # Codex OAuth login proxy is dev-only. Production should rely on OPENAI_API_KEY.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
     environment:
       - DATABASE_URL=/data/aif.sqlite
       - API_BASE_URL=http://api:3009
-      - AGENT_BYPASS_PERMISSIONS=true
+      - AGENT_BYPASS_PERMISSIONS=false
       - AIF_ENABLE_CODEX_LOGIN_PROXY=true
       - AIF_CODEX_LOGIN_BROKER_PORT=3010
       - AGENT_INTERNAL_URL=http://agent:3010

--- a/docs/api.md
+++ b/docs/api.md
@@ -1503,12 +1503,32 @@ GET /chat/sessions?projectId=<uuid>
 POST /chat/sessions
 PUT /chat/sessions/:id
 DELETE /chat/sessions/:id
+GET /chat/sessions/:id/workspace
+POST /chat/sessions/:id/objectives
+PUT /chat/sessions/:id/objectives/:objectiveId
+PUT /chat/sessions/:id/tasks/:taskId
+DELETE /chat/sessions/:id/tasks/:taskId
 ```
 
 Chat sessions persist the runtime profile chosen when the session starts. This keeps older conversations tied to the runtime they were created with even if the project's current default changes later.
 For local Codex runtimes, session discovery uses the indexed `codex_sessions` read-model. Session detail/message reads resolve `sessionId -> filePath` from the same index before compatibility fallback to runtime-adapter lookups.
 
 `POST` and `PUT` accept `runtimeProfileId` as an optional field. The value must be either a global profile or one owned by the same project.
+
+The project workspace treats persisted chat sessions as threads. A thread has an independent
+`status` (`open`, `wip`, `waiting`, `blocked`, or `done`), ordered objectives, and optional task
+links. A task can belong to at most one thread. Linking rejects tasks from another project and
+objectives from another thread. `GET .../workspace` returns each linked task together with any
+GitHub pull-request number, URL, state, checks, and review evidence already synchronized for that
+task. Pull requests remain evidence for a task; they do not replace the thread or objective. When
+Participants Mode is enabled, linking or unlinking a task requires an administrator session.
+Discovered Codex or Claude sessions can be claimed as managed threads without sending a new model
+message. A claim is accepted only when the runtime session is visible in that project's current
+runtime discovery, and repeated claims return the existing managed thread.
+
+Required objectives must be `done` or `dropped` before the thread can move to `done`. Dropping an
+objective requires a non-empty `dropReason`. A completed thread cannot receive a new objective or
+reopen a required objective.
 
 ### Permissions
 

--- a/packages/agent/src/__tests__/hooks.test.ts
+++ b/packages/agent/src/__tests__/hooks.test.ts
@@ -39,6 +39,7 @@ function makeEnv(overrides: Record<string, unknown> = {}) {
     OPENAI_BASE_URL: undefined,
     CODEX_CLI_PATH: undefined,
     AIF_RUNTIME_MODULES: [],
+    AIF_KERRY_PILOT_MODE: false,
     AIF_DEFAULT_RUNTIME_ID: "claude",
     AIF_DEFAULT_PROVIDER_ID: "anthropic",
     PORT: 3009,

--- a/packages/api/src/__tests__/chatSessions.test.ts
+++ b/packages/api/src/__tests__/chatSessions.test.ts
@@ -9,6 +9,12 @@ const mockListCodexSessionsByProjectRoot = vi.fn();
 const mockFindCodexSessionFilePathBySessionId = vi.fn();
 const mockUpdateChatSession = vi.fn();
 const mockDeleteChatSession = vi.fn();
+const mockCreateThreadObjective = vi.fn();
+const mockUpdateThreadObjective = vi.fn();
+const mockGetThreadWorkspace = vi.fn();
+const mockLinkTaskToThread = vi.fn();
+const mockUnlinkTaskFromThread = vi.fn();
+const mockFindTaskById = vi.fn();
 const mockListChatMessages = vi.fn();
 const mockToChatSessionResponse = vi.fn((row: Record<string, unknown>) => row);
 const mockToChatMessageResponse = vi.fn((row: Record<string, unknown>) => row);
@@ -65,11 +71,16 @@ vi.mock("@aif/data", () => ({
     mockFindCodexSessionFilePathBySessionId(...args),
   updateChatSession: (...args: unknown[]) => mockUpdateChatSession(...args),
   deleteChatSession: (...args: unknown[]) => mockDeleteChatSession(...args),
+  createThreadObjective: (...args: unknown[]) => mockCreateThreadObjective(...args),
+  updateThreadObjective: (...args: unknown[]) => mockUpdateThreadObjective(...args),
+  getThreadWorkspace: (...args: unknown[]) => mockGetThreadWorkspace(...args),
+  linkTaskToThread: (...args: unknown[]) => mockLinkTaskToThread(...args),
+  unlinkTaskFromThread: (...args: unknown[]) => mockUnlinkTaskFromThread(...args),
   listChatMessages: (...args: unknown[]) => mockListChatMessages(...args),
   toChatSessionResponse: (row: Record<string, unknown>) => mockToChatSessionResponse(row),
   toChatMessageResponse: (row: Record<string, unknown>) => mockToChatMessageResponse(row),
   findProjectById: (id: string) => mockFindProjectById(id),
-  findTaskById: vi.fn(),
+  findTaskById: (...args: unknown[]) => mockFindTaskById(...args),
   toTaskResponse: vi.fn(),
   createChatMessage: vi.fn(),
   updateChatSessionTimestamp: vi.fn(),
@@ -176,9 +187,62 @@ describe("chat session API", () => {
     mockReadCodexSessionMetaFromFile.mockResolvedValue(null);
     mockReadCodexSessionEventsFromFile.mockResolvedValue([]);
     mockShouldUseSessionCacheForRuntime.mockReturnValue(true);
+    mockGetThreadWorkspace.mockReturnValue({
+      thread: { ...SESSION_ROW, status: "open", source: "web" },
+      objectives: [],
+      tasks: [],
+    });
+    mockLinkTaskToThread.mockReturnValue(true);
+    mockUnlinkTaskFromThread.mockReturnValue(true);
     mockFindRuntimeProfileById.mockImplementation((id: string) =>
       id === "profile-1" ? { id, projectId: "proj-1" } : null,
     );
+  });
+
+  describe("thread workspace routes", () => {
+    it("returns objectives, linked tasks, and PR evidence", async () => {
+      mockGetThreadWorkspace.mockReturnValueOnce({
+        thread: { ...SESSION_ROW, status: "wip", source: "web" },
+        objectives: [{ id: "objective-1", title: "Deliver", status: "open" }],
+        tasks: [{ taskId: "task-1", prNumber: 42, prState: "open" }],
+      });
+
+      const res = await app.request("/chat/sessions/session-1/workspace");
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual(
+        expect.objectContaining({
+          tasks: [expect.objectContaining({ prNumber: 42 })],
+        }),
+      );
+    });
+
+    it("rejects linking a task from another project", async () => {
+      mockFindChatSessionById.mockReturnValueOnce({ ...SESSION_ROW, projectId: "proj-1" });
+      mockFindTaskById.mockReturnValueOnce({ id: "task-2", projectId: "proj-2" });
+
+      const res = await app.request("/chat/sessions/session-1/tasks/task-2", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ objectiveId: null }),
+      });
+
+      expect(res.status).toBe(400);
+      expect(mockLinkTaskToThread).not.toHaveBeenCalled();
+    });
+
+    it("returns a conflict when required objectives block closure", async () => {
+      mockFindChatSessionById.mockReturnValueOnce(SESSION_ROW);
+      mockUpdateChatSession.mockReturnValueOnce(undefined);
+
+      const res = await app.request("/chat/sessions/session-1", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "done" }),
+      });
+
+      expect(res.status).toBe(409);
+    });
   });
 
   describe("GET /chat/sessions", () => {
@@ -341,6 +405,14 @@ describe("chat session API", () => {
   describe("POST /chat/sessions", () => {
     it("creates session and returns 201", async () => {
       mockCreateChatSession.mockReturnValue(SESSION_ROW);
+      mockListSessions.mockResolvedValue([
+        {
+          id: "runtime-session-1",
+          title: "New Chat",
+          createdAt: "2026-04-01T00:00:00Z",
+          updatedAt: "2026-04-01T00:00:00Z",
+        },
+      ]);
 
       const res = await app.request("/chat/sessions", {
         method: "POST",
@@ -362,6 +434,100 @@ describe("chat session API", () => {
       });
       expect(mockBroadcast).toHaveBeenCalledWith(
         expect.objectContaining({ type: "chat:session_created" }),
+      );
+    });
+
+    it("rejects claiming a runtime session outside the project discovery scope", async () => {
+      mockListSessions.mockResolvedValue([]);
+
+      const res = await app.request("/chat/sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          projectId: "proj-1",
+          title: "Foreign chat",
+          runtimeProfileId: "profile-1",
+          runtimeSessionId: "runtime-session-foreign",
+        }),
+      });
+
+      expect(res.status).toBe(404);
+      expect(await res.json()).toEqual({ error: "Runtime session not found in this project" });
+      expect(mockCreateChatSession).not.toHaveBeenCalled();
+    });
+
+    it("rejects claiming a session under a different runtime profile", async () => {
+      mockFindRuntimeProfileById.mockReturnValue({ id: "profile-other", projectId: null });
+
+      const res = await app.request("/chat/sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          projectId: "proj-1",
+          title: "Mismatched runtime",
+          runtimeProfileId: "profile-other",
+          runtimeSessionId: "runtime-session-1",
+        }),
+      });
+
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({
+        error: "Runtime profile does not match project session discovery",
+      });
+      expect(mockCreateChatSession).not.toHaveBeenCalled();
+    });
+
+    it("claims an indexed Codex session from the same project", async () => {
+      mockFindRuntimeProfileById.mockImplementation((id: string) =>
+        id === "profile-codex-app-server" ? { id, projectId: "proj-1" } : null,
+      );
+      mockCreateChatSession.mockReturnValue({
+        ...SESSION_ROW,
+        runtimeProfileId: "profile-codex-app-server",
+        runtimeSessionId: "codex-idx-1",
+      });
+      mockResolveApiRuntimeContext.mockResolvedValue({
+        project: { id: "proj-1", rootPath: "/tmp/proj" },
+        adapter: runtimeAdapter,
+        resolvedProfile: {
+          source: "project_default",
+          profileId: "profile-codex-app-server",
+          runtimeId: "codex",
+          providerId: "openai",
+          transport: "app_server",
+          model: null,
+          baseUrl: null,
+          apiKey: null,
+          apiKeyEnvVar: null,
+          headers: {},
+          options: {},
+        },
+        selectionSource: "project_default",
+      });
+      mockListCodexSessionsByProjectRoot.mockReturnValue([
+        {
+          sessionId: "codex-idx-1",
+          title: "Existing Codex chat",
+          previewText: "Existing Codex chat",
+          sourceCreatedAt: "2026-04-01T00:00:00Z",
+          sourceUpdatedAt: "2026-04-01T00:00:00Z",
+        },
+      ]);
+
+      const res = await app.request("/chat/sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          projectId: "proj-1",
+          title: "Existing Codex chat",
+          runtimeProfileId: "profile-codex-app-server",
+          runtimeSessionId: "codex-idx-1",
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      expect(mockCreateChatSession).toHaveBeenCalledWith(
+        expect.objectContaining({ runtimeSessionId: "codex-idx-1" }),
       );
     });
 

--- a/packages/api/src/__tests__/participantAuth.test.ts
+++ b/packages/api/src/__tests__/participantAuth.test.ts
@@ -63,6 +63,7 @@ function createApp(options: { cors?: boolean } = {}) {
   app.get("/board", (c) => c.json({ ok: true }));
   app.post("/tasks/example/comments", (c) => c.json({ ok: true }));
   app.delete("/tasks/example", (c) => c.json({ ok: true }));
+  app.put("/chat/sessions/thread-1/tasks/task-1", (c) => c.json({ ok: true }));
   app.post("/projects", (c) => c.json({ ok: true }));
   app.post("/tasks/example/broadcast", internalBroadcastAuth, (c) => c.json({ ok: true }));
   return app;
@@ -433,8 +434,11 @@ describe("Participants Mode request security", () => {
       ).status,
     ).toBe(200);
 
-    for (const path of ["/projects", "/tasks/example"]) {
-      const method = path === "/projects" ? "POST" : "DELETE";
+    for (const [path, method] of [
+      ["/projects", "POST"],
+      ["/tasks/example", "DELETE"],
+      ["/chat/sessions/thread-1/tasks/task-1", "PUT"],
+    ] as const) {
       const forbidden = await app.request(path, {
         method,
         headers: {

--- a/packages/api/src/__tests__/pilotModePolicy.test.ts
+++ b/packages/api/src/__tests__/pilotModePolicy.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+
+const pilot = { enabled: true };
+
+vi.mock("@aif/shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@aif/shared")>();
+  return {
+    ...actual,
+    getEnv: () => ({ ...actual.validateEnv({}), AIF_KERRY_PILOT_MODE: pilot.enabled }),
+  };
+});
+
+const { pilotModePolicy } = await import("../middleware/requireRole.js");
+
+function createApp() {
+  const app = new Hono();
+  app.use("*", pilotModePolicy());
+  app.all("*", (c) => c.json({ ok: true }));
+  return app;
+}
+
+describe("Kerry pilot policy", () => {
+  it("blocks execution but allows planning metadata", async () => {
+    const app = createApp();
+    for (const [method, path] of [
+      ["POST", "/chat"],
+      ["POST", "/tasks/task-1/handoff"],
+      ["POST", "/tasks/task-1/run-qa"],
+      ["POST", "/projects/project-1/roadmap"],
+      ["POST", "/projects/project-1/roadmap/import"],
+      ["PATCH", "/projects/project-1/auto-queue-mode"],
+      ["PUT", "/projects/project-1/github"],
+      ["DELETE", "/projects/project-1/github"],
+      ["POST", "/projects/project-1/github/sync"],
+      ["POST", "/runtime-profiles"],
+      ["PUT", "/settings/runtime-defaults"],
+    ] as const) {
+      const response = await app.request(path, { method });
+      expect(response.status).toBe(403);
+      await expect(response.json()).resolves.toMatchObject({ code: "pilot_execution_disabled" });
+    }
+
+    expect((await app.request("/tasks", { method: "POST" })).status).toBe(200);
+    expect((await app.request("/chat/sessions", { method: "POST" })).status).toBe(200);
+    expect(
+      (await app.request("/chat/sessions/thread-1/objectives", { method: "POST" })).status,
+    ).toBe(200);
+  });
+
+  it("does not change routes when pilot mode is off", async () => {
+    pilot.enabled = false;
+    expect((await createApp().request("/chat", { method: "POST" })).status).toBe(200);
+    pilot.enabled = true;
+  });
+});

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -18,7 +18,7 @@ import { createCodexIndexService } from "./services/codexIndex.js";
 import { createGracefulShutdownHandler } from "./shutdown.js";
 import { participantAuth, type ParticipantApiEnv } from "./middleware/participantAuth.js";
 import { participantCsrf } from "./middleware/csrf.js";
-import { participantRouteAuthorization } from "./middleware/requireRole.js";
+import { participantRouteAuthorization, pilotModePolicy } from "./middleware/requireRole.js";
 import { participantCors } from "./middleware/participantCors.js";
 
 const log = logger("server");
@@ -37,6 +37,7 @@ app.use("*", requestLogger);
 app.use("*", participantAuth);
 app.use("*", participantRouteAuthorization());
 app.use("*", participantCsrf());
+app.use("*", pilotModePolicy());
 
 // Health check
 app.get("/health", (c) => {
@@ -115,6 +116,7 @@ const recoveredQaRuns = resetStaleQaRuns();
 if (recoveredQaRuns > 0) {
   log.warn({ recoveredQaRuns }, "Reset stale running QA runs to error after restart");
 }
+const pilotMode = getEnv().AIF_KERRY_PILOT_MODE;
 const codexIndexService = createCodexIndexService();
 
 const server = startServer({
@@ -123,7 +125,7 @@ const server = startServer({
   webSocketServer,
   injectWebSocket,
   onStarted() {
-    void codexIndexService.start();
+    if (!pilotMode) void codexIndexService.start();
   },
   logger: log,
 });

--- a/packages/api/src/middleware/requireRole.ts
+++ b/packages/api/src/middleware/requireRole.ts
@@ -59,6 +59,7 @@ export function isAdminOnlyRoute(method: string, path: string): boolean {
   if (method === "DELETE" && (path.startsWith("/tasks/") || path.startsWith("/chat/"))) {
     return true;
   }
+  if (method === "PUT" && /^\/chat\/sessions\/[^/]+\/tasks\/[^/]+$/.test(path)) return true;
   return false;
 }
 

--- a/packages/api/src/middleware/requireRole.ts
+++ b/packages/api/src/middleware/requireRole.ts
@@ -1,5 +1,5 @@
 import type { MiddlewareHandler } from "hono";
-import { logger, type ParticipantRole } from "@aif/shared";
+import { getEnv, logger, type ParticipantRole } from "@aif/shared";
 import { getParticipantAuth, type ParticipantApiEnv } from "./participantAuth.js";
 
 const log = logger("participant-authorization");
@@ -79,5 +79,31 @@ export function participantRouteAuthorization(): MiddlewareHandler<ParticipantAp
       return adminGuard(c, next);
     }
     return memberGuard(c, next);
+  };
+}
+
+export function pilotModePolicy(): MiddlewareHandler<ParticipantApiEnv> {
+  return async (c, next) => {
+    if (!getEnv().AIF_KERRY_PILOT_MODE) return next();
+
+    const method = c.req.method;
+    const path = c.req.path;
+    const blocked =
+      (method === "POST" && path === "/chat") ||
+      (method === "POST" && /\/chat\/[^/]+\/abort$/.test(path)) ||
+      (method === "GET" && /\/chat\/sessions\/(runtime:|sdk:)/.test(path)) ||
+      (method !== "GET" && method !== "HEAD" && path.startsWith("/runtime-profiles")) ||
+      (method !== "GET" && method !== "HEAD" && path.startsWith("/settings")) ||
+      (method !== "GET" && method !== "HEAD" && path.startsWith("/auth/codex")) ||
+      /\/projects\/[^/]+\/github(?:\/|$)/.test(path) ||
+      /\/projects\/[^/]+\/(roadmap|warmup|auto-queue|broadcast)/.test(path) ||
+      /\/tasks\/[^/]+\/(broadcast|handoff|sync-plan|events|run-qa)$/.test(path);
+
+    if (!blocked) return next();
+    log.warn({ method, path, code: "pilot_execution_disabled" }, "Pilot blocked execution");
+    return c.json(
+      { error: "Execution is disabled in the Kerry pilot", code: "pilot_execution_disabled" },
+      403,
+    );
   };
 }

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -795,6 +795,14 @@ chatRouter.get("/sessions", async (c) => {
   const dbRows = listChatSessions(projectId);
   const dbSessions = dbRows.map(toChatSessionResponse);
 
+  if (getEnv().AIF_KERRY_PILOT_MODE) {
+    return c.json(
+      dbSessions
+        .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
+        .slice(0, 20),
+    );
+  }
+
   // Collect linked external runtime session IDs to avoid duplicates
   const linkedRuntimeSessionIds = new Set(
     dbRows.map((r) => r.runtimeSessionId ?? r.agentSessionId).filter(Boolean) as string[],

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -32,12 +32,15 @@ import {
 import {
   createChatMessage,
   createChatSession,
+  createThreadObjective,
   deleteChatSession,
   findChatSessionById,
   findCodexSessionFilePathBySessionId,
   findProjectById,
   findRuntimeProfileById,
   findTaskById,
+  getThreadWorkspace,
+  linkTaskToThread,
   listChatMessages,
   listChatSessions,
   listCodexSessionsByProjectRoot,
@@ -47,8 +50,17 @@ import {
   toTaskResponse,
   updateChatSession,
   updateChatSessionTimestamp,
+  updateThreadObjective,
+  unlinkTaskFromThread,
 } from "@aif/data";
-import { chatRequestSchema, createChatSessionSchema, updateChatSessionSchema } from "../schemas.js";
+import {
+  chatRequestSchema,
+  createChatSessionSchema,
+  createThreadObjectiveSchema,
+  linkThreadTaskSchema,
+  updateChatSessionSchema,
+  updateThreadObjectiveSchema,
+} from "../schemas.js";
 import { persistAttachments } from "../services/attachmentPersistence.js";
 import { readAttachment } from "../services/attachmentStorage.js";
 import { broadcast, sendToClient } from "../ws.js";
@@ -172,6 +184,9 @@ const log = logger("chat-route");
 const API_RUNTIME_LOG = "api-runtime";
 type CreateChatSessionPayload = z.infer<typeof createChatSessionSchema>;
 type UpdateChatSessionPayload = z.infer<typeof updateChatSessionSchema>;
+type CreateThreadObjectivePayload = z.infer<typeof createThreadObjectiveSchema>;
+type UpdateThreadObjectivePayload = z.infer<typeof updateThreadObjectiveSchema>;
+type LinkThreadTaskPayload = z.infer<typeof linkThreadTaskSchema>;
 type ChatRequestPayload = z.infer<typeof chatRequestSchema>;
 
 interface VirtualRuntimeSessionRef {
@@ -334,6 +349,7 @@ async function loadIndexedCodexVirtualSession(input: {
     agentSessionId: null,
     runtimeProfileId: input.runtimeProfileId,
     runtimeSessionId: meta.id,
+    status: "open",
     source: "agent",
     createdAt: meta.createdAt,
     updatedAt: meta.updatedAt,
@@ -808,10 +824,11 @@ chatRouter.get("/sessions", async (c) => {
             context.resolvedProfile.transport,
           ),
           projectId,
-          title: session.title || session.previewText || "Untitled",
+          title: (session.title || session.previewText || "Untitled").slice(0, 200),
           agentSessionId: null,
           runtimeProfileId: context.resolvedProfile.profileId,
           runtimeSessionId: session.sessionId,
+          status: "open",
           source: runtimeSourceFromTransport(context.resolvedProfile.transport),
           createdAt: session.sourceCreatedAt ?? session.createdAt,
           updatedAt: session.sourceUpdatedAt ?? session.updatedAt,
@@ -880,10 +897,11 @@ chatRouter.get("/sessions", async (c) => {
               context.resolvedProfile.transport,
             ),
             projectId,
-            title: session.title || "Untitled",
+            title: (session.title || "Untitled").slice(0, 200),
             agentSessionId: null,
             runtimeProfileId: context.resolvedProfile.profileId,
             runtimeSessionId: session.id,
+            status: "open",
             source: runtimeSourceFromTransport(context.resolvedProfile.transport),
             createdAt: session.createdAt,
             updatedAt: session.updatedAt,
@@ -929,6 +947,48 @@ chatRouter.post("/sessions", jsonValidator(createChatSessionSchema), async (c) =
   });
   if (runtimeValidation) {
     return c.json(runtimeValidation, 400);
+  }
+  if (body.runtimeSessionId) {
+    const project = findProjectById(body.projectId);
+    if (!project) return c.json({ error: "Project not found" }, 404);
+    const { context } = await resolveChatRuntimeAdapter(
+      body.projectId,
+      "session-claim",
+      buildContextAppend(project.name, null),
+    );
+    if ((body.runtimeProfileId ?? null) !== (context.resolvedProfile.profileId ?? null)) {
+      return c.json({ error: "Runtime profile does not match project session discovery" }, 400);
+    }
+    const runtimeId = context.resolvedProfile.runtimeId;
+    let found = false;
+    if (isLocalCodexRuntimeId(runtimeId)) {
+      found = listCodexSessionsByProjectRoot({
+        projectRoot: project.rootPath,
+        limit: 50,
+      }).some((session) => session.sessionId === body.runtimeSessionId);
+    } else {
+      const adapter = context.adapter;
+      const caps = resolveAdapterCapabilities(adapter, context.resolvedProfile.transport);
+      if (caps.supportsSessionList && adapter.listSessions) {
+        const sessions = await adapter.listSessions({
+          runtimeId,
+          providerId: context.resolvedProfile.providerId,
+          profileId: context.resolvedProfile.profileId,
+          projectRoot: project.rootPath,
+          transport: context.resolvedProfile.transport,
+          limit: 50,
+          options: {
+            ...context.resolvedProfile.options,
+            ...(context.resolvedProfile.baseUrl
+              ? { baseUrl: context.resolvedProfile.baseUrl }
+              : {}),
+          },
+          headers: context.resolvedProfile.headers,
+        });
+        found = sessions.some((session) => session.id === body.runtimeSessionId);
+      }
+    }
+    if (!found) return c.json({ error: "Runtime session not found in this project" }, 404);
   }
 
   const row = createChatSession({
@@ -1005,6 +1065,7 @@ chatRouter.get("/sessions/:id", async (c) => {
         agentSessionId: null,
         runtimeProfileId: lookupContext.runtimeProfileId,
         runtimeSessionId: info.id,
+        status: "open",
         source: runtimeSourceFromTransport(lookupContext.transport ?? RuntimeTransport.API),
         createdAt: info.createdAt,
         updatedAt: info.updatedAt,
@@ -1021,6 +1082,60 @@ chatRouter.get("/sessions/:id", async (c) => {
     return c.json({ error: "Chat session not found" }, 404);
   }
   return c.json(toChatSessionResponse(row));
+});
+
+// GET /chat/sessions/:id/workspace
+chatRouter.get("/sessions/:id/workspace", (c) => {
+  const workspace = getThreadWorkspace(c.req.param("id"));
+  return workspace ? c.json(workspace) : c.json({ error: "Thread not found" }, 404);
+});
+
+// POST /chat/sessions/:id/objectives
+chatRouter.post("/sessions/:id/objectives", jsonValidator(createThreadObjectiveSchema), (c) => {
+  const objective = createThreadObjective({
+    threadId: c.req.param("id"),
+    ...(c.req.valid("json") as CreateThreadObjectivePayload),
+  });
+  return objective ? c.json(objective, 201) : c.json({ error: "Thread not found" }, 404);
+});
+
+// PUT /chat/sessions/:id/objectives/:objectiveId
+chatRouter.put(
+  "/sessions/:id/objectives/:objectiveId",
+  jsonValidator(updateThreadObjectiveSchema),
+  (c) => {
+    const objective = updateThreadObjective(
+      c.req.param("id"),
+      c.req.param("objectiveId"),
+      c.req.valid("json") as UpdateThreadObjectivePayload,
+    );
+    return objective ? c.json(objective) : c.json({ error: "Objective not found or invalid" }, 404);
+  },
+);
+
+// PUT /chat/sessions/:id/tasks/:taskId
+chatRouter.put("/sessions/:id/tasks/:taskId", jsonValidator(linkThreadTaskSchema), (c) => {
+  const thread = findChatSessionById(c.req.param("id"));
+  const task = findTaskById(c.req.param("taskId"));
+  if (!thread || !task) return c.json({ error: "Thread or task not found" }, 404);
+  if (thread.projectId !== task.projectId) {
+    return c.json({ error: "Task and thread must belong to the same project" }, 400);
+  }
+  const body = c.req.valid("json") as LinkThreadTaskPayload;
+  const linked = linkTaskToThread({
+    threadId: thread.id,
+    taskId: task.id,
+    objectiveId: body.objectiveId,
+  });
+  return linked
+    ? c.json(getThreadWorkspace(thread.id))
+    : c.json({ error: "Objective does not belong to this thread" }, 400);
+});
+
+// DELETE /chat/sessions/:id/tasks/:taskId
+chatRouter.delete("/sessions/:id/tasks/:taskId", (c) => {
+  const removed = unlinkTaskFromThread(c.req.param("id"), c.req.param("taskId"));
+  return removed ? c.body(null, 204) : c.json({ error: "Task link not found" }, 404);
 });
 
 // GET /chat/sessions/:id/messages
@@ -1204,9 +1319,13 @@ chatRouter.put("/sessions/:id", jsonValidator(updateChatSessionSchema), async (c
 
   const row = updateChatSession(id, {
     title: body.title,
+    status: body.status,
     runtimeProfileId: body.runtimeProfileId,
     runtimeSessionId: body.runtimeSessionId,
   });
+  if (!row && body.status === "done") {
+    return c.json({ error: "Complete or drop required objectives before closing" }, 409);
+  }
   return c.json(row ? toChatSessionResponse(row) : null);
 });
 

--- a/packages/api/src/routes/settings.ts
+++ b/packages/api/src/routes/settings.ts
@@ -87,6 +87,7 @@ export async function buildSettingsOverview() {
     const runtimeProfiles = listRuntimeProfiles();
     const enabledProfiles = runtimeProfiles.filter((profile) => profile.enabled);
     return {
+      kerryPilotMode: env.AIF_KERRY_PILOT_MODE,
       useSubagents: env.AGENT_USE_SUBAGENTS,
       maxReviewIterations: env.AGENT_MAX_REVIEW_ITERATIONS,
       autoReviewStrategy: env.AGENT_AUTO_REVIEW_STRATEGY,
@@ -112,6 +113,7 @@ export async function buildSettingsOverview() {
     const allProfiles = listRuntimeProfiles();
     const enabledProfiles = listRuntimeProfiles({ enabledOnly: true });
     return {
+      kerryPilotMode: env.AIF_KERRY_PILOT_MODE,
       useSubagents: env.AGENT_USE_SUBAGENTS,
       maxReviewIterations: env.AGENT_MAX_REVIEW_ITERATIONS,
       autoReviewStrategy: env.AGENT_AUTO_REVIEW_STRATEGY,

--- a/packages/api/src/schemas.ts
+++ b/packages/api/src/schemas.ts
@@ -285,8 +285,30 @@ export const createChatSessionSchema = z.object({
 
 export const updateChatSessionSchema = z.object({
   title: z.string().min(1).max(200).optional(),
+  status: z.enum(["open", "wip", "waiting", "blocked", "done"]).optional(),
   runtimeProfileId: z.string().min(1).nullable().optional(),
   runtimeSessionId: z.string().min(1).nullable().optional(),
+});
+
+export const createThreadObjectiveSchema = z.object({
+  title: z.string().trim().min(1).max(300),
+  required: z.boolean().optional(),
+});
+
+export const updateThreadObjectiveSchema = z
+  .object({
+    title: z.string().trim().min(1).max(300).optional(),
+    status: z.enum(["open", "done", "dropped"]).optional(),
+    required: z.boolean().optional(),
+    dropReason: z.string().trim().min(1).max(1000).nullable().optional(),
+  })
+  .refine((value) => value.status !== "dropped" || Boolean(value.dropReason), {
+    message: "dropReason is required when an objective is dropped",
+    path: ["dropReason"],
+  });
+
+export const linkThreadTaskSchema = z.object({
+  objectiveId: z.string().min(1).nullable().optional(),
 });
 
 export const updateAppRuntimeDefaultsSchema = z

--- a/packages/data/src/__tests__/chatSessions.test.ts
+++ b/packages/data/src/__tests__/chatSessions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { projects } from "@aif/shared";
+import { githubIssues, projects, tasks } from "@aif/shared";
 import { createTestDb } from "@aif/shared/server";
 
 const testDb = { current: createTestDb() };
@@ -22,6 +22,11 @@ const {
   updateChatSessionTimestamp,
   toChatSessionResponse,
   toChatMessageResponse,
+  createThreadObjective,
+  updateThreadObjective,
+  getThreadWorkspace,
+  linkTaskToThread,
+  unlinkTaskFromThread,
   upsertCodexSessions,
   upsertCodexSessionFiles,
   listCodexSessionsByProjectRoot,
@@ -50,12 +55,29 @@ describe("chat sessions data layer", () => {
       expect(session!.agentSessionId).toBeNull();
       expect(session!.runtimeProfileId).toBeNull();
       expect(session!.runtimeSessionId).toBeNull();
+      expect(session!.status).toBe("open");
     });
 
     it("creates a session with custom title", () => {
       const session = createChatSession({ projectId: "proj-1", title: "My Chat" });
       expect(session).toBeDefined();
       expect(session!.title).toBe("My Chat");
+    });
+
+    it("returns the existing thread when the runtime session was already claimed", () => {
+      const first = createChatSession({
+        projectId: "proj-1",
+        title: "Existing chat",
+        runtimeSessionId: "runtime-1",
+      });
+      const second = createChatSession({
+        projectId: "proj-1",
+        title: "Existing chat again",
+        runtimeSessionId: "runtime-1",
+      });
+
+      expect(second?.id).toBe(first?.id);
+      expect(listChatSessions("proj-1")).toHaveLength(1);
     });
 
     it("persists runtime profile and session metadata from the create payload", () => {
@@ -138,6 +160,101 @@ describe("chat sessions data layer", () => {
 
       expect(findChatSessionById(session!.id)).toBeUndefined();
       expect(listChatMessages(session!.id)).toHaveLength(0);
+    });
+  });
+
+  describe("thread workspace", () => {
+    it("requires required objectives to be resolved before closing", () => {
+      const session = createChatSession({ projectId: "proj-1", title: "Ship thread view" })!;
+      const objective = createThreadObjective({
+        threadId: session.id,
+        title: "Show objectives",
+      })!;
+
+      expect(updateChatSession(session.id, { status: "done" })).toBeUndefined();
+      updateThreadObjective(session.id, objective.id, { status: "done" });
+      expect(updateChatSession(session.id, { status: "done" })?.status).toBe("done");
+      expect(
+        createThreadObjective({ threadId: session.id, title: "Required after close" }),
+      ).toBeUndefined();
+      expect(
+        updateThreadObjective(session.id, objective.id, { status: "open" }),
+      ).toBeUndefined();
+    });
+
+    it("links same-project tasks and projects their pull request evidence", () => {
+      const session = createChatSession({ projectId: "proj-1" })!;
+      const objective = createThreadObjective({ threadId: session.id, title: "Deliver code" })!;
+      testDb.current
+        .insert(tasks)
+        .values({ id: "task-1", projectId: "proj-1", title: "Implement view" })
+        .run();
+      testDb.current
+        .insert(githubIssues)
+        .values({
+          projectId: "proj-1",
+          issueNumber: 12,
+          taskId: "task-1",
+          nodeId: "issue-node-12",
+          htmlUrl: "https://github.com/example/repo/issues/12",
+          state: "open",
+          metadataJson: "{}",
+          sourceUpdatedAt: "2026-08-19T00:00:00.000Z",
+          lastSyncedAt: "2026-08-19T00:00:00.000Z",
+          prNumber: 34,
+          prUrl: "https://github.com/example/repo/pull/34",
+          prState: "open",
+          prChecksStatus: "success",
+          reviewState: "approved",
+        })
+        .run();
+
+      expect(
+        linkTaskToThread({
+          threadId: session.id,
+          taskId: "task-1",
+          objectiveId: objective.id,
+        }),
+      ).toBe(true);
+      expect(getThreadWorkspace(session.id)?.tasks).toEqual([
+        expect.objectContaining({
+          taskId: "task-1",
+          objectiveId: objective.id,
+          prNumber: 34,
+          prState: "open",
+          prChecksStatus: "success",
+          reviewState: "approved",
+        }),
+      ]);
+      expect(unlinkTaskFromThread(session.id, "task-1")).toBe(true);
+      expect(getThreadWorkspace(session.id)?.tasks).toHaveLength(0);
+    });
+
+    it("rejects task links across project and objective boundaries", () => {
+      seedProject("proj-2");
+      const first = createChatSession({ projectId: "proj-1" })!;
+      const second = createChatSession({ projectId: "proj-2" })!;
+      const otherObjective = createThreadObjective({
+        threadId: second.id,
+        title: "Other project",
+      })!;
+      testDb.current
+        .insert(tasks)
+        .values({ id: "task-2", projectId: "proj-2", title: "Other task" })
+        .run();
+      testDb.current
+        .insert(tasks)
+        .values({ id: "task-1", projectId: "proj-1", title: "Local task" })
+        .run();
+
+      expect(linkTaskToThread({ threadId: first.id, taskId: "task-2" })).toBe(false);
+      expect(
+        linkTaskToThread({
+          threadId: first.id,
+          taskId: "task-1",
+          objectiveId: otherObjective.id,
+        }),
+      ).toBe(false);
     });
   });
 
@@ -280,6 +397,7 @@ describe("chat sessions data layer", () => {
         agentSessionId: null,
         runtimeProfileId: null,
         runtimeSessionId: null,
+        status: "open",
         source: "web",
         createdAt: session!.createdAt,
         updatedAt: session!.updatedAt,

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -44,6 +44,9 @@ import {
   runtimeProfiles,
   chatSessions,
   chatMessages,
+  threadObjectives,
+  threadTaskLinks,
+  githubIssues,
   usageEvents,
   runtimeWarmupSessions,
   codexSessions,
@@ -84,6 +87,10 @@ import {
   type ChatSessionRow,
   type ChatMessageRow,
   type ChatMessageAttachment,
+  type ThreadObjective,
+  type ThreadObjectiveStatus,
+  type ThreadStatus,
+  type ThreadWorkspace,
 } from "@aif/shared";
 import { getDb } from "@aif/shared/server";
 import {
@@ -3946,6 +3953,7 @@ export function toChatSessionResponse(row: ChatSessionRow): ChatSession {
     agentSessionId: row.agentSessionId,
     runtimeProfileId: row.runtimeProfileId,
     runtimeSessionId: row.runtimeSessionId ?? row.agentSessionId,
+    status: row.status,
     source: "web",
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
@@ -3977,6 +3985,19 @@ export function createChatSession(input: {
   runtimeProfileId?: string | null;
   runtimeSessionId?: string | null;
 }): ChatSessionRow | undefined {
+  if (input.runtimeSessionId) {
+    const existing = getDb()
+      .select()
+      .from(chatSessions)
+      .where(
+        and(
+          eq(chatSessions.projectId, input.projectId),
+          eq(chatSessions.runtimeSessionId, input.runtimeSessionId),
+        ),
+      )
+      .get();
+    if (existing) return existing;
+  }
   const id = crypto.randomUUID();
   const now = new Date().toISOString();
   log.debug(
@@ -4020,6 +4041,7 @@ export function updateChatSession(
   id: string,
   fields: {
     title?: string;
+    status?: ThreadStatus;
     agentSessionId?: string | null;
     runtimeProfileId?: string | null;
     runtimeSessionId?: string | null;
@@ -4033,12 +4055,32 @@ export function updateChatSession(
     },
     "Updating chat session runtime metadata",
   );
+  const db = getDb();
   const patch: Record<string, unknown> = { updatedAt: new Date().toISOString() };
   if (fields.title !== undefined) patch.title = fields.title;
+  if (fields.status !== undefined) patch.status = fields.status;
   if (fields.agentSessionId !== undefined) patch.agentSessionId = fields.agentSessionId;
   if (fields.runtimeProfileId !== undefined) patch.runtimeProfileId = fields.runtimeProfileId;
   if (fields.runtimeSessionId !== undefined) patch.runtimeSessionId = fields.runtimeSessionId;
-  getDb().update(chatSessions).set(patch).where(eq(chatSessions.id, id)).run();
+  const updated = db.transaction((tx) => {
+    if (fields.status === "done") {
+      const incomplete = tx
+        .select({ count: count() })
+        .from(threadObjectives)
+        .where(
+          and(
+            eq(threadObjectives.threadId, id),
+            eq(threadObjectives.required, true),
+            eq(threadObjectives.status, "open"),
+          ),
+        )
+        .get();
+      if ((incomplete?.count ?? 0) > 0) return false;
+    }
+    tx.update(chatSessions).set(patch).where(eq(chatSessions.id, id)).run();
+    return true;
+  });
+  if (!updated) return undefined;
   return findChatSessionById(id);
 }
 
@@ -4046,7 +4088,166 @@ export function deleteChatSession(id: string): void {
   log.debug("deleteChatSession id=%s", id);
   const db = getDb();
   db.delete(chatMessages).where(eq(chatMessages.sessionId, id)).run();
+  db.delete(threadTaskLinks).where(eq(threadTaskLinks.threadId, id)).run();
+  db.delete(threadObjectives).where(eq(threadObjectives.threadId, id)).run();
   db.delete(chatSessions).where(eq(chatSessions.id, id)).run();
+}
+
+export function getThreadWorkspace(id: string): ThreadWorkspace | undefined {
+  const row = findChatSessionById(id);
+  if (!row) return undefined;
+  const objectives = getDb()
+    .select()
+    .from(threadObjectives)
+    .where(eq(threadObjectives.threadId, id))
+    .orderBy(asc(threadObjectives.position), asc(threadObjectives.createdAt))
+    .all();
+  const taskRows = getDb()
+    .select({
+      taskId: tasks.id,
+      title: tasks.title,
+      status: tasks.status,
+      objectiveId: threadTaskLinks.objectiveId,
+      prNumber: githubIssues.prNumber,
+      prUrl: githubIssues.prUrl,
+      prState: githubIssues.prState,
+      prChecksStatus: githubIssues.prChecksStatus,
+      reviewState: githubIssues.reviewState,
+    })
+    .from(threadTaskLinks)
+    .innerJoin(tasks, eq(threadTaskLinks.taskId, tasks.id))
+    .leftJoin(githubIssues, eq(githubIssues.taskId, tasks.id))
+    .where(eq(threadTaskLinks.threadId, id))
+    .orderBy(asc(threadTaskLinks.createdAt))
+    .all();
+  return {
+    thread: toChatSessionResponse(row),
+    objectives,
+    tasks: taskRows,
+  };
+}
+
+export function createThreadObjective(input: {
+  threadId: string;
+  title: string;
+  required?: boolean;
+}): ThreadObjective | undefined {
+  const db = getDb();
+  return db.transaction((tx) => {
+    const thread = tx
+      .select({ status: chatSessions.status })
+      .from(chatSessions)
+      .where(eq(chatSessions.id, input.threadId))
+      .get();
+    if (!thread || thread.status === "done") return undefined;
+    const now = new Date().toISOString();
+    const last = tx
+      .select({ position: max(threadObjectives.position) })
+      .from(threadObjectives)
+      .where(eq(threadObjectives.threadId, input.threadId))
+      .get();
+    const id = crypto.randomUUID();
+    tx.insert(threadObjectives)
+      .values({
+        id,
+        threadId: input.threadId,
+        title: input.title,
+        required: input.required ?? true,
+        position: (last?.position ?? 900) + 100,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return tx.select().from(threadObjectives).where(eq(threadObjectives.id, id)).get();
+  });
+}
+
+export function updateThreadObjective(
+  threadId: string,
+  objectiveId: string,
+  fields: {
+    title?: string;
+    status?: ThreadObjectiveStatus;
+    required?: boolean;
+    dropReason?: string | null;
+  },
+): ThreadObjective | undefined {
+  return getDb().transaction((tx) => {
+    const existing = tx
+      .select()
+      .from(threadObjectives)
+      .where(
+        and(eq(threadObjectives.id, objectiveId), eq(threadObjectives.threadId, threadId)),
+      )
+      .get();
+    if (!existing) return undefined;
+    const nextStatus = fields.status ?? existing.status;
+    const nextRequired = fields.required ?? existing.required;
+    const nextDropReason = fields.dropReason ?? existing.dropReason;
+    if (nextStatus === "dropped" && !nextDropReason?.trim()) return undefined;
+    const thread = tx
+      .select({ status: chatSessions.status })
+      .from(chatSessions)
+      .where(eq(chatSessions.id, threadId))
+      .get();
+    if (thread?.status === "done" && nextRequired && nextStatus === "open") return undefined;
+    tx.update(threadObjectives)
+      .set({
+        ...fields,
+        dropReason: nextStatus === "dropped" ? nextDropReason!.trim() : null,
+        updatedAt: new Date().toISOString(),
+      })
+      .where(eq(threadObjectives.id, objectiveId))
+      .run();
+    return tx.select().from(threadObjectives).where(eq(threadObjectives.id, objectiveId)).get();
+  });
+}
+
+export function linkTaskToThread(input: {
+  threadId: string;
+  taskId: string;
+  objectiveId?: string | null;
+}): boolean {
+  const thread = findChatSessionById(input.threadId);
+  const task = findTaskById(input.taskId);
+  if (!thread || !task || thread.projectId !== task.projectId) return false;
+  if (input.objectiveId) {
+    const objective = getDb()
+      .select({ id: threadObjectives.id })
+      .from(threadObjectives)
+      .where(
+        and(
+          eq(threadObjectives.id, input.objectiveId),
+          eq(threadObjectives.threadId, input.threadId),
+        ),
+      )
+      .get();
+    if (!objective) return false;
+  }
+  getDb()
+    .insert(threadTaskLinks)
+    .values({
+      taskId: input.taskId,
+      threadId: input.threadId,
+      objectiveId: input.objectiveId ?? null,
+    })
+    .onConflictDoUpdate({
+      target: threadTaskLinks.taskId,
+      set: { threadId: input.threadId, objectiveId: input.objectiveId ?? null },
+    })
+    .run();
+  return true;
+}
+
+export function unlinkTaskFromThread(threadId: string, taskId: string): boolean {
+  return (
+    getDb()
+      .delete(threadTaskLinks)
+      .where(
+        and(eq(threadTaskLinks.threadId, threadId), eq(threadTaskLinks.taskId, taskId)),
+      )
+      .run().changes > 0
+  );
 }
 
 export function createChatMessage(input: {

--- a/packages/mcp/src/__tests__/httpTransport.test.ts
+++ b/packages/mcp/src/__tests__/httpTransport.test.ts
@@ -28,7 +28,7 @@ vi.mock("@aif/shared", async (importOriginal) => {
 });
 
 // Import the handler from server.ts — NOT index.ts, which self-runs main().
-const { createMcpHttpHandler, createToolContext } = await import("../server.js");
+const { createMcpHttpHandler, createMcpServer, createToolContext } = await import("../server.js");
 
 const env = {
   apiUrl: "http://localhost:3009",
@@ -197,6 +197,26 @@ describe("MCP HTTP transport — multi-session (opt-in)", () => {
       expect(context.rateLimiter.check("listTasks", "read")).toBe(true);
     }
     expect(context.rateLimiter.check("listTasks", "read")).toBe(false);
+  });
+
+  it("does not register task execution tools in Kerry pilot mode", () => {
+    const server = createMcpServer(createToolContext({ ...env, kerryPilotMode: true }));
+    const tools = Object.keys(
+      (server as unknown as { _registeredTools: Record<string, unknown> })._registeredTools,
+    );
+
+    expect(tools).toEqual(
+      expect.arrayContaining([
+        "handoff_list_tasks",
+        "handoff_get_task",
+        "handoff_search_tasks",
+        "handoff_list_projects",
+        "handoff_push_plan",
+      ]),
+    );
+    expect(tools).not.toEqual(
+      expect.arrayContaining(["handoff_create_task", "handoff_update_task", "handoff_sync_status"]),
+    );
   });
 });
 

--- a/packages/mcp/src/env.ts
+++ b/packages/mcp/src/env.ts
@@ -27,6 +27,8 @@ export interface McpEnv {
   httpMultiSession: boolean;
   /** Whether Participants Mode is enabled in the shared application. */
   participantsModeEnabled: boolean;
+  /** Kerry pilot exposes planning tools but no task execution mutations. */
+  kerryPilotMode?: boolean;
   /** Dedicated bearer token for HTTP MCP. Never used for participant sessions. */
   authToken: string | null;
 }
@@ -91,6 +93,7 @@ export function loadMcpEnv(): McpEnv {
     rateLimitWriteBurst: parseInt(process.env.MCP_RATE_LIMIT_WRITE_BURST || "5", 10),
     httpMultiSession: parseBooleanFlag(process.env.AIF_MCP_HTTP_MULTI_SESSION_ENABLED),
     participantsModeEnabled: Boolean(sharedEnv.PARTICIPANTS_MODE_ENABLED),
+    kerryPilotMode: sharedEnv.AIF_KERRY_PILOT_MODE,
     authToken: process.env.MCP_AUTH_TOKEN?.trim() || null,
   };
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -40,7 +40,7 @@ export function createToolContext(env: McpEnv): ToolContext {
     "Shared tool context created",
   );
 
-  return { rateLimiter };
+  return { rateLimiter, kerryPilotMode: Boolean(env.kerryPilotMode) };
 }
 
 /**
@@ -67,9 +67,11 @@ export function createMcpServer(context: ToolContext): McpServer {
   registerListProjects(server, context);
 
   // Register write tools
-  registerCreateTask(server, context);
-  registerUpdateTask(server, context);
-  registerSyncStatus(server, context);
+  if (!context.kerryPilotMode) {
+    registerCreateTask(server, context);
+    registerUpdateTask(server, context);
+    registerSyncStatus(server, context);
+  }
   registerPushPlan(server, context);
   registerAnnotatePlan(server, context);
 

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -4,6 +4,7 @@ import type { RateLimiter } from "../middleware/rateLimit.js";
 
 export interface ToolContext {
   rateLimiter: RateLimiter;
+  kerryPilotMode?: boolean;
 }
 
 type LooseToolCallback = (args: unknown) => Promise<unknown> | unknown;

--- a/packages/shared/src/__tests__/db.test.ts
+++ b/packages/shared/src/__tests__/db.test.ts
@@ -7,7 +7,7 @@ import { eq } from "drizzle-orm";
 import { chatSessions } from "../schema.js";
 import { closeDb, createTestDb, getDb } from "../db.js";
 
-const CURRENT_SCHEMA_VERSION = 28;
+const CURRENT_SCHEMA_VERSION = 29;
 
 function removeSqliteArtifacts(dbPath: string): void {
   for (const path of [dbPath, `${dbPath}-wal`, `${dbPath}-shm`]) {

--- a/packages/shared/src/__tests__/env.test.ts
+++ b/packages/shared/src/__tests__/env.test.ts
@@ -53,6 +53,7 @@ describe("env validation", () => {
     expect(result.OPENAI_MODEL).toBeUndefined();
     expect(result.CODEX_CLI_PATH).toBeUndefined();
     expect(result.AIF_RUNTIME_MODULES).toEqual([]);
+    expect(result.AIF_KERRY_PILOT_MODE).toBe(false);
     expect(result.TELEGRAM_BOT_API_URL).toBeUndefined();
     expect(result.AGENT_QUERY_AUDIT_ENABLED).toBe(true);
     expect(result.LOG_LEVEL).toBe("debug");
@@ -116,6 +117,31 @@ describe("env validation", () => {
     expect(() =>
       validateEnv({ PARTICIPANT_ALLOWED_ORIGINS: "https://team.example.test/path" }),
     ).toThrow();
+  });
+
+  it("requires fail-closed settings in Kerry pilot mode", () => {
+    const safePilot = {
+      AIF_KERRY_PILOT_MODE: "true",
+      PARTICIPANTS_MODE_ENABLED: "true",
+      AGENT_WAKE_ENABLED: "false",
+      AGENT_BYPASS_PERMISSIONS: "false",
+    };
+
+    expect(validateEnv(safePilot).AIF_KERRY_PILOT_MODE).toBe(true);
+    for (const unsafe of [
+      { PARTICIPANTS_MODE_ENABLED: "false" },
+      { AGENT_WAKE_ENABLED: "true" },
+      { AGENT_BYPASS_PERMISSIONS: "true" },
+      { AIF_WARMUP_ENABLED: "true" },
+      { AIF_QA_PIPELINE_ENABLED: "true" },
+      { AIF_GITHUB_PROJECT_CLONE_ENABLED: "true" },
+      { AIF_GITHUB_ISSUE_PR_ENABLED: "true" },
+      { AIF_RUNTIME_SESSION_FORK_ENABLED: "true" },
+      { AIF_ENABLE_CODEX_LOGIN_PROXY: "true" },
+      { AIF_RUNTIME_MODULES: "unsafe-runtime" },
+    ]) {
+      expect(() => validateEnv({ ...safePilot, ...unsafe })).toThrow();
+    }
   });
 
   it("should parse AIF_WARMUP_ENABLED boolean values", () => {

--- a/packages/shared/src/browser.ts
+++ b/packages/shared/src/browser.ts
@@ -94,10 +94,15 @@ export {
   type RuntimeLimitEventPayload,
   type WarmupBroadcastPayload,
   type ChatSessionSource,
+  type ThreadStatus,
+  type ThreadObjectiveStatus,
   type ChatSession,
   type CreateChatSessionInput,
   type UpdateChatSessionInput,
   type ChatSessionMessage,
+  type ThreadObjective,
+  type ThreadTaskReference,
+  type ThreadWorkspace,
 } from "./types.js";
 
 export {

--- a/packages/shared/src/db.ts
+++ b/packages/shared/src/db.ts
@@ -292,11 +292,33 @@ function ensureTables(sqlite: Database.Database): void {
       id TEXT PRIMARY KEY,
       project_id TEXT NOT NULL,
       title TEXT NOT NULL DEFAULT 'New Chat',
+      status TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'wip', 'waiting', 'blocked', 'done')),
       agent_session_id TEXT,
       runtime_profile_id TEXT,
       runtime_session_id TEXT,
       created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
       updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+    )
+  `);
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS thread_objectives (
+      id TEXT PRIMARY KEY,
+      thread_id TEXT NOT NULL REFERENCES chat_sessions(id) ON DELETE CASCADE,
+      title TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'done', 'dropped')),
+      required INTEGER NOT NULL DEFAULT 1,
+      drop_reason TEXT,
+      position REAL NOT NULL DEFAULT 1000.0,
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+      updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+    )
+  `);
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS thread_task_links (
+      task_id TEXT PRIMARY KEY REFERENCES tasks(id) ON DELETE CASCADE,
+      thread_id TEXT NOT NULL REFERENCES chat_sessions(id) ON DELETE CASCADE,
+      objective_id TEXT REFERENCES thread_objectives(id) ON DELETE SET NULL,
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
     )
   `);
   sqlite.exec(`
@@ -1084,6 +1106,30 @@ const MIGRATIONS: Migration[] = [
       );
     `,
   },
+  {
+    version: 29,
+    description: "Add thread status, objectives, and optional task ownership",
+    sql: `
+      ALTER TABLE chat_sessions ADD COLUMN status TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'wip', 'waiting', 'blocked', 'done'));
+      CREATE TABLE IF NOT EXISTS thread_objectives (
+        id TEXT PRIMARY KEY,
+        thread_id TEXT NOT NULL REFERENCES chat_sessions(id) ON DELETE CASCADE,
+        title TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'done', 'dropped')),
+        required INTEGER NOT NULL DEFAULT 1,
+        drop_reason TEXT,
+        position REAL NOT NULL DEFAULT 1000.0,
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+      );
+      CREATE TABLE IF NOT EXISTS thread_task_links (
+        task_id TEXT PRIMARY KEY REFERENCES tasks(id) ON DELETE CASCADE,
+        thread_id TEXT NOT NULL REFERENCES chat_sessions(id) ON DELETE CASCADE,
+        objective_id TEXT REFERENCES thread_objectives(id) ON DELETE SET NULL,
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+      );
+    `,
+  },
 ];
 
 function splitSqlStatements(sqlText: string): string[] {
@@ -1362,6 +1408,9 @@ function ensureIndexes(sqlite: Database.Database): void {
     "CREATE INDEX IF NOT EXISTS idx_tasks_runtime_profile_id ON tasks(runtime_profile_id)",
     // Runtime profile lookups for chat sessions
     "CREATE INDEX IF NOT EXISTS idx_chat_sessions_runtime_profile_id ON chat_sessions(runtime_profile_id)",
+    // Thread workspace hydration
+    "CREATE INDEX IF NOT EXISTS idx_thread_objectives_thread ON thread_objectives(thread_id, position)",
+    "CREATE INDEX IF NOT EXISTS idx_thread_task_links_thread ON thread_task_links(thread_id, created_at)",
     // Usage event scope lookups for per-entity aggregation queries and dashboards
     "CREATE INDEX IF NOT EXISTS idx_usage_events_project ON usage_events(project_id, created_at)",
     "CREATE INDEX IF NOT EXISTS idx_usage_events_task ON usage_events(task_id, created_at)",

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -78,250 +78,271 @@ const exactOriginSchema = z.string().transform((value, context) => {
   }
 });
 
-const envSchema = z.object({
-  ANTHROPIC_API_KEY: z.string().optional(),
-  ANTHROPIC_AUTH_TOKEN: z.string().optional(),
-  ANTHROPIC_BASE_URL: z.string().optional(),
-  ANTHROPIC_MODEL: z.string().optional(),
-  OPENAI_API_KEY: z.string().optional(),
-  OPENAI_BASE_URL: z.string().optional(),
-  OPENAI_MODEL: z.string().optional(),
-  CODEX_CLI_PATH: z.string().optional(),
-  HTTP_PROXY: z.string().optional(),
-  HTTPS_PROXY: z.string().optional(),
-  ALL_PROXY: z.string().optional(),
-  NO_PROXY: z.string().optional(),
-  http_proxy: z.string().optional(),
-  https_proxy: z.string().optional(),
-  all_proxy: z.string().optional(),
-  no_proxy: z.string().optional(),
-  AIF_RUNTIME_MODULES: z.preprocess(parseRuntimeModules, z.array(z.string())).default([]),
-  AIF_DEFAULT_RUNTIME_ID: z.string().default("claude"),
-  AIF_DEFAULT_PROVIDER_ID: z.string().default("anthropic"),
-  PORT: z.coerce.number().default(3009),
-  POLL_INTERVAL_MS: z.coerce.number().default(30000),
-  AGENT_STAGE_STALE_TIMEOUT_MS: z.coerce.number().default(90 * 60 * 1000),
-  AGENT_STAGE_STALE_MAX_RETRY: z.coerce.number().default(3),
-  AGENT_STAGE_RUN_TIMEOUT_MS: z.coerce.number().default(60 * 60 * 1000),
-  AGENT_QUERY_START_TIMEOUT_MS: z.coerce.number().default(60 * 1000),
-  AGENT_QUERY_START_RETRY_DELAY_MS: z.coerce.number().default(1000),
-  AGENT_FIRST_ACTIVITY_TIMEOUT_MS: z.coerce.number().default(60 * 1000),
-  API_RUNTIME_START_TIMEOUT_MS: z.coerce.number().default(60 * 1000),
-  API_RUNTIME_RUN_TIMEOUT_MS: z.coerce.number().default(120 * 1000),
-  DATABASE_URL: z.string().default("./data/aif.sqlite"),
-  CORS_ORIGIN: z.string().default("*"),
-  PARTICIPANTS_MODE_ENABLED: booleanEnvSchema.default(false),
-  PARTICIPANT_SESSION_TTL_SECONDS: z.coerce
-    .number()
-    .int()
-    .min(300)
-    .max(31_536_000)
-    .default(7 * 24 * 60 * 60),
-  PARTICIPANT_SESSION_COOKIE_NAME: z
-    .string()
-    .regex(/^[A-Za-z0-9_-]+$/)
-    .default("aif_participant_session"),
-  PARTICIPANT_SESSION_COOKIE_SECURE: booleanEnvSchema.default(false),
-  PARTICIPANT_LOGIN_RATE_LIMIT_WINDOW_MS: z.coerce.number().int().min(1_000).default(60_000),
-  PARTICIPANT_LOGIN_RATE_LIMIT_MAX: z.coerce.number().int().min(1).max(1_000).default(10),
-  PARTICIPANT_ALLOWED_ORIGINS: z
-    .preprocess(parseCommaSeparatedValues, z.array(exactOriginSchema).min(1))
-    .default(["http://localhost:5180"]),
-  API_BASE_URL: z.string().default("http://localhost:3009"),
-  AGENT_QUERY_AUDIT_ENABLED: z
-    .preprocess((value) => {
-      if (typeof value === "string") {
+const envSchema = z
+  .object({
+    ANTHROPIC_API_KEY: z.string().optional(),
+    ANTHROPIC_AUTH_TOKEN: z.string().optional(),
+    ANTHROPIC_BASE_URL: z.string().optional(),
+    ANTHROPIC_MODEL: z.string().optional(),
+    OPENAI_API_KEY: z.string().optional(),
+    OPENAI_BASE_URL: z.string().optional(),
+    OPENAI_MODEL: z.string().optional(),
+    CODEX_CLI_PATH: z.string().optional(),
+    HTTP_PROXY: z.string().optional(),
+    HTTPS_PROXY: z.string().optional(),
+    ALL_PROXY: z.string().optional(),
+    NO_PROXY: z.string().optional(),
+    http_proxy: z.string().optional(),
+    https_proxy: z.string().optional(),
+    all_proxy: z.string().optional(),
+    no_proxy: z.string().optional(),
+    AIF_RUNTIME_MODULES: z.preprocess(parseRuntimeModules, z.array(z.string())).default([]),
+    AIF_KERRY_PILOT_MODE: booleanEnvSchema.default(false),
+    AIF_DEFAULT_RUNTIME_ID: z.string().default("claude"),
+    AIF_DEFAULT_PROVIDER_ID: z.string().default("anthropic"),
+    PORT: z.coerce.number().default(3009),
+    POLL_INTERVAL_MS: z.coerce.number().default(30000),
+    AGENT_STAGE_STALE_TIMEOUT_MS: z.coerce.number().default(90 * 60 * 1000),
+    AGENT_STAGE_STALE_MAX_RETRY: z.coerce.number().default(3),
+    AGENT_STAGE_RUN_TIMEOUT_MS: z.coerce.number().default(60 * 60 * 1000),
+    AGENT_QUERY_START_TIMEOUT_MS: z.coerce.number().default(60 * 1000),
+    AGENT_QUERY_START_RETRY_DELAY_MS: z.coerce.number().default(1000),
+    AGENT_FIRST_ACTIVITY_TIMEOUT_MS: z.coerce.number().default(60 * 1000),
+    API_RUNTIME_START_TIMEOUT_MS: z.coerce.number().default(60 * 1000),
+    API_RUNTIME_RUN_TIMEOUT_MS: z.coerce.number().default(120 * 1000),
+    DATABASE_URL: z.string().default("./data/aif.sqlite"),
+    CORS_ORIGIN: z.string().default("*"),
+    PARTICIPANTS_MODE_ENABLED: booleanEnvSchema.default(false),
+    PARTICIPANT_SESSION_TTL_SECONDS: z.coerce
+      .number()
+      .int()
+      .min(300)
+      .max(31_536_000)
+      .default(7 * 24 * 60 * 60),
+    PARTICIPANT_SESSION_COOKIE_NAME: z
+      .string()
+      .regex(/^[A-Za-z0-9_-]+$/)
+      .default("aif_participant_session"),
+    PARTICIPANT_SESSION_COOKIE_SECURE: booleanEnvSchema.default(false),
+    PARTICIPANT_LOGIN_RATE_LIMIT_WINDOW_MS: z.coerce.number().int().min(1_000).default(60_000),
+    PARTICIPANT_LOGIN_RATE_LIMIT_MAX: z.coerce.number().int().min(1).max(1_000).default(10),
+    PARTICIPANT_ALLOWED_ORIGINS: z
+      .preprocess(parseCommaSeparatedValues, z.array(exactOriginSchema).min(1))
+      .default(["http://localhost:5180"]),
+    API_BASE_URL: z.string().default("http://localhost:3009"),
+    AGENT_QUERY_AUDIT_ENABLED: z
+      .preprocess((value) => {
+        if (typeof value === "string") {
+          const normalized = value.trim().toLowerCase();
+          if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
+          if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;
+        }
+        return value;
+      }, z.boolean())
+      .default(true),
+    INTERNAL_BROADCAST_TOKEN: z.string().optional(),
+    LOG_LEVEL: z.enum(["fatal", "error", "warn", "info", "debug", "trace"]).default("debug"),
+    ACTIVITY_LOG_MODE: z
+      .preprocess((value) => {
+        if (typeof value !== "string") return "sync";
         const normalized = value.trim().toLowerCase();
-        if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
-        if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;
-      }
-      return value;
-    }, z.boolean())
-    .default(true),
-  INTERNAL_BROADCAST_TOKEN: z.string().optional(),
-  LOG_LEVEL: z.enum(["fatal", "error", "warn", "info", "debug", "trace"]).default("debug"),
-  ACTIVITY_LOG_MODE: z
-    .preprocess((value) => {
-      if (typeof value !== "string") return "sync";
-      const normalized = value.trim().toLowerCase();
-      if (!(ACTIVITY_LOG_MODES as readonly string[]).includes(normalized)) {
-        log.warn(
-          { value, fallback: "sync" },
-          "Invalid ACTIVITY_LOG_MODE value, falling back to sync",
-        );
-        return "sync";
-      }
-      return normalized;
-    }, z.enum(ACTIVITY_LOG_MODES))
-    .default("sync"),
-  ACTIVITY_LOG_BATCH_SIZE: z.coerce.number().min(1).default(20),
-  ACTIVITY_LOG_BATCH_MAX_AGE_MS: z.coerce.number().min(100).default(5000),
-  ACTIVITY_LOG_QUEUE_LIMIT: z.coerce.number().min(1).default(500),
-  AGENT_WAKE_ENABLED: z
-    .preprocess((value) => {
-      if (typeof value === "string") {
-        const normalized = value.trim().toLowerCase();
-        if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
-        if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;
-      }
-      return value;
-    }, z.boolean())
-    .default(true),
-  AGENT_BYPASS_PERMISSIONS: z
-    .preprocess((value) => {
-      if (typeof value === "string") {
-        const normalized = value.trim().toLowerCase();
-        if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
-        if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;
-      }
-      return value;
-    }, z.boolean())
-    .default(true),
-  COORDINATOR_MAX_CONCURRENT_TASKS: z.coerce.number().min(1).max(100).default(12),
-  COORDINATOR_MAX_CONCURRENT_TASKS_PER_PROJECT: z.coerce.number().min(1).max(10).default(3),
-  COORDINATOR_MAX_CONCURRENT_PROJECTS: z.coerce.number().min(1).max(10).default(4),
-  AGENT_CHAT_MAX_TURNS: z.coerce.number().min(1).default(50),
-  AGENT_MAX_REVIEW_ITERATIONS: z.coerce.number().min(1).default(3),
-  AGENT_AUTO_REVIEW_STRATEGY: z.enum(AUTO_REVIEW_STRATEGIES).default("full_re_review"),
-  AGENT_USE_SUBAGENTS: z
-    .preprocess((value) => {
-      if (typeof value === "string") {
-        const normalized = value.trim().toLowerCase();
-        if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
-        if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;
-      }
-      return value;
-    }, z.boolean())
-    .default(false),
-  AIF_USAGE_LIMITS_ENABLED: z
-    .preprocess((value) => {
-      if (typeof value === "string") {
-        const normalized = value.trim().toLowerCase();
-        if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
-        if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;
-      }
-      return value;
-    }, z.boolean())
-    .default(false),
-  AIF_STAGE_RUNTIME_PIN_ENABLED: z
-    .preprocess((value) => {
-      if (typeof value === "string") {
-        const normalized = value.trim().toLowerCase();
-        if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
-        if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;
-      }
-      return value;
-    }, z.boolean())
-    .default(false),
-  AIF_RUNTIME_MODEL_EFFORT_DISCOVERY_ENABLED: z
-    .preprocess((value) => {
-      if (typeof value === "string") {
-        const normalized = value.trim().toLowerCase();
-        if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
-        if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;
-      }
-      return value;
-    }, z.boolean())
-    .default(false),
-  AIF_API_NODE_SERVER_V2_WEBSOCKET_ENABLED: z
-    .preprocess((value) => {
-      if (typeof value === "string") {
-        const normalized = value.trim().toLowerCase();
-        if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
-        if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;
-      }
-      return value;
-    }, z.boolean())
-    .default(false),
-  AIF_WARMUP_ENABLED: z
-    .preprocess((value) => {
-      if (typeof value === "string") {
-        const normalized = value.trim().toLowerCase();
-        if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
-        if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;
-      }
-      return value;
-    }, z.boolean())
-    .default(false),
-  AIF_QA_PIPELINE_ENABLED: z
-    .preprocess((value) => {
-      if (typeof value === "string") {
-        const normalized = value.trim().toLowerCase();
-        if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
-        if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;
-      }
-      return value;
-    }, z.boolean())
-    .default(false),
-  AIF_TASK_WORKTREES_ENABLED: z
-    .preprocess((value) => {
-      if (typeof value === "string") {
-        const normalized = value.trim().toLowerCase();
-        if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
-        if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;
-      }
-      return value;
-    }, z.boolean())
-    .default(false),
-  AIF_AGENT_AUTO_QUEUE_COMMIT_GATE_ENABLED: z
-    .preprocess((value) => {
-      if (typeof value === "string") {
-        const normalized = value.trim().toLowerCase();
-        if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
-        if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;
-      }
-      return value;
-    }, z.boolean())
-    .default(false),
-  AIF_GITHUB_PROJECT_CLONE_ENABLED: booleanEnvSchema.default(false),
-  AIF_GITHUB_ISSUE_PR_ENABLED: booleanEnvSchema.default(false),
-  AIF_RUNTIME_SESSION_FORK_ENABLED: z
-    .preprocess((value) => {
-      if (typeof value === "string") {
-        const normalized = value.trim().toLowerCase();
-        if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
-        if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;
-      }
-      return value;
-    }, z.boolean())
-    .default(false),
-  AIF_RUNTIME_CODEX_NATIVE_SUBAGENTS_ENABLED: z
-    .preprocess((value) => {
-      if (typeof value === "string") {
-        const normalized = value.trim().toLowerCase();
-        if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
-        if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;
-      }
-      return value;
-    }, z.boolean())
-    .default(false),
-  AIF_RUNTIME_OPENCODE_LONG_RUNNING_DISPATCHER_ENABLED: z
-    .preprocess((value) => {
-      if (typeof value === "string") {
-        const normalized = value.trim().toLowerCase();
-        if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
-        if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;
-      }
-      return value;
-    }, z.boolean())
-    .default(false),
-  AIF_ENABLE_CODEX_LOGIN_PROXY: z
-    .preprocess((value) => {
-      if (typeof value === "string") {
-        const normalized = value.trim().toLowerCase();
-        if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
-        if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;
-      }
-      return value;
-    }, z.boolean())
-    .default(false),
-  AIF_CODEX_LOGIN_BROKER_PORT: z.coerce.number().default(3010),
-  AGENT_INTERNAL_URL: z.string().default("http://agent:3010"),
-  AIF_NOTIFICATIONS_PROJECT_NAMES_ENABLED: booleanEnvSchema.default(false),
-  TELEGRAM_BOT_API_URL: z.string().optional(),
-  TELEGRAM_BOT_TOKEN: z.string().optional(),
-  TELEGRAM_USER_ID: z.string().optional(),
-});
+        if (!(ACTIVITY_LOG_MODES as readonly string[]).includes(normalized)) {
+          log.warn(
+            { value, fallback: "sync" },
+            "Invalid ACTIVITY_LOG_MODE value, falling back to sync",
+          );
+          return "sync";
+        }
+        return normalized;
+      }, z.enum(ACTIVITY_LOG_MODES))
+      .default("sync"),
+    ACTIVITY_LOG_BATCH_SIZE: z.coerce.number().min(1).default(20),
+    ACTIVITY_LOG_BATCH_MAX_AGE_MS: z.coerce.number().min(100).default(5000),
+    ACTIVITY_LOG_QUEUE_LIMIT: z.coerce.number().min(1).default(500),
+    AGENT_WAKE_ENABLED: z
+      .preprocess((value) => {
+        if (typeof value === "string") {
+          const normalized = value.trim().toLowerCase();
+          if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
+          if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;
+        }
+        return value;
+      }, z.boolean())
+      .default(true),
+    AGENT_BYPASS_PERMISSIONS: z
+      .preprocess((value) => {
+        if (typeof value === "string") {
+          const normalized = value.trim().toLowerCase();
+          if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
+          if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;
+        }
+        return value;
+      }, z.boolean())
+      .default(true),
+    COORDINATOR_MAX_CONCURRENT_TASKS: z.coerce.number().min(1).max(100).default(12),
+    COORDINATOR_MAX_CONCURRENT_TASKS_PER_PROJECT: z.coerce.number().min(1).max(10).default(3),
+    COORDINATOR_MAX_CONCURRENT_PROJECTS: z.coerce.number().min(1).max(10).default(4),
+    AGENT_CHAT_MAX_TURNS: z.coerce.number().min(1).default(50),
+    AGENT_MAX_REVIEW_ITERATIONS: z.coerce.number().min(1).default(3),
+    AGENT_AUTO_REVIEW_STRATEGY: z.enum(AUTO_REVIEW_STRATEGIES).default("full_re_review"),
+    AGENT_USE_SUBAGENTS: z
+      .preprocess((value) => {
+        if (typeof value === "string") {
+          const normalized = value.trim().toLowerCase();
+          if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
+          if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;
+        }
+        return value;
+      }, z.boolean())
+      .default(false),
+    AIF_USAGE_LIMITS_ENABLED: z
+      .preprocess((value) => {
+        if (typeof value === "string") {
+          const normalized = value.trim().toLowerCase();
+          if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
+          if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;
+        }
+        return value;
+      }, z.boolean())
+      .default(false),
+    AIF_STAGE_RUNTIME_PIN_ENABLED: z
+      .preprocess((value) => {
+        if (typeof value === "string") {
+          const normalized = value.trim().toLowerCase();
+          if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
+          if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;
+        }
+        return value;
+      }, z.boolean())
+      .default(false),
+    AIF_RUNTIME_MODEL_EFFORT_DISCOVERY_ENABLED: z
+      .preprocess((value) => {
+        if (typeof value === "string") {
+          const normalized = value.trim().toLowerCase();
+          if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
+          if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;
+        }
+        return value;
+      }, z.boolean())
+      .default(false),
+    AIF_API_NODE_SERVER_V2_WEBSOCKET_ENABLED: z
+      .preprocess((value) => {
+        if (typeof value === "string") {
+          const normalized = value.trim().toLowerCase();
+          if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
+          if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;
+        }
+        return value;
+      }, z.boolean())
+      .default(false),
+    AIF_WARMUP_ENABLED: z
+      .preprocess((value) => {
+        if (typeof value === "string") {
+          const normalized = value.trim().toLowerCase();
+          if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
+          if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;
+        }
+        return value;
+      }, z.boolean())
+      .default(false),
+    AIF_QA_PIPELINE_ENABLED: z
+      .preprocess((value) => {
+        if (typeof value === "string") {
+          const normalized = value.trim().toLowerCase();
+          if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
+          if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;
+        }
+        return value;
+      }, z.boolean())
+      .default(false),
+    AIF_TASK_WORKTREES_ENABLED: z
+      .preprocess((value) => {
+        if (typeof value === "string") {
+          const normalized = value.trim().toLowerCase();
+          if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
+          if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;
+        }
+        return value;
+      }, z.boolean())
+      .default(false),
+    AIF_AGENT_AUTO_QUEUE_COMMIT_GATE_ENABLED: z
+      .preprocess((value) => {
+        if (typeof value === "string") {
+          const normalized = value.trim().toLowerCase();
+          if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
+          if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;
+        }
+        return value;
+      }, z.boolean())
+      .default(false),
+    AIF_GITHUB_PROJECT_CLONE_ENABLED: booleanEnvSchema.default(false),
+    AIF_GITHUB_ISSUE_PR_ENABLED: booleanEnvSchema.default(false),
+    AIF_RUNTIME_SESSION_FORK_ENABLED: z
+      .preprocess((value) => {
+        if (typeof value === "string") {
+          const normalized = value.trim().toLowerCase();
+          if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
+          if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;
+        }
+        return value;
+      }, z.boolean())
+      .default(false),
+    AIF_RUNTIME_CODEX_NATIVE_SUBAGENTS_ENABLED: z
+      .preprocess((value) => {
+        if (typeof value === "string") {
+          const normalized = value.trim().toLowerCase();
+          if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
+          if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;
+        }
+        return value;
+      }, z.boolean())
+      .default(false),
+    AIF_RUNTIME_OPENCODE_LONG_RUNNING_DISPATCHER_ENABLED: z
+      .preprocess((value) => {
+        if (typeof value === "string") {
+          const normalized = value.trim().toLowerCase();
+          if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
+          if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;
+        }
+        return value;
+      }, z.boolean())
+      .default(false),
+    AIF_ENABLE_CODEX_LOGIN_PROXY: z
+      .preprocess((value) => {
+        if (typeof value === "string") {
+          const normalized = value.trim().toLowerCase();
+          if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
+          if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;
+        }
+        return value;
+      }, z.boolean())
+      .default(false),
+    AIF_CODEX_LOGIN_BROKER_PORT: z.coerce.number().default(3010),
+    AGENT_INTERNAL_URL: z.string().default("http://agent:3010"),
+    AIF_NOTIFICATIONS_PROJECT_NAMES_ENABLED: booleanEnvSchema.default(false),
+    TELEGRAM_BOT_API_URL: z.string().optional(),
+    TELEGRAM_BOT_TOKEN: z.string().optional(),
+    TELEGRAM_USER_ID: z.string().optional(),
+  })
+  .superRefine((env, context) => {
+    if (!env.AIF_KERRY_PILOT_MODE) return;
+
+    const unsafe: Array<[boolean, string]> = [
+      [!env.PARTICIPANTS_MODE_ENABLED, "PARTICIPANTS_MODE_ENABLED must be true"],
+      [env.AGENT_WAKE_ENABLED, "AGENT_WAKE_ENABLED must be false"],
+      [env.AGENT_BYPASS_PERMISSIONS, "AGENT_BYPASS_PERMISSIONS must be false"],
+      [env.AIF_WARMUP_ENABLED, "AIF_WARMUP_ENABLED must be false"],
+      [env.AIF_QA_PIPELINE_ENABLED, "AIF_QA_PIPELINE_ENABLED must be false"],
+      [env.AIF_GITHUB_PROJECT_CLONE_ENABLED, "AIF_GITHUB_PROJECT_CLONE_ENABLED must be false"],
+      [env.AIF_GITHUB_ISSUE_PR_ENABLED, "AIF_GITHUB_ISSUE_PR_ENABLED must be false"],
+      [env.AIF_RUNTIME_SESSION_FORK_ENABLED, "AIF_RUNTIME_SESSION_FORK_ENABLED must be false"],
+      [env.AIF_ENABLE_CODEX_LOGIN_PROXY, "AIF_ENABLE_CODEX_LOGIN_PROXY must be false"],
+      [env.AIF_RUNTIME_MODULES.length > 0, "AIF_RUNTIME_MODULES must be empty"],
+    ];
+    for (const [invalid, message] of unsafe) {
+      if (invalid) context.addIssue({ code: "custom", message });
+    }
+  });
 
 export type Env = z.infer<typeof envSchema>;
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -13,6 +13,8 @@ export {
   githubIssues,
   runtimeProfiles,
   chatSessions,
+  threadObjectives,
+  threadTaskLinks,
   chatMessages,
   usageEvents,
   runtimeWarmupSessions,
@@ -49,6 +51,8 @@ export type {
   NewRuntimeProfileRow,
   ChatSessionRow,
   NewChatSessionRow,
+  ThreadObjectiveRow,
+  ThreadTaskLinkRow,
   ChatMessageRow,
   NewChatMessageRow,
   UsageEventRow,
@@ -157,10 +161,15 @@ export {
   type RuntimeLimitEventPayload,
   type WarmupBroadcastPayload,
   type ChatSessionSource,
+  type ThreadStatus,
+  type ThreadObjectiveStatus,
   type ChatSession,
   type CreateChatSessionInput,
   type UpdateChatSessionInput,
   type ChatSessionMessage,
+  type ThreadObjective,
+  type ThreadTaskReference,
+  type ThreadWorkspace,
 } from "./types.js";
 
 // Database

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -6,6 +6,8 @@ import type {
   ExecutionOwner,
   ParticipantRole,
   TaskStatus,
+  ThreadObjectiveStatus,
+  ThreadStatus,
 } from "./types.js";
 
 export const projects = sqliteTable("projects", {
@@ -369,6 +371,7 @@ export const chatSessions = sqliteTable("chat_sessions", {
     .$defaultFn(() => crypto.randomUUID()),
   projectId: text("project_id").notNull(),
   title: text("title").notNull().default("New Chat"),
+  status: text("status").$type<ThreadStatus>().notNull().default("open"),
   agentSessionId: text("agent_session_id"),
   runtimeProfileId: text("runtime_profile_id"),
   runtimeSessionId: text("runtime_session_id"),
@@ -386,6 +389,45 @@ export const chatSessions = sqliteTable("chat_sessions", {
 
 export type ChatSessionRow = typeof chatSessions.$inferSelect;
 export type NewChatSessionRow = typeof chatSessions.$inferInsert;
+
+export const threadObjectives = sqliteTable("thread_objectives", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  threadId: text("thread_id")
+    .notNull()
+    .references(() => chatSessions.id, { onDelete: "cascade" }),
+  title: text("title").notNull(),
+  status: text("status").$type<ThreadObjectiveStatus>().notNull().default("open"),
+  required: integer("required", { mode: "boolean" }).notNull().default(true),
+  dropReason: text("drop_reason"),
+  position: real("position").notNull().default(1000),
+  createdAt: text("created_at")
+    .notNull()
+    .default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
+  updatedAt: text("updated_at")
+    .notNull()
+    .default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
+});
+
+export type ThreadObjectiveRow = typeof threadObjectives.$inferSelect;
+
+export const threadTaskLinks = sqliteTable("thread_task_links", {
+  taskId: text("task_id")
+    .primaryKey()
+    .references(() => tasks.id, { onDelete: "cascade" }),
+  threadId: text("thread_id")
+    .notNull()
+    .references(() => chatSessions.id, { onDelete: "cascade" }),
+  objectiveId: text("objective_id").references(() => threadObjectives.id, {
+    onDelete: "set null",
+  }),
+  createdAt: text("created_at")
+    .notNull()
+    .default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
+});
+
+export type ThreadTaskLinkRow = typeof threadTaskLinks.$inferSelect;
 
 export const chatMessages = sqliteTable("chat_messages", {
   id: text("id")

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -913,6 +913,8 @@ export interface RuntimeLimitEventPayload {
 // ── Chat session types ──────────────────────────────────────
 
 export type ChatSessionSource = "web" | "cli" | "agent";
+export type ThreadStatus = "open" | "wip" | "waiting" | "blocked" | "done";
+export type ThreadObjectiveStatus = "open" | "done" | "dropped";
 
 export interface ChatSession {
   id: string;
@@ -921,6 +923,7 @@ export interface ChatSession {
   agentSessionId: string | null;
   runtimeProfileId?: string | null;
   runtimeSessionId?: string | null;
+  status: ThreadStatus;
   source: ChatSessionSource;
   createdAt: string;
   updatedAt: string;
@@ -935,9 +938,40 @@ export interface CreateChatSessionInput {
 
 export interface UpdateChatSessionInput {
   title?: string;
+  status?: ThreadStatus;
   agentSessionId?: string | null;
   runtimeProfileId?: string | null;
   runtimeSessionId?: string | null;
+}
+
+export interface ThreadObjective {
+  id: string;
+  threadId: string;
+  title: string;
+  status: ThreadObjectiveStatus;
+  required: boolean;
+  dropReason: string | null;
+  position: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ThreadTaskReference {
+  taskId: string;
+  title: string;
+  status: TaskStatus;
+  objectiveId: string | null;
+  prNumber: number | null;
+  prUrl: string | null;
+  prState: "open" | "closed" | "merged" | null;
+  prChecksStatus: "pending" | "success" | "failure" | null;
+  reviewState: "pending" | "approved" | "changes_requested" | null;
+}
+
+export interface ThreadWorkspace {
+  thread: ChatSession;
+  objectives: ThreadObjective[];
+  tasks: ThreadTaskReference[];
 }
 
 export interface ChatMessageAttachment {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -10,6 +10,7 @@ import { useProjectTaskOverviews, useProjects } from "./hooks/useProjects";
 import { useTasks } from "./hooks/useTasks";
 import { useAuth } from "./hooks/useAuth";
 import { useTheme } from "./hooks/useTheme";
+import { useSettings } from "./hooks/useSettings";
 import { useKeyboardShortcut } from "./hooks/useKeyboardShortcut";
 import { ChatBubble } from "./components/chat/ChatBubble";
 import { ChatPanel } from "./components/chat/ChatPanel";
@@ -67,6 +68,8 @@ function AppContent({
   useCommitToasts();
   const { theme, toggleTheme } = useTheme();
   const { data: projects } = useProjects();
+  const { data: settings } = useSettings();
+  const kerryPilotMode = settings?.kerryPilotMode ?? false;
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(
     () => readInitialSelection().projectId,
   );
@@ -196,6 +199,7 @@ function AppContent({
   return (
     <div className="app-pattern-bg min-h-screen text-foreground">
       <Header
+        kerryPilotMode={kerryPilotMode}
         selectedProject={project}
         onSelectProject={handleSelectProject}
         onDeselectProject={() => {
@@ -253,6 +257,7 @@ function AppContent({
             </div>
             {projectWorkspace === "threads" ? (
               <ChatPanel
+                kerryPilotMode={kerryPilotMode}
                 key={`workspace-${project.id}`}
                 embedded
                 isOpen
@@ -291,6 +296,7 @@ function AppContent({
       {project && projectWorkspace === "execution" && (
         <>
           <ChatPanel
+            kerryPilotMode={kerryPilotMode}
             key={project.id}
             isOpen={chatOpen}
             projectId={project.id}

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -75,6 +75,7 @@ function AppContent({
   );
   const [commandOpen, setCommandOpen] = useState(false);
   const [chatOpen, setChatOpen] = useState(false);
+  const [projectWorkspace, setProjectWorkspace] = useState<"threads" | "execution">("threads");
   const [runtimeSettingsOpen, setRuntimeSettingsOpen] = useState(false);
   const [participantsOpen, setParticipantsOpen] = useState(false);
   const [density, setDensity] = useState<"comfortable" | "compact">(() => {
@@ -233,12 +234,43 @@ function AppContent({
           />
         )}
         {project ? (
-          <Board
-            projectId={project.id}
-            onTaskClick={handleTaskOpen}
-            density={density}
-            viewMode={viewMode}
-          />
+          <div>
+            <div className="mb-3 flex items-center gap-2">
+              <Button
+                variant={projectWorkspace === "threads" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setProjectWorkspace("threads")}
+              >
+                Threads
+              </Button>
+              <Button
+                variant={projectWorkspace === "execution" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setProjectWorkspace("execution")}
+              >
+                Execution
+              </Button>
+            </div>
+            {projectWorkspace === "threads" ? (
+              <ChatPanel
+                key={`workspace-${project.id}`}
+                embedded
+                isOpen
+                projectId={project.id}
+                projectName={project.name}
+                taskId={selectedTaskId}
+                onClose={() => undefined}
+                onOpenTask={handleTaskOpen}
+              />
+            ) : (
+              <Board
+                projectId={project.id}
+                onTaskClick={handleTaskOpen}
+                density={density}
+                viewMode={viewMode}
+              />
+            )}
+          </div>
         ) : (
           <ProjectsOverview projects={projects ?? []} onSelectProject={handleSelectProject} />
         )}
@@ -256,7 +288,7 @@ function AppContent({
         }}
       />
 
-      {project && (
+      {project && projectWorkspace === "execution" && (
         <>
           <ChatPanel
             key={project.id}

--- a/packages/web/src/__tests__/ChatPanel.test.tsx
+++ b/packages/web/src/__tests__/ChatPanel.test.tsx
@@ -136,6 +136,7 @@ function renderPanel(
     projectName: string | null;
     taskId: string | null;
     embedded: boolean;
+    kerryPilotMode: boolean;
   }> = {},
 ) {
   return render(
@@ -183,6 +184,12 @@ describe("ChatPanel", () => {
     mockUnlinkTask.mockClear();
     mockUpdateThreadStatus.mockClear();
     mockOnClose.mockClear();
+  });
+
+  it("disables chat execution in Kerry pilot mode", () => {
+    renderPanel({ kerryPilotMode: true });
+    expect(screen.getByPlaceholderText("Execution is disabled in pilot mode")).toBeDisabled();
+    expect(screen.getByLabelText("Send message")).toBeDisabled();
   });
 
   it("shows active chat runtime profile and model", () => {

--- a/packages/web/src/__tests__/ChatPanel.test.tsx
+++ b/packages/web/src/__tests__/ChatPanel.test.tsx
@@ -9,10 +9,16 @@ const mockClearMessages = vi.fn();
 const mockSetExplore = vi.fn();
 const mockPinActiveSession = vi.fn();
 const mockClearActiveSession = vi.fn();
+const mockClaimSession = vi.fn();
 const mockDeleteSession = vi.fn();
 const mockRenameSession = vi.fn();
 const mockSetActiveSessionId = vi.fn();
 const mockNewSession = vi.fn();
+const mockCreateObjective = vi.fn();
+const mockUpdateObjective = vi.fn();
+const mockLinkTask = vi.fn();
+const mockUnlinkTask = vi.fn();
+const mockUpdateThreadStatus = vi.fn();
 
 let mockMessages: {
   role: string;
@@ -53,6 +59,11 @@ let mockEffectiveChatRuntime: {
   } | null;
   resolved?: { runtimeId: string; providerId: string; model: string | null };
 } | null = null;
+let mockWorkspace: Record<string, unknown> | undefined;
+let mockWorkspaceError: string | null = null;
+let mockClaimError: string | null = null;
+let mockIsClaiming = false;
+let mockProjectTasks: Array<Record<string, unknown>> = [];
 
 vi.mock("@/hooks/useChat", () => ({
   useChat: () => ({
@@ -76,6 +87,9 @@ vi.mock("@/hooks/useChatSessions", () => ({
     setActiveSessionId: mockSetActiveSessionId,
     pinActiveSession: mockPinActiveSession,
     clearActiveSession: mockClearActiveSession,
+    claimSession: mockClaimSession,
+    isClaiming: mockIsClaiming,
+    claimError: mockClaimError,
     createSession: vi.fn(),
     deleteSession: mockDeleteSession,
     renameSession: mockRenameSession,
@@ -85,7 +99,21 @@ vi.mock("@/hooks/useChatSessions", () => ({
 
 vi.mock("@/hooks/useTasks", () => ({
   useTask: () => ({ data: null }),
+  useTasks: () => ({ data: mockProjectTasks }),
   useCreateTask: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@/hooks/useThreadWorkspace", () => ({
+  useThreadWorkspace: () => ({
+    workspace: mockWorkspace,
+    isLoading: false,
+    error: mockWorkspaceError,
+    createObjective: mockCreateObjective,
+    updateObjective: mockUpdateObjective,
+    linkTask: mockLinkTask,
+    unlinkTask: mockUnlinkTask,
+    updateStatus: mockUpdateThreadStatus,
+  }),
 }));
 
 vi.mock("@/hooks/useRuntimeProfiles", () => ({
@@ -107,6 +135,7 @@ function renderPanel(
     projectId: string | null;
     projectName: string | null;
     taskId: string | null;
+    embedded: boolean;
   }> = {},
 ) {
   return render(
@@ -132,15 +161,27 @@ describe("ChatPanel", () => {
     mockSessions = [];
     mockRuntimeProfiles = [];
     mockEffectiveChatRuntime = null;
+    mockWorkspace = undefined;
+    mockWorkspaceError = null;
+    mockClaimError = null;
+    mockIsClaiming = false;
+    mockProjectTasks = [];
     mockSendMessage.mockClear();
     mockClearMessages.mockClear();
     mockSetExplore.mockClear();
     mockPinActiveSession.mockClear();
     mockClearActiveSession.mockClear();
+    mockClaimSession.mockClear();
+    mockClaimSession.mockResolvedValue({});
     mockDeleteSession.mockClear();
     mockRenameSession.mockClear();
     mockSetActiveSessionId.mockClear();
     mockNewSession.mockClear();
+    mockCreateObjective.mockClear();
+    mockUpdateObjective.mockClear();
+    mockLinkTask.mockClear();
+    mockUnlinkTask.mockClear();
+    mockUpdateThreadStatus.mockClear();
     mockOnClose.mockClear();
   });
 
@@ -197,6 +238,107 @@ describe("ChatPanel", () => {
   it("shows empty state when no messages", () => {
     renderPanel();
     expect(screen.getByText('Ask anything about "Project One"')).toBeDefined();
+  });
+
+  it("shows thread objectives, linked tasks, and pull request evidence", () => {
+    mockActiveSessionId = "session-1";
+    mockSessions = [
+      {
+        id: "session-1",
+        title: "Thread first",
+        source: "web",
+        status: "wip",
+        runtimeProfileId: null,
+        updatedAt: "2026-08-19T00:00:00.000Z",
+      },
+    ];
+    mockWorkspace = {
+      thread: {
+        ...mockSessions[0],
+        projectId: "p-1",
+        agentSessionId: null,
+        createdAt: "2026-08-19T00:00:00.000Z",
+      },
+      objectives: [
+        { id: "objective-1", title: "Ship the feature", status: "open", required: true },
+      ],
+      tasks: [
+        {
+          taskId: "task-1",
+          title: "Implement workspace",
+          status: "review",
+          objectiveId: "objective-1",
+          prNumber: 42,
+          prUrl: "https://github.com/example/repo/pull/42",
+          prState: "open",
+        },
+      ],
+    };
+
+    renderPanel({ embedded: true });
+
+    expect(screen.getByText("Ship the feature")).toBeDefined();
+    expect(screen.getByText("Implement workspace")).toBeDefined();
+    expect(screen.getByRole("link", { name: /PR #42/ })).toBeDefined();
+  });
+
+  it("claims a discovered runtime chat without sending a model message", () => {
+    mockActiveSessionId = "runtime:codex:runtime-1";
+    mockSessions = [
+      {
+        id: "runtime:codex:runtime-1",
+        projectId: "p-1",
+        title: "Existing Codex chat",
+        source: "cli",
+        runtimeProfileId: "profile-1",
+        runtimeSessionId: "runtime-1",
+        status: "open",
+        createdAt: "2026-08-19T00:00:00.000Z",
+        updatedAt: "2026-08-19T00:00:00.000Z",
+      },
+    ];
+
+    renderPanel({ embedded: true });
+    fireEvent.click(screen.getByRole("button", { name: "Add objectives and tasks" }));
+
+    expect(mockClaimSession).toHaveBeenCalledWith(mockSessions[0]);
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+
+  it("disables the claim action and shows claim errors", () => {
+    mockActiveSessionId = "runtime:codex:runtime-1";
+    mockSessions = [
+      {
+        id: "runtime:codex:runtime-1",
+        title: "Existing Codex chat",
+        source: "cli",
+        runtimeSessionId: "runtime-1",
+      },
+    ];
+    mockIsClaiming = true;
+    mockClaimError = "Runtime session not found in this project";
+
+    renderPanel({ embedded: true });
+
+    expect(screen.getByRole("button", { name: "Adding..." })).toHaveProperty("disabled", true);
+    expect(screen.getByText("Runtime session not found in this project")).toBeDefined();
+  });
+
+  it("shows workspace loading errors even when no workspace data loaded", () => {
+    mockActiveSessionId = "session-1";
+    mockSessions = [
+      {
+        id: "session-1",
+        title: "Broken workspace",
+        source: "web",
+        runtimeProfileId: null,
+      },
+    ];
+    mockWorkspaceError = "Unable to load thread workspace";
+
+    renderPanel({ embedded: true });
+
+    expect(screen.getByText("Unable to load thread workspace")).toBeDefined();
   });
 
   it("renders user and assistant messages", () => {
@@ -416,7 +558,7 @@ describe("ChatPanel", () => {
 
   it("does not call onClose on inside click", () => {
     renderPanel();
-    fireEvent.pointerDown(screen.getByText("AI Chat"));
+    fireEvent.pointerDown(screen.getByText("New Thread"));
     expect(mockOnClose).not.toHaveBeenCalled();
   });
 

--- a/packages/web/src/__tests__/Header.test.tsx
+++ b/packages/web/src/__tests__/Header.test.tsx
@@ -113,7 +113,7 @@ const metrics: TaskMetricsSummary = {
   completionRate: 0,
 };
 
-function renderHeader(canManageConfiguration = true) {
+function renderHeader(canManageConfiguration = true, kerryPilotMode = false) {
   return render(
     <Header
       selectedProject={project}
@@ -129,6 +129,7 @@ function renderHeader(canManageConfiguration = true) {
       runtimeProfilesOpen={false}
       onToggleRuntimeProfiles={vi.fn()}
       canManageConfiguration={canManageConfiguration}
+      kerryPilotMode={kerryPilotMode}
     />,
   );
 }
@@ -154,6 +155,12 @@ describe("Header", () => {
     mockRuntimeProfiles = [];
     mockWarmupEnabled = false;
     mockWarmupData = undefined;
+  });
+
+  it("shows that execution is off in Kerry pilot mode", () => {
+    renderHeader(true, true);
+    expect(screen.getByText("PILOT · EXECUTION OFF")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Generate roadmap tasks" })).toBeDisabled();
   });
 
   it("hides the warmup entry point by default", () => {

--- a/packages/web/src/__tests__/useChatSessions.test.ts
+++ b/packages/web/src/__tests__/useChatSessions.test.ts
@@ -81,6 +81,43 @@ describe("useChatSessions", () => {
     expect(result.current.activeSessionId).toBe("s-new");
   });
 
+  it("claims a discovered runtime session and selects the persisted thread", async () => {
+    mockCreateChatSession.mockResolvedValue({
+      id: "s-claimed",
+      projectId: "proj-1",
+      title: "Existing Codex chat".repeat(20),
+      source: "web",
+    });
+    const discovered = {
+      id: "runtime:codex:runtime-1",
+      projectId: "proj-1",
+      title: "Existing Codex chat".repeat(20),
+      source: "cli" as const,
+      runtimeProfileId: "profile-1",
+      runtimeSessionId: "runtime-1",
+      status: "open" as const,
+      agentSessionId: null,
+      createdAt: "2026-08-19T00:00:00.000Z",
+      updatedAt: "2026-08-19T00:00:00.000Z",
+    };
+
+    const { result } = renderHook(() => useChatSessions("proj-1"), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.claimSession(discovered);
+    });
+
+    expect(mockCreateChatSession).toHaveBeenCalledWith({
+      projectId: "proj-1",
+      title: "Existing Codex chat".repeat(20).slice(0, 200),
+      runtimeProfileId: "profile-1",
+      runtimeSessionId: "runtime-1",
+    });
+    expect(result.current.activeSessionId).toBe("s-claimed");
+  });
+
   it("deletes session and switches to next", async () => {
     mockListChatSessions.mockResolvedValue([
       { id: "s1", projectId: "proj-1", title: "Chat 1", updatedAt: "2026-01-01" },

--- a/packages/web/src/components/chat/ChatPanel.tsx
+++ b/packages/web/src/components/chat/ChatPanel.tsx
@@ -19,6 +19,8 @@ import {
   PanelLeftOpen,
   Paperclip,
   Square,
+  ExternalLink,
+  Link2,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
@@ -26,10 +28,12 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
+import { Input } from "@/components/ui/input";
 import { AttachmentChip } from "@/components/ui/attachment-chip";
 import { useChat } from "@/hooks/useChat";
 import { useChatSessions } from "@/hooks/useChatSessions";
-import { useTask } from "@/hooks/useTasks";
+import { useTask, useTasks } from "@/hooks/useTasks";
+import { useThreadWorkspace } from "@/hooks/useThreadWorkspace";
 import { useEffectiveChatRuntime, useRuntimeProfiles } from "@/hooks/useRuntimeProfiles";
 import { useUsageLimitsEnabled } from "@/hooks/useSettings";
 import {
@@ -55,6 +59,7 @@ interface ChatPanelProps {
   taskId: string | null;
   onClose: () => void;
   onOpenTask?: (taskId: string) => void;
+  embedded?: boolean;
 }
 
 export function ChatPanel({
@@ -64,8 +69,9 @@ export function ChatPanel({
   taskId,
   onClose,
   onOpenTask,
+  embedded = false,
 }: ChatPanelProps) {
-  const [showSessions, setShowSessions] = useState(false);
+  const [showSessions, setShowSessions] = useState(embedded);
 
   const {
     sessions,
@@ -74,11 +80,25 @@ export function ChatPanel({
     setActiveSessionId,
     pinActiveSession,
     clearActiveSession,
+    claimSession,
+    isClaiming,
+    claimError,
     deleteSession,
     renameSession,
   } = useChatSessions(projectId);
 
   const activeSession = sessions.find((s) => s.id === activeSessionId);
+  const workspaceThreadId = activeSession?.source === "web" ? activeSession.id : null;
+  const {
+    workspace,
+    error: workspaceError,
+    createObjective,
+    updateObjective,
+    linkTask,
+    unlinkTask,
+    updateStatus,
+  } = useThreadWorkspace(workspaceThreadId);
+  const { data: projectTasks } = useTasks(projectId);
 
   const {
     messages,
@@ -104,6 +124,9 @@ export function ChatPanel({
   const { data: effectiveChatRuntime } = useEffectiveChatRuntime(projectId);
   const { data: runtimeProfiles } = useRuntimeProfiles(projectId, true);
   const [input, setInput] = useState("");
+  const [objectiveTitle, setObjectiveTitle] = useState("");
+  const [taskToLink, setTaskToLink] = useState("");
+  const [taskObjectiveId, setTaskObjectiveId] = useState("");
   const [pendingFiles, setPendingFiles] = useState<ChatAttachment[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const handleTaskCreated = useCallback(() => {
@@ -126,7 +149,7 @@ export function ChatPanel({
   }, [isOpen]);
 
   // Close chat on Escape key or outside click while open
-  useOutsideClick(panelRef, onClose, isOpen);
+  useOutsideClick(panelRef, onClose, isOpen && !embedded);
 
   const handleSend = () => {
     if (!input.trim() || isStreaming) return;
@@ -229,6 +252,23 @@ export function ChatPanel({
     [renameSession],
   );
 
+  const linkedTaskIds = new Set(workspace?.tasks.map((task) => task.taskId) ?? []);
+  const availableTasks = projectTasks?.filter((task) => !linkedTaskIds.has(task.id)) ?? [];
+
+  const handleAddObjective = async () => {
+    const title = objectiveTitle.trim();
+    if (!title) return;
+    await createObjective({ title });
+    setObjectiveTitle("");
+  };
+
+  const handleLinkTask = async () => {
+    if (!taskToLink) return;
+    await linkTask({ taskId: taskToLink, objectiveId: taskObjectiveId || null });
+    setTaskToLink("");
+    setTaskObjectiveId("");
+  };
+
   const sessionProfileId = activeSession?.runtimeProfileId ?? null;
 
   // Show the session's own runtime when it has one, otherwise show the project effective runtime
@@ -302,12 +342,13 @@ export function ChatPanel({
     <div
       ref={panelRef}
       className={cn(
-        "fixed bottom-0 left-0 flex w-[800px] flex-col",
-        "border-r border-border bg-background",
-        "transition-transform duration-300 ease-in-out",
-        isOpen ? "translate-x-0" : "-translate-x-full",
+        "flex flex-col border-border bg-background",
+        embedded
+          ? "relative h-[calc(100vh-190px)] min-h-[620px] w-full border"
+          : "fixed bottom-0 left-0 w-[800px] border-r transition-transform duration-300 ease-in-out",
+        !embedded && (isOpen ? "translate-x-0" : "-translate-x-full"),
       )}
-      style={{ top: "var(--header-height, 65px)", zIndex: "var(--z-chat)" }}
+      style={embedded ? undefined : { top: "var(--header-height, 65px)", zIndex: "var(--z-chat)" }}
     >
       {/* Header */}
       <div className="border-b border-border px-4 py-3">
@@ -328,7 +369,7 @@ export function ChatPanel({
             </Button>
             <Bot className="h-4 w-4 text-primary" />
             <span className="text-sm font-semibold truncate max-w-[300px]">
-              {activeSession?.title ?? "AI Chat"}
+              {activeSession?.title ?? "New Thread"}
             </span>
           </div>
           <div className="flex items-center gap-3">
@@ -337,7 +378,7 @@ export function ChatPanel({
               size="icon"
               onClick={handleNewChat}
               className="h-7 w-7 border-0 text-muted-foreground"
-              aria-label="New chat"
+              aria-label="New thread"
             >
               <Plus className="h-3.5 w-3.5" />
             </Button>
@@ -350,15 +391,17 @@ export function ChatPanel({
             >
               <Trash2 className="h-3.5 w-3.5" />
             </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={onClose}
-              className="h-7 w-7 border-0 text-muted-foreground"
-              aria-label="Close chat"
-            >
-              <X className="h-4 w-4" />
-            </Button>
+            {!embedded && (
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={onClose}
+                className="h-7 w-7 border-0 text-muted-foreground"
+                aria-label="Close chat"
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            )}
           </div>
         </div>
         {currentTask && (
@@ -411,6 +454,195 @@ export function ChatPanel({
           </div>
         )}
       </div>
+
+      {activeSession?.source !== "web" && activeSession?.runtimeSessionId && (
+        <div className="border-b border-border bg-secondary/20 px-4 py-3">
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-xs text-muted-foreground">
+              Track this existing chat with objectives, tasks, and pull requests.
+            </p>
+            <Button
+              size="sm"
+              disabled={isClaiming}
+              onClick={() => void claimSession(activeSession).catch(() => undefined)}
+            >
+              {isClaiming ? "Adding..." : "Add objectives and tasks"}
+            </Button>
+          </div>
+          {claimError && <p className="mt-2 text-xs text-destructive">{claimError}</p>}
+        </div>
+      )}
+
+      {workspace && (
+        <div className="border-b border-border bg-secondary/20 px-4 py-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-xs font-semibold uppercase tracking-wide">Objectives</span>
+            <select
+              aria-label="Thread status"
+              value={workspace.thread.status}
+              onChange={(event) =>
+                void updateStatus(event.target.value as typeof workspace.thread.status)
+              }
+              className="h-7 border border-border bg-background px-2 text-xs"
+            >
+              <option value="open">Open</option>
+              <option value="wip">In progress</option>
+              <option value="waiting">Waiting</option>
+              <option value="blocked">Blocked</option>
+              <option value="done">Done</option>
+            </select>
+            <div className="flex min-w-[260px] flex-1 gap-2">
+              <Input
+                value={objectiveTitle}
+                onChange={(event) => setObjectiveTitle(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") void handleAddObjective();
+                }}
+                placeholder="Add an objective"
+                inputSize="sm"
+              />
+              <Button
+                size="sm"
+                onClick={() => void handleAddObjective()}
+                disabled={!objectiveTitle.trim()}
+              >
+                Add
+              </Button>
+            </div>
+          </div>
+          {workspace.objectives.length > 0 && (
+            <div className="mt-2 grid gap-1">
+              {workspace.objectives.map((objective) => (
+                <div key={objective.id} className="flex items-center gap-2 text-xs">
+                  <input
+                    type="checkbox"
+                    checked={objective.status === "done"}
+                    disabled={objective.status === "dropped"}
+                    aria-label={`Complete ${objective.title}`}
+                    onChange={(event) =>
+                      void updateObjective({
+                        objectiveId: objective.id,
+                        status: event.target.checked ? "done" : "open",
+                      })
+                    }
+                  />
+                  <span
+                    className={cn(
+                      "flex-1",
+                      objective.status !== "open" && "line-through opacity-60",
+                    )}
+                  >
+                    {objective.title}
+                    {objective.dropReason ? ` — ${objective.dropReason}` : ""}
+                  </span>
+                  {objective.status !== "dropped" && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-6 border-0 px-2 text-[10px] text-muted-foreground"
+                      onClick={() => {
+                        const reason = window
+                          .prompt("Why is this objective being dropped?")
+                          ?.trim();
+                        if (reason) {
+                          void updateObjective({
+                            objectiveId: objective.id,
+                            status: "dropped",
+                            dropReason: reason,
+                          });
+                        }
+                      }}
+                    >
+                      Drop
+                    </Button>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+
+          <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-border pt-2">
+            <Link2 className="h-3.5 w-3.5 text-muted-foreground" />
+            <span className="text-xs font-semibold">Tasks and PRs</span>
+            {availableTasks.length > 0 && (
+              <>
+                <select
+                  aria-label="Task to link"
+                  value={taskToLink}
+                  onChange={(event) => setTaskToLink(event.target.value)}
+                  className="h-7 min-w-[180px] border border-border bg-background px-2 text-xs"
+                >
+                  <option value="">Select a task</option>
+                  {availableTasks.map((task) => (
+                    <option key={task.id} value={task.id}>
+                      {task.title}
+                    </option>
+                  ))}
+                </select>
+                <select
+                  aria-label="Objective for task"
+                  value={taskObjectiveId}
+                  onChange={(event) => setTaskObjectiveId(event.target.value)}
+                  className="h-7 border border-border bg-background px-2 text-xs"
+                >
+                  <option value="">No objective</option>
+                  {workspace.objectives.map((objective) => (
+                    <option key={objective.id} value={objective.id}>
+                      {objective.title}
+                    </option>
+                  ))}
+                </select>
+                <Button size="sm" onClick={() => void handleLinkTask()} disabled={!taskToLink}>
+                  Link
+                </Button>
+              </>
+            )}
+          </div>
+          {workspace.tasks.length > 0 && (
+            <div className="mt-2 grid gap-1">
+              {workspace.tasks.map((task) => (
+                <div key={task.taskId} className="flex items-center gap-2 text-xs">
+                  <button
+                    type="button"
+                    className="min-w-0 flex-1 truncate text-left font-medium hover:underline"
+                    onClick={() => onOpenTask?.(task.taskId)}
+                  >
+                    {task.title}
+                  </button>
+                  <Badge variant="outline" size="sm">
+                    {task.status}
+                  </Badge>
+                  {task.prUrl && (
+                    <a
+                      href={task.prUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="inline-flex items-center gap-1 text-primary hover:underline"
+                    >
+                      PR #{task.prNumber}
+                      <ExternalLink className="h-3 w-3" />
+                    </a>
+                  )}
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6 border-0 text-muted-foreground"
+                    aria-label={`Unlink ${task.title}`}
+                    onClick={() => void unlinkTask(task.taskId)}
+                  >
+                    <X className="h-3 w-3" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+      {workspaceError && (
+        <p className="border-b border-border px-4 py-2 text-xs text-destructive">
+          {workspaceError}
+        </p>
+      )}
 
       {/* Content area: sessions sidebar + messages */}
       <div className="flex flex-1 overflow-hidden">
@@ -607,5 +839,5 @@ export function ChatPanel({
     </div>
   );
 
-  return createPortal(content, document.body);
+  return embedded ? content : createPortal(content, document.body);
 }

--- a/packages/web/src/components/chat/ChatPanel.tsx
+++ b/packages/web/src/components/chat/ChatPanel.tsx
@@ -60,6 +60,7 @@ interface ChatPanelProps {
   onClose: () => void;
   onOpenTask?: (taskId: string) => void;
   embedded?: boolean;
+  kerryPilotMode?: boolean;
 }
 
 export function ChatPanel({
@@ -70,6 +71,7 @@ export function ChatPanel({
   onClose,
   onOpenTask,
   embedded = false,
+  kerryPilotMode = false,
 }: ChatPanelProps) {
   const [showSessions, setShowSessions] = useState(embedded);
 
@@ -799,7 +801,7 @@ export function ChatPanel({
             variant="ghost"
             size="icon"
             onClick={() => fileInputRef.current?.click()}
-            disabled={isStreaming || pendingFiles.length >= MAX_CHAT_ATTACHMENTS}
+            disabled={kerryPilotMode || isStreaming || pendingFiles.length >= MAX_CHAT_ATTACHMENTS}
             className="h-9 w-9 shrink-0 border-0 text-muted-foreground"
             aria-label="Attach file"
           >
@@ -810,7 +812,10 @@ export function ChatPanel({
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder="Ask a question..."
+            placeholder={
+              kerryPilotMode ? "Execution is disabled in pilot mode" : "Ask a question..."
+            }
+            disabled={kerryPilotMode}
             rows={1}
             containerClassName="flex-1"
             className="max-h-32 min-h-[2.25rem] resize-none bg-secondary/50"
@@ -827,7 +832,7 @@ export function ChatPanel({
           ) : (
             <Button
               onClick={handleSend}
-              disabled={!input.trim()}
+              disabled={kerryPilotMode || !input.trim()}
               aria-label="Send message"
               className="h-auto self-stretch w-9 shrink-0 rounded px-0"
             >

--- a/packages/web/src/components/chat/SessionList.tsx
+++ b/packages/web/src/components/chat/SessionList.tsx
@@ -64,7 +64,7 @@ export function SessionList({
           className="w-full gap-1.5 bg-primary/10 text-primary hover:bg-primary/20"
         >
           <Plus className="h-3.5 w-3.5" />
-          New Chat
+          New Thread
         </Button>
         <p className="mt-2 text-3xs uppercase tracking-[0.12em] text-muted-foreground">
           {projectName ? `Current Project: ${projectName}` : "Current Project"}
@@ -72,9 +72,7 @@ export function SessionList({
       </div>
       <div className="flex-1 overflow-y-auto overscroll-contain py-1">
         {sessions.length === 0 && (
-          <p className="px-3 py-4 text-center text-xs text-muted-foreground">
-            No conversations yet
-          </p>
+          <p className="px-3 py-4 text-center text-xs text-muted-foreground">No threads yet</p>
         )}
         {sessions.map((session) => (
           <div
@@ -139,6 +137,7 @@ export function SessionList({
                 <>
                   <p className="text-xs font-medium text-foreground truncate">{session.title}</p>
                   <p className="text-3xs text-muted-foreground">
+                    <span className="mr-1 uppercase font-semibold">{session.status}</span>
                     {session.source !== "web" && (
                       <span
                         className={cn(

--- a/packages/web/src/components/layout/Header.tsx
+++ b/packages/web/src/components/layout/Header.tsx
@@ -16,6 +16,7 @@ import { useEffectiveChatRuntime } from "@/hooks/useRuntimeProfiles";
 import { useUsageLimitsEnabled, useWarmupEnabled } from "@/hooks/useSettings";
 import { useProjectWarmup } from "@/hooks/useProjectWarmup";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import { ProjectSelector } from "@/components/project/ProjectSelector";
 import { WarmupDialog } from "@/components/project/WarmupDialog";
@@ -56,6 +57,7 @@ interface Props {
   isLoggingOut?: boolean;
   onChangePassword?: (input: { currentPassword: string; newPassword: string }) => Promise<unknown>;
   isChangingPassword?: boolean;
+  kerryPilotMode?: boolean;
 }
 
 export function Header({
@@ -79,6 +81,7 @@ export function Header({
   isLoggingOut = false,
   onChangePassword = async () => undefined,
   isChangingPassword = false,
+  kerryPilotMode = false,
 }: Props) {
   const { theme, toggleTheme } = useTheme();
   const headerRef = useRef<HTMLElement>(null);
@@ -165,6 +168,7 @@ export function Header({
             onDeselect={onDeselectProject}
             canManage={canManageConfiguration}
           />
+          {kerryPilotMode && <Badge variant="secondary">PILOT · EXECUTION OFF</Badge>}
         </div>
 
         <div className="ml-auto flex items-center gap-2.5">
@@ -222,7 +226,7 @@ export function Header({
             variant="outline"
             size="sm"
             onClick={() => setRoadmapOpen((v) => !v)}
-            disabled={!selectedProject}
+            disabled={!selectedProject || kerryPilotMode}
             className="gap-1 font-mono text-3xs"
             aria-label="Generate roadmap tasks"
           >

--- a/packages/web/src/hooks/useChatSessions.ts
+++ b/packages/web/src/hooks/useChatSessions.ts
@@ -53,7 +53,8 @@ export function useChatSessions(projectId: string | null) {
   }, [projectId, queryClient]);
 
   const createMutation = useMutation({
-    mutationFn: (title?: string) => api.createChatSession({ projectId: projectId!, title }),
+    mutationFn: (input: Parameters<typeof api.createChatSession>[0]) =>
+      api.createChatSession(input),
     onSuccess: (session) => {
       console.debug("[useChatSessions] Created session %s", session.id);
       queryClient.invalidateQueries({ queryKey: ["chatSessions", projectId] });
@@ -83,8 +84,19 @@ export function useChatSessions(projectId: string | null) {
   });
 
   const createSession = useCallback(
-    (title?: string) => createMutation.mutateAsync(title),
-    [createMutation],
+    (title?: string) => createMutation.mutateAsync({ projectId: projectId!, title }),
+    [createMutation, projectId],
+  );
+
+  const claimSession = useCallback(
+    (session: ChatSession) =>
+      createMutation.mutateAsync({
+        projectId: projectId!,
+        title: session.title.slice(0, 200),
+        runtimeProfileId: session.runtimeProfileId,
+        runtimeSessionId: session.runtimeSessionId,
+      }),
+    [createMutation, projectId],
   );
 
   const deleteSession = useCallback(
@@ -130,6 +142,9 @@ export function useChatSessions(projectId: string | null) {
     pinActiveSession,
     clearActiveSession,
     createSession,
+    claimSession,
+    isClaiming: createMutation.isPending,
+    claimError: createMutation.error instanceof Error ? createMutation.error.message : null,
     deleteSession,
     renameSession,
     loadSessionMessages,

--- a/packages/web/src/hooks/useThreadWorkspace.ts
+++ b/packages/web/src/hooks/useThreadWorkspace.ts
@@ -1,0 +1,61 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { ThreadObjectiveStatus, ThreadStatus, ThreadWorkspace } from "@aif/shared/browser";
+import { api } from "@/lib/api";
+
+export function useThreadWorkspace(threadId: string | null) {
+  const queryClient = useQueryClient();
+  const queryKey = ["threadWorkspace", threadId] as const;
+  const refresh = () => {
+    queryClient.invalidateQueries({ queryKey });
+    queryClient.invalidateQueries({ queryKey: ["chatSessions"] });
+  };
+  const query = useQuery<ThreadWorkspace>({
+    queryKey,
+    queryFn: () => api.getThreadWorkspace(threadId!),
+    enabled: Boolean(threadId),
+  });
+  const createObjective = useMutation({
+    mutationFn: (input: { title: string; required?: boolean }) =>
+      api.createThreadObjective(threadId!, input),
+    onSuccess: refresh,
+  });
+  const updateObjective = useMutation({
+    mutationFn: (input: {
+      objectiveId: string;
+      status?: ThreadObjectiveStatus;
+      dropReason?: string | null;
+    }) => api.updateThreadObjective(threadId!, input.objectiveId, input),
+    onSuccess: refresh,
+  });
+  const linkTask = useMutation({
+    mutationFn: (input: { taskId: string; objectiveId?: string | null }) =>
+      api.linkTaskToThread(threadId!, input.taskId, input.objectiveId),
+    onSuccess: (workspace) => queryClient.setQueryData(queryKey, workspace),
+  });
+  const unlinkTask = useMutation({
+    mutationFn: (taskId: string) => api.unlinkTaskFromThread(threadId!, taskId),
+    onSuccess: refresh,
+  });
+  const updateStatus = useMutation({
+    mutationFn: (status: ThreadStatus) => api.updateThreadStatus(threadId!, status),
+    onSuccess: refresh,
+  });
+  const error =
+    query.error ??
+    createObjective.error ??
+    updateObjective.error ??
+    linkTask.error ??
+    unlinkTask.error ??
+    updateStatus.error;
+
+  return {
+    workspace: query.data,
+    isLoading: query.isLoading,
+    error: error instanceof Error ? error.message : null,
+    createObjective: createObjective.mutateAsync,
+    updateObjective: updateObjective.mutateAsync,
+    linkTask: linkTask.mutateAsync,
+    unlinkTask: unlinkTask.mutateAsync,
+    updateStatus: updateStatus.mutateAsync,
+  };
+}

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -17,6 +17,10 @@ import type {
   UpdateChatSessionInput,
   ChatSessionMessage,
   ChatMessageAttachment,
+  ThreadObjective,
+  ThreadObjectiveStatus,
+  ThreadStatus,
+  ThreadWorkspace,
   RuntimeDescriptor,
   RuntimeProfile,
   CreateRuntimeProfileInput,
@@ -848,6 +852,55 @@ export const api = {
 
   deleteChatSession(id: string): Promise<void> {
     return request(`/chat/sessions/${id}`, { method: "DELETE" });
+  },
+
+  getThreadWorkspace(id: string): Promise<ThreadWorkspace> {
+    return request<ThreadWorkspace>(`/chat/sessions/${id}/workspace`);
+  },
+
+  createThreadObjective(
+    threadId: string,
+    input: { title: string; required?: boolean },
+  ): Promise<ThreadObjective> {
+    return request<ThreadObjective>(`/chat/sessions/${threadId}/objectives`, {
+      method: "POST",
+      body: JSON.stringify(input),
+    });
+  },
+
+  updateThreadObjective(
+    threadId: string,
+    objectiveId: string,
+    input: {
+      title?: string;
+      status?: ThreadObjectiveStatus;
+      required?: boolean;
+      dropReason?: string | null;
+    },
+  ): Promise<ThreadObjective> {
+    return request<ThreadObjective>(`/chat/sessions/${threadId}/objectives/${objectiveId}`, {
+      method: "PUT",
+      body: JSON.stringify(input),
+    });
+  },
+
+  linkTaskToThread(
+    threadId: string,
+    taskId: string,
+    objectiveId?: string | null,
+  ): Promise<ThreadWorkspace> {
+    return request<ThreadWorkspace>(`/chat/sessions/${threadId}/tasks/${taskId}`, {
+      method: "PUT",
+      body: JSON.stringify({ objectiveId: objectiveId ?? null }),
+    });
+  },
+
+  unlinkTaskFromThread(threadId: string, taskId: string): Promise<void> {
+    return request(`/chat/sessions/${threadId}/tasks/${taskId}`, { method: "DELETE" });
+  },
+
+  updateThreadStatus(threadId: string, status: ThreadStatus): Promise<ChatSession> {
+    return api.updateChatSession(threadId, { status });
   },
 
   // Runtime profiles

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -187,6 +187,7 @@ export function reportWebSocketAuthenticationFailure(): void {
 }
 
 export interface SettingsResponse {
+  kerryPilotMode?: boolean;
   useSubagents: boolean;
   maxReviewIterations: number;
   autoReviewStrategy: "full_re_review" | "closure_first";


### PR DESCRIPTION
## Summary

- Make chats the thread-first workspace for objectives, task links, and status.
- Add a fail-closed Kerry pilot mode whose UI is usable for planning while execution stays disabled.

## Codex Context

- Persisted task title: `WIP | AIF handoff — implementation`
- `CODEX_THREAD_ID`: `01a014a8-8967-7631-a37e-5035e7aff77f`
- Why: Kerry IQ needs AIF Handoff's UI without granting it repository, credential, agent, or GitHub execution authority.
- Objective: provide the thread-first UI and enforce the pilot boundary in the API, MCP server, startup configuration, and UI.

## Changes

- Persist thread status, objectives, and task links and expose the thread-first workspace in the web UI.
- Add server-owned pilot policy with stable `pilot_execution_disabled` responses for chat, runtime, roadmap, auto-queue, GitHub, and agent execution routes.
- Remove default permission bypass, suppress unsafe session discovery, and register read-only MCP tools only in pilot mode.
- Show `PILOT · EXECUTION OFF` and disable chat execution controls.
- Add API, MCP, shared, data, and web regressions for the lifecycle and security boundary.

## AI Model

Which AI model was used to generate or assist with this code?

- [x] GPT (latest)
- [ ] Claude Fable (latest)
- [ ] Claude Opus (latest)
- [ ] Claude Sonnet (latest)
- [ ] Other: <!-- specify -->
- [ ] No AI used

## Test Plan

- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Documentation updated (if applicable)
- [x] Manually verified the change works as expected

Evidence collected:

- `npm run ai:validate`: format, lint, tests, coverage, and build passed; browser performance then blocked because the Playwright Chromium binary is not installed.
- `npm run ai:protocol`: passed; generated Codex protocol artifacts are in sync.
- `npm audit --omit=dev --audit-level=high`: passed with zero vulnerabilities.
- Focused pilot API regression: passed, including roadmap import, auto-queue mode, and GitHub mutation denial.
- Live loopback pilot: login/project/task/thread/objective/link returned `200/201`; chat and GitHub sync returned `403 pilot_execution_disabled`.
- Authenticated MCP: initialize/list returned `200`; six safe tools and zero execution tools.
- `npm run ai:load`: skipped itself because `k6` is not installed.

Expected result: authenticated users can organize a thread and human-owned tasks in the pilot UI, while all agent execution and external mutations remain unavailable.
